### PR TITLE
setup: Drop operator family as well as class

### DIFF
--- a/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
@@ -13,6 +13,8 @@ import knexPublicCfg from './knexfile.public';
 const knexRoot = knex(knexRootCfg);
 const knexPublic = knex(knexPublicCfg);
 
+
+
 const databaseName = process.env[`PG_DATABASE_${(process.env.NODE_ENV || 'development').toUpperCase()}`];
 const createExtensionsAndSchemaQuery = `
   CREATE EXTENSION IF NOT EXISTS "plpgsql"   SCHEMA public;
@@ -21,6 +23,7 @@ const createExtensionsAndSchemaQuery = `
   CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA public;
   CREATE SCHEMA    IF NOT EXISTS "${process.env.PG_DATABASE_SCHEMA || config.projectShortname}";
   DROP OPERATOR CLASS IF EXISTS public._uuid_ops USING gin CASCADE;
+  DROP OPERATOR FAMILY IF EXISTS public._uuid_ops USING gin CASCADE;
   CREATE OPERATOR CLASS public._uuid_ops DEFAULT 
     FOR TYPE _uuid USING gin AS 
     OPERATOR 1 &&(anyarray, anyarray), 
@@ -48,6 +51,13 @@ knexRoot('pg_catalog.pg_database')
                 await knexRoot.raw(`CREATE DATABASE ${databaseName}`);
             }
             knexRoot.destroy();
+            /*createExtensionsAndSchemaQueryArr.forEach(async (query) => {
+                try {
+                    await knexPublic.raw(query);
+                } catch(error){
+                    console.log('An error occurred when creating the database or the schema:', query, error);
+                }
+            })*/
             await knexPublic.raw(createExtensionsAndSchemaQuery);
             knexPublic.destroy();
         } catch (error) {


### PR DESCRIPTION
Fixes #457

In recent postgresql versions (at least on 14+), dropping the operator class is not sufficient to clean up everything and when re-creating it, there's an exception for a duplicate key in the pg_amop table. This prevents the setup task to be run more than once.

Dropping the operator family fixes the issue. It works also on old versions of postgresql.