### PR TITLE
config: Add default paths for project config file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-PROJECT_CONFIG=${rootDir}/examples/config.js
+PROJECT_CONFIG=/absolute/path/to/transition/config.js
 #OSRM_DIRECTORY_PREFIX=demo_osrm (default: empty)
 HOST=http://localhost:8080
 PG_DATABASE_DEVELOPMENT=tr_dev

--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -15,6 +15,8 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
+    env:
+      PROJECT_CONFIG: ${{ github.workspace }}/examples/config.js
     steps:
     - uses: actions/checkout@v2
     - name: copy env file

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This folder contains an example configuration file, as well as necessary files t
 2. Update the .env file and set the `PROJECT_CONFIG` to point to the config file in this directory
 
 ```
-PROJECT_CONFIG=${rootDir}/examples/transition/config.js
+PROJECT_CONFIG=</path/to/this/repo>/examples/transition/config.js
 ```
 
 3. Follow the [installations instructions](../../README.md#installation) at the root of this repo to setup the database and create users
@@ -17,12 +17,12 @@ PROJECT_CONFIG=${rootDir}/examples/transition/config.js
 5. Get and prepare the road network for `osrm` to route. This step is optional, but required to create new lines that properly follow the road network. The first line will download the Open Street Map network data from the overpass API. The second line will prepare the data for the `osrm` servers. Data is prepared differently for different modes of tranportation. Selecting `driving` and `walking` are mandatory modes, as `driving` is the default mode for vehicles and `walking` is required to calculate access, transfer and egress times from transit.
 
 ```shell
-yarn babel-node --max-old-space-size=4096 packages/chaire-lib-backend/lib/scripts/osrm/downloadOsmNetworkData.task.js --polygon-file examples/transition/polygon_rtl_area.geojson
+yarn babel-node --max-old-space-size=4096 packages/chaire-lib-backend/lib/scripts/osrm/downloadOsmNetworkData.task.js --polygon-file examples/polygon_rtl_area.geojson
 
 yarn babel-node --max-old-space-size=4096 packages/chaire-lib-backend/lib/scripts/osrm/prepareOsmNetworkData.task.js
 ```
 
-6. Start the nodejs server with `yarn start`.
+6. Start the nodejs server with `yarn start:demo`.
 
 7. Navigate to `http://localhost:8080` and log into the application.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "build:dev": "yarn workspace transition-frontend run build:dev",
         "build:prod": "yarn workspace transition-frontend run build:prod",
         "start": "yarn workspace transition-backend run start",
+        "start:demo": "PROJECT_CONFIG=${PWD}/examples/config.js yarn workspace transition-backend run start",
         "start:debug": "yarn workspace transition-backend run start:debug",
         "start:tracing": "yarn workspace transition-backend run start:tracing",
         "start:json2capnp": "cd services/json2capnp && cargo run --release",

--- a/packages/chaire-lib-backend/src/config/__tests__/server.config.noenv.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/server.config.noenv.test.ts
@@ -1,0 +1,29 @@
+// Test the server configuration without the environment variable, the file won't exists
+delete process.env.PROJECT_CONFIG;
+import fs from 'fs';
+import os from 'os';
+
+jest.mock('fs', () => {
+    // Require the original module to not be mocked...
+    const originalModule =
+        jest.requireActual<typeof import('fs')>('fs');
+  
+    return {
+        ...originalModule,
+        existsSync: jest.fn().mockReturnValue(false)
+    };
+});
+const existsSyncMock = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
+
+test('Expected reading configuration files in default paths', () => {
+    let error: unknown | undefined = undefined;
+    try {
+        require('../server.config')
+    } catch (err) {
+        error = err;
+    }
+    expect(error).toBeDefined();
+    expect(existsSyncMock).toHaveBeenCalledTimes(2);
+    expect(existsSyncMock).toHaveBeenCalledWith(`${os.homedir}/.config/transition/config.js`);
+    expect(existsSyncMock).toHaveBeenCalledWith(`/etc/transition/config.js`);
+});

--- a/packages/chaire-lib-backend/src/config/auth/index.ts
+++ b/packages/chaire-lib-backend/src/config/auth/index.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 // Unused, but must be imported to make sure the environment is configured at this point, otherwise process.env will have undefined values
-import _dotenv from 'chaire-lib-common/lib/config/shared/dotenv.config'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import _dotenv from '../dotenv.config'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import knex from '../shared/db.config';
 import passport from 'passport';
 import GoogleStrategy from 'passport-google-oauth';

--- a/packages/chaire-lib-backend/src/config/auth/localLogin.config.ts
+++ b/packages/chaire-lib-backend/src/config/auth/localLogin.config.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 // Unused, but must be imported to make sure the environment is configured at this point, otherwise process.env will have undefined values
-import _dotenv from 'chaire-lib-common/lib/config/shared/dotenv.config'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import _dotenv from '../dotenv.config'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import url from 'url';
 import { PassportStatic } from 'passport';
 import LocalStrategy from 'passport-local';

--- a/packages/chaire-lib-backend/src/config/auth/passport.utils.ts
+++ b/packages/chaire-lib-backend/src/config/auth/passport.utils.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 // Unused, but must be imported to make sure the environment is configured at this point, otherwise process.env will have undefined values
-import _dotenv from 'chaire-lib-common/lib/config/shared/dotenv.config'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import _dotenv from '../dotenv.config'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import UserModel from '../../services/auth/user';
 
 interface newUserParams {

--- a/packages/chaire-lib-backend/src/config/dotenv.config.ts
+++ b/packages/chaire-lib-backend/src/config/dotenv.config.ts
@@ -5,8 +5,39 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import path from 'path';
+import fs from 'fs';
 
 if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'development';
 }
-export default require('dotenv').config({ path: path.join(__dirname, '../../../..', '.env') });
+
+// INIT_CWD is the directory from which the script was run (usually root of the
+// repo), while PWD would be the chaire-lib-backend directory if run with `yarn
+// start`
+const workingDir = process.env.INIT_CWD || process.env.PWD;
+
+// Get the .env file. The return file path exists, the .env file can come from
+// the TRANSITION_DOTENV environment variable, or is expected to be at the root
+// of the directory
+const getDotEnvFile = (): string => {
+    // First, check the PROJECT_CONFIG environment variable
+    if (typeof process.env.TRANSITION_DOTENV === 'string') {
+        const dotEnvFile = process.env.TRANSITION_DOTENV.startsWith('/')
+            ? process.env.TRANSITION_DOTENV
+            : `${workingDir}/${process.env.TRANSITION_DOTENV}`;
+        if (fs.existsSync(dotEnvFile)) {
+            return path.normalize(dotEnvFile);
+        }
+        console.log(`.env file specified by TRANSITION_DOTENV environment variable does not exist: ${dotEnvFile}`);
+    }
+    const defaultDotEnv = `${workingDir}/.env`;
+    if (fs.existsSync(defaultDotEnv)) {
+        return defaultDotEnv;
+    }
+    // FIXME When all that is in .env right now can also be in the config file (issue #97), the .env will not be required anymore and the throw won't be necessary
+    throw `.env file not found. Set the TRANSITION_DOTENV environment variable to point to the .env file. The default path is ${defaultDotEnv}`;
+};
+
+const dotEnvPath = getDotEnvFile();
+console.log(`Using .env file from ${dotEnvPath}`);
+export default require('dotenv').config({ path: dotEnvPath });

--- a/packages/chaire-lib-backend/src/config/dotenv.config.ts
+++ b/packages/chaire-lib-backend/src/config/dotenv.config.ts
@@ -9,4 +9,4 @@ import path from 'path';
 if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'development';
 }
