### PR TITLE
chaire-lib-backend: Add @babel/cli dependency

### DIFF
--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -26,6 +26,7 @@
         "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write && eslint --fix ."
     },
     "dependencies": {
+        "@babel/cli": "^7.19.3",
         "@casl/ability": "^5.4.3",
         "@zeit/fetch-retry": "^5.0.1",
         "bcryptjs": "^2.4.3",


### PR DESCRIPTION
The yarn scripts require babel-node. From this repo, it runs fine without it, but when importing with submodules, this dependency is required.