### PR TITLE
dataSources: Add a findByName db query

### DIFF
--- a/packages/transition-backend/src/models/db/__tests__/dataSources.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/dataSources.db.test.ts
@@ -117,6 +117,16 @@ describe(`${objectName}`, () => {
 
     });
 
+    test('should find by name', async() => {
+        // By shortname
+        const object = await dbQueries.findByName(newObjectAttributes2.shortname);
+        expect(object).toEqual(expect.objectContaining(newObjectAttributes2));
+
+        // By name
+        const object2 = await dbQueries.findByName(newObjectAttributes2.name);
+        expect(object2).toEqual(expect.objectContaining(newObjectAttributes2));
+    });
+
     test('should read collection from database', async() => {
         
         const _collection = await dbQueries.collection();

--- a/packages/transition-backend/src/models/db/dataSources.db.queries.ts
+++ b/packages/transition-backend/src/models/db/dataSources.db.queries.ts
@@ -51,6 +51,27 @@ const collection = async (type?: DataSourceType): Promise<DataSourceAttributes[]
     }
 };
 
+/**
+ * Find a single data source by its name or shortname
+ *
+ * @param name Name or shortname of the data source to find
+ * @returns The data source attributes if found or undefined otherwise
+ */
+const findByName = async (name: string): Promise<DataSourceAttributes | undefined> => {
+    try {
+        const dataSources = await knex(tableName)
+            .where('name', name)
+            .orWhere('shortname', name);
+        return dataSources.length > 0 ? dataSources[0] : undefined;
+    } catch (error) {
+        throw new TrError(
+            `cannot query data sources by name of a database error (knex error: ${error})`,
+            'DBQDSC0003',
+            'DataSourceCouldNotQueryByNameBecauseDatabaseError'
+        );
+    }
+};
+
 export default {
     exists: exists.bind(null, knex, tableName),
     read: read.bind(null, knex, tableName, undefined, '*'),
@@ -70,5 +91,6 @@ export default {
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
-    collection
+    collection,
+    findByName
 };


### PR DESCRIPTION
Backported from octavi. Useful for tasks requiring a data source argument, to fetch a data source by name or shortname.