-export default require('dotenv').config({ path: path.join(__dirname, '../../../../..', '.env') });
+export default require('dotenv').config({ path: path.join(__dirname, '../../../..', '.env') });

--- a/packages/chaire-lib-backend/src/config/knexfile.ts
+++ b/packages/chaire-lib-backend/src/config/knexfile.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-require('chaire-lib-common/lib/config/shared/dotenv.config'); // dotenv is required to get the connection strings
+require('./dotenv.config'); // dotenv is required to get the connection strings
 import config from './server.config';
 // TODO Let this data be in the config file instead, but only when the server config is separate from project config to not leak data
 if (

--- a/packages/chaire-lib-backend/src/config/knexfile.ts
+++ b/packages/chaire-lib-backend/src/config/knexfile.ts
@@ -31,6 +31,6 @@ export default {
     migrations: {
         directory: __dirname + '/../models/db/migrations',
         tableName: 'knex_migrations_lib',
-        loadExtensions: [`.js`],
+        loadExtensions: ['.js']
     }
 };

--- a/packages/chaire-lib-backend/src/config/server.config.ts
+++ b/packages/chaire-lib-backend/src/config/server.config.ts
@@ -5,21 +5,46 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import path from 'path';
+import os from 'os';
 
 import config, { setProjectConfiguration } from 'chaire-lib-common/lib/config/shared/project.config';
 import fs from 'fs';
 
-// TODO Add a default path for the project configuration file. Now, it fails
-if (typeof process.env.PROJECT_CONFIG !== 'string') {
-    throw 'You must set the PROJECT_CONFIG environment variable in the .env file with the path to the config file.';
-}
+const etcConfigFile = '/etc/transition/config.js';
+const homeDirConfigFileRelative = '.config/transition/config.js';
 
-const projectConfigFile = process.env.PROJECT_CONFIG.replace('${rootDir}', `${__dirname}/../../../../`);
+// INIT_CWD is the directory from which the script was run (usually root of the
+// repo), while PWD would be the chaire-lib-backend directory if run with `yarn
+// start`
+const workingDir = process.env.INIT_CWD || process.env.PWD;
 
-const configFileNormalized = path.normalize(projectConfigFile);
-if (!fs.existsSync(configFileNormalized)) {
-    throw `Configuration file '${configFileNormalized}' does not exist`;
-}
+// Get the config file. The return file path exists, the configuration file can
+// come from the PROJECT_CONFIG environment variable, then
+// $HOME/.config/transition/config.js, then /etc/transition/config.js
+const getConfigFilePath = (): string => {
+    // First, check the PROJECT_CONFIG environment variable
+    if (typeof process.env.PROJECT_CONFIG === 'string') {
+        const projectConfigFile = process.env.PROJECT_CONFIG.startsWith('/')
+            ? process.env.PROJECT_CONFIG
+            : `${workingDir}/${process.env.PROJECT_CONFIG}`;
+        if (fs.existsSync(projectConfigFile)) {
+            return path.normalize(projectConfigFile);
+        }
+        console.log(
+            `Configuration file specified by PROJECT_CONFIG environment variable does not exist: ${projectConfigFile}`
+        );
+    }
+    const homeDirConfigFile = path.normalize(`${os.homedir()}/${homeDirConfigFileRelative}`);
+    if (fs.existsSync(homeDirConfigFile)) {
+        return homeDirConfigFile;
+    }
+    if (fs.existsSync(etcConfigFile)) {
+        return etcConfigFile;
+    }
+    throw `Configuration file not found. Either set the PROJECT_CONFIG environment variable to point to the config file, or use files ${homeDirConfigFile} or ${etcConfigFile} paths`;
+};
+
+const configFileNormalized = getConfigFilePath();
 
 // Initialize default server side configuration
 setProjectConfiguration({
@@ -29,6 +54,7 @@ setProjectConfiguration({
 
 try {
     const configFromFile = require(configFileNormalized);
+    console.log(`Read server configuration from ${configFileNormalized}`);
     // Default project directory is `runtime` at the root of the repo
     if (configFromFile.projectDirectory === undefined && configFromFile.projectShortname !== undefined) {
         configFromFile.projectDirectory = path.normalize(
@@ -37,7 +63,7 @@ try {
     }
     setProjectConfiguration(configFromFile);
 } catch (error) {
-    console.error('Error loading server configuration from the PROJECT_CONFIG environment variable');
+    console.error(`Error loading server configuration in file ${configFileNormalized}`);
 }
 
 /** Application configuration, does not include the server configuration */

--- a/packages/chaire-lib-backend/src/scripts/config/createUser.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/createUser.task.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config'; // Unused, but must be imported
+import '../../config/dotenv.config'; // Unused, but must be imported
 import { CreateUser } from '../../tasks/user/createUser';
 import taskWrapper from '../../tasks/taskWrapper';
 

--- a/packages/chaire-lib-backend/src/scripts/config/knexfile.public.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/knexfile.public.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import '../../config/dotenv.config';
 
 // TODO Typesafe the connection when refactoring knex files (#426)
 export default {

--- a/packages/chaire-lib-backend/src/scripts/config/knexfile.root.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/knexfile.root.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import '../../config/dotenv.config';
 
 // TODO Refactor knex files (#426)
 export default {

--- a/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
@@ -13,8 +13,6 @@ import knexPublicCfg from './knexfile.public';
 const knexRoot = knex(knexRootCfg);
 const knexPublic = knex(knexPublicCfg);
 
-
-
 const databaseName = process.env[`PG_DATABASE_${(process.env.NODE_ENV || 'development').toUpperCase()}`];
 const createExtensionsAndSchemaQuery = `
   CREATE EXTENSION IF NOT EXISTS "plpgsql"   SCHEMA public;

--- a/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/config/setup.task.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config'; // Unused, but must be imported
+import '../../config/dotenv.config'; // Unused, but must be imported
 import config from '../../config/server.config';
 import knex from 'knex';
 

--- a/packages/chaire-lib-backend/src/tasks/taskWrapper.ts
+++ b/packages/chaire-lib-backend/src/tasks/taskWrapper.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import '../config/dotenv.config';
 
 // Just make sure the config is initialized in the task, so tasks that are in common workspaces can have the right config
 import '../config/server.config';

--- a/packages/chaire-lib-backend/src/utils/filesystem/directoryManager.ts
+++ b/packages/chaire-lib-backend/src/utils/filesystem/directoryManager.ts
@@ -9,7 +9,7 @@ import glob from 'glob';
 import util from 'util';
 import fs from 'fs-extra';
 
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import '../../config/dotenv.config';
 import config from '../../config/server.config';
 
 // Recursively get size in bytes of a file or directory

--- a/packages/transition-backend/src/scripts/cache/recreateCache.task.ts
+++ b/packages/transition-backend/src/scripts/cache/recreateCache.task.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import 'chaire-lib-backend/lib/config/dotenv.config';
 import prepareSocketRoutes from '../prepareProcessRoutes';
 import { recreateCache } from '../../services/capnpCache/dbToCache';
 import OSRMProcessManager from 'chaire-lib-backend/lib/utils/processManagers/OSRMProcessManager';

--- a/packages/transition-backend/src/scripts/listTasks.task.ts
+++ b/packages/transition-backend/src/scripts/listTasks.task.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import 'chaire-lib-backend/lib/config/dotenv.config';
 
 import { listTasks } from './listTasks';
 import inquirer from 'inquirer';

--- a/packages/transition-backend/src/scripts/simulations/simulation.task.ts
+++ b/packages/transition-backend/src/scripts/simulations/simulation.task.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import 'chaire-lib-common/lib/config/shared/dotenv.config';
+import 'chaire-lib-backend/lib/config/dotenv.config';
 
 import prepareSocketRoutes from '../prepareProcessRoutes';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';

--- a/packages/transition-backend/src/server.ts
+++ b/packages/transition-backend/src/server.ts
@@ -8,7 +8,7 @@
 import fs from 'fs';
 import { join } from 'path';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import _dotenv from 'chaire-lib-common/lib/config/shared/dotenv.config';
+import _dotenv from 'chaire-lib-backend/lib/config/dotenv.config';
 import { setupServer } from './serverApp';
 import setupSocketServerApp from './socketServerApp';
 import yargs from 'yargs/yargs';

--- a/packages/transition-backend/src/serverApp.ts
+++ b/packages/transition-backend/src/serverApp.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 // FIXME Need to make sure it is imported. Really? It was imported in server.ts it should be enough
-import _dotenv from 'chaire-lib-common/lib/config/shared/dotenv.config';
+import _dotenv from 'chaire-lib-backend/lib/config/dotenv.config';
 // FIXME Need to make sure it is imported. Really? Any component using this should import it
 import _project from 'chaire-lib-backend/lib/config/server.config';
 import passport from 'chaire-lib-backend/lib/config/auth';

--- a/packages/transition-frontend/webpack.config.js
+++ b/packages/transition-frontend/webpack.config.js
@@ -12,7 +12,7 @@ const CopyWebpackPlugin       = require('copy-webpack-plugin');
 const HtmlWebpackPlugin       = require('html-webpack-plugin');
 const { CleanWebpackPlugin }  = require("clean-webpack-plugin");
 const CompressionPlugin       = require('compression-webpack-plugin');
-require('chaire-lib-common/lib/config/shared/dotenv.config');
+require('chaire-lib-backend/lib/config/dotenv.config');
 
 if (!process.env.NODE_ENV) {
   process.env.NODE_ENV = 'development';


### PR DESCRIPTION
Fixes #425

First, we check if the PROJECT_CONFIG environment variable contains the
path to the config file. Otherwise, it is expected to be in the
$homedir/.config/transition/config.js or /etc/transition/config.js.

The path in the .env now has to be absolute. ${rootDir} works only in
the current repository, but chaire-lib is meant as a library, so rootDir
will not work for those.

Add a start:demo script in the package.json which sets the
PROJECT_CONFIG environment variable to the example config.
