### PR TITLE
Fix start of osrm-contract

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
@@ -118,6 +118,13 @@ const configureAllOsrmServers = async function(startServers = true): Promise<voi
     }
 };
 
+function getOsrmRoutedStartArgs(osrmDirectory: string, mode: string, port: string): string[] {
+    return [
+        osrmDirectory + `/${mode}.osrm`,
+        `--max-table-size=100000 --max-matching-size=1000 --max-trip-size=1000 --max-viaroute-size=10000 -p${port}`
+    ];
+}
+
 //TODO set type for parameters instead of any
 //TODO set type for Promise return (in all the file)
 const start = function(parameters = {} as any): Promise<any> {
@@ -129,10 +136,7 @@ const start = function(parameters = {} as any): Promise<any> {
 
     return new Promise((resolve, reject) => {
         const command = 'osrm-routed';
-        const commandArgs = [
-            osrmDirectoryPath + '/*.osrm',
-            `--max-table-size=100000 --max-matching-size=1000 --max-trip-size=1000 --max-viaroute-size=10000 -p${port}`
-        ];
+        const commandArgs = getOsrmRoutedStartArgs(osrmDirectoryPath, mode, port);
         const waitString = 'running and waiting for requests';
 
         resolve(ProcessManager.startProcess(serviceName, tagName, command, commandArgs, waitString, true));
@@ -159,10 +163,7 @@ const restart = function(parameters): Promise<any> {
 
     return new Promise((resolve, reject) => {
         const command = 'osrm-routed';
-        const commandArgs = [
-            osrmDirectoryPath + '/*.osrm',
-            `--max-table-size=100000 --max-matching-size=1000 --max-trip-size=1000 --max-viaroute-size=10000 -p${port}`
-        ];
+        const commandArgs = getOsrmRoutedStartArgs(osrmDirectoryPath, mode, port);
         const waitString = 'running and waiting for requests';
 
         resolve(

--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMServicePreparation.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMServicePreparation.ts
@@ -119,7 +119,10 @@ const contract = function(parameters = {} as any): Promise<any> {
     return new Promise((resolve, reject) => {
         console.log(`osrm: contracting osrm data for mode ${mode} from directory ${osrmDirectoryPath}`);
 
-        const osrmProcess = spawn('osrm-contract', ['*.osrm'], {
+        // contract parameter need to match the prefix of the osm file passed to extract
+        // in our case it's the mode name. The .osrm is not generated in the latest osrm-extract
+        // but the name is still accepted as a base path
+        const osrmProcess = spawn('osrm-contract', [`${mode}.osrm`], {
             shell: true,
             detached: false,
             cwd: osrmDirectoryPath


### PR DESCRIPTION
osrm-contract expect the file prefix when starting. I don't know how the previous command worked