### PR TITLE
chaire-lib: Make setup work and remove create-project

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "packages/transition-frontend"
     ],
     "scripts": {
-        "create-project": "yarn workspace transition-legacy run create-project",
         "setup": "yarn workspace chaire-lib-backend run setup",
         "setup-test": "yarn workspace chaire-lib-backend run setup-test",
         "migrate": "knex migrate:latest",

--- a/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
@@ -8,11 +8,10 @@ import 'chaire-lib-common/lib/config/shared/dotenv.config'; // Unused, but must 
 import config from '../../config/server.config';
 import knex from 'knex';
 
-// These files should not be published, they are for application preparation and should never be called by actual app
-// eslint-disable-next-line node/no-unpublished-require
-const knexRoot = knex(require('./knexfile.root'));
-// eslint-disable-next-line node/no-unpublished-require
-const knexPublic = knex(require('./knexfile.public'));
+import knexRootCfg from './knexfile.root';
+import knexPublicCfg from './knexfile.public';
+const knexRoot = knex(knexRootCfg);
+const knexPublic = knex(knexPublicCfg);
 
 const databaseName = process.env[`PG_DATABASE_${(process.env.NODE_ENV || 'development').toUpperCase()}`];
 const createExtensionsAndSchemaQuery = `


### PR DESCRIPTION
The create-project command is not required anymore in this repo, one just has to provide a configuration file in the .env

Also remove comments and do proper import of knexfiles in the setup task.