### PR TITLE
chaire-lib: Add user email or name at the right of the header

### DIFF
--- a/locales/en/menu.json
+++ b/locales/en/menu.json
@@ -1,1 +1,7 @@
-{"dashboard":"Dashboard","home":"Home","login":"Login","logout":"Logout"}
+{
+    "dashboard": "Dashboard",
+    "home": "Home",
+    "login": "Login",
+    "logout": "Logout",
+    "User": "Connected"
+}

--- a/locales/fr/menu.json
+++ b/locales/fr/menu.json
@@ -2,5 +2,6 @@
     "dashboard": "Tableau de bord",
     "home": "Accueil",
     "login": "Se connecter",
-    "logout": "Quitter"
+    "logout": "Quitter",
+    "User": "Connecté"
 }

--- a/packages/chaire-lib-frontend/src/actions/Auth.tsx
+++ b/packages/chaire-lib-frontend/src/actions/Auth.tsx
@@ -10,9 +10,17 @@ import { toFrontendUser } from '../services/auth/user';
 import { AuthAction, AuthActionTypes } from '../store/auth';
 import { History, Location } from 'history';
 
+// Required permissions to show user information in the header menu. For some basic user roles, like anonymous users, user information may not be wanted.
+let showUserInfoPerm:
+    | {
+          [subject: string]: string | string[];
+      }
+    | undefined = undefined;
+export const setShowUserInfoPerm = (perms: { [subject: string]: string | string[] }) => (showUserInfoPerm = perms);
+
 export const login = (user: BaseUser | null, isAuthenticated = false, register = false, login = false): AuthAction => ({
     type: AuthActionTypes.LOGIN,
-    user: user ? toFrontendUser(user, appConfiguration.pages) : user,
+    user: user ? toFrontendUser(user, appConfiguration.pages, showUserInfoPerm) : user,
     isAuthenticated,
     register,
     login

--- a/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
@@ -23,6 +23,18 @@ export interface HeaderProps extends WithTranslation {
     history: History;
 }
 
+interface UserProps {
+    user: FrontendUser;
+}
+
+const User: React.FunctionComponent<UserProps & WithTranslation> = (props: UserProps & WithTranslation) => (
+    <div className="menu-button" key={'header__nav-username'}>
+        {props.user.showUserInfo && (props.user.username || props.user.email || props.t('menu:User'))}
+    </div>
+);
+
+const TranslatableUser = withTranslation('menu')(User);
+
 const Header: React.FunctionComponent<HeaderProps> = (props: HeaderProps) => {
     const appTitle = config.appTitle;
     const title = config.title[props.i18n.language];
@@ -77,6 +89,7 @@ const Header: React.FunctionComponent<HeaderProps> = (props: HeaderProps) => {
                             ''
                         );
                     })}
+                    {props.user && <TranslatableUser user={props.user} />}
                 </nav>
             </div>
         </header>

--- a/packages/chaire-lib-frontend/src/services/auth/user.ts
+++ b/packages/chaire-lib-frontend/src/services/auth/user.ts
@@ -17,18 +17,24 @@ export type PermUser = {
     isAuthorized: (permissions: Permission) => boolean;
     is_admin: boolean;
     pages: UserPages[];
+    showUserInfo: boolean;
 };
 
 export type FrontendUser = BaseUser & PermUser;
 
-export const toFrontendUser = (user: BaseUser, pages: UserPages[] = []): FrontendUser => {
+export const toFrontendUser = (
+    user: BaseUser,
+    pages: UserPages[] = [],
+    showUserInfoPerm?: Permission
+): FrontendUser => {
     const ability = deserializeRules(user);
-    const authFunction = (permissions: { [subject: string]: string | string[] }) => isAuthorized(ability, permissions);
+    const authFunction = (permissions: Permission) => isAuthorized(ability, permissions);
     const userPages = pages.filter((page) => authFunction(page.permissions));
     return {
         isAuthorized: authFunction,
         is_admin: authFunction({ all: 'manage' }),
         pages: userPages,
+        showUserInfo: showUserInfoPerm !== undefined ? authFunction(showUserInfoPerm) : true,
         ...user
     };
 };

--- a/packages/chaire-lib-frontend/src/store/auth/__tests__/reducer.test.ts
+++ b/packages/chaire-lib-frontend/src/store/auth/__tests__/reducer.test.ts
@@ -13,7 +13,8 @@ const testUser = {
     serializedPermissions: [],
     isAuthorized: jest.fn(),
     is_admin: false,
-    pages: []
+    pages: [],
+    showUserInfo: true
 }
 
 test('Test a login status', () => {


### PR DESCRIPTION
Backported from transition-legacy

The logged in username or email is displayed at the right of the header. It is possible to set permissions for which to display this information, to allow applications like evolution, who have anonymous or participants roles to not have this information displayed.