### PR TITLE
config: Allow the .env file to not exist

### DIFF
--- a/packages/chaire-lib-backend/src/config/dotenv.config.ts
+++ b/packages/chaire-lib-backend/src/config/dotenv.config.ts
@@ -19,7 +19,7 @@ const workingDir = process.env.INIT_CWD || process.env.PWD;
 // Get the .env file. The return file path exists, the .env file can come from
 // the TRANSITION_DOTENV environment variable, or is expected to be at the root
 // of the directory
-const getDotEnvFile = (): string => {
+const getDotEnvFile = (): string | null => {
     // First, check the PROJECT_CONFIG environment variable
     if (typeof process.env.TRANSITION_DOTENV === 'string') {
         const dotEnvFile = process.env.TRANSITION_DOTENV.startsWith('/')
@@ -34,10 +34,14 @@ const getDotEnvFile = (): string => {
     if (fs.existsSync(defaultDotEnv)) {
         return defaultDotEnv;
     }
-    // FIXME When all that is in .env right now can also be in the config file (issue #97), the .env will not be required anymore and the throw won't be necessary
-    throw `.env file not found. Set the TRANSITION_DOTENV environment variable to point to the .env file. The default path is ${defaultDotEnv}`;
+    console.log(
+        `.env file not found. You can set the TRANSITION_DOTENV environment variable to point to the .env file. The default path is ${defaultDotEnv}`
+    );
+    return null;
 };
 
 const dotEnvPath = getDotEnvFile();
-console.log(`Using .env file from ${dotEnvPath}`);
+if (dotEnvPath !== null) {
+    console.log(`Using .env file from ${dotEnvPath}`);
+}
 export default require('dotenv').config({ path: dotEnvPath });

--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -16,7 +16,7 @@
         "migrate:rollback": "knex migrate:down --knexfile lib/config/knexfile.js",
         "migrate-test": "cross-env NODE_ENV=test knex migrate:latest --knexfile lib/config/knexfile.js",
         "start": "yarn babel-node lib/server.js --max-old-space-size=4096",
-        "start:tracing": "yarn babel-node -r ../../../tracing.js lib/server.js --max-old-space-size=4096",
+        "start:tracing": "yarn babel-node -r ../../tracing.js lib/server.js --max-old-space-size=4096",
         "start:debug": "cross-env DEBUG=express:* yarn babel-node --trace-warnings lib/server.js --max-old-space-size=4096",
         "start:test": "cross-env NODE_ENV=test DEBUG=express:* yarn babel-node --trace-warnings lib/server.js --max-old-space-size=4096",
         "test": "cross-env NODE_ENV=test jest --config=jest.config.js",


### PR DESCRIPTION
The infrastructures just set the environment variables and do not need the .env file.