### PR TITLE
batchRouting: Reduce the amount of logging in batch calculations

### DIFF
--- a/packages/transition-backend/src/services/accessMapLocation/AccessMapLocationProvider.ts
+++ b/packages/transition-backend/src/services/accessMapLocation/AccessMapLocationProvider.ts
@@ -26,6 +26,7 @@ export interface accessMapLocationOptions {
     timeAttributeDepartureOrArrival: 'arrival' | 'departure';
     timeFormat: string;
     timeAttribute: string;
+    debug?: boolean;
 }
 
 const extractLocation = (
@@ -122,12 +123,14 @@ export const parseLocationsFromCsv = async (
             try {
                 const location = extractLocation(line, options, projections);
 
-                console.log(
-                    `line ${rowNumber} new location ${location.id} ${
-                        location.timeType === 'departure' ? 'dts=' : 'ats='
-                    }${location.timeOfTrip}
-                           `
-                );
+                if (options.debug) {
+                    console.log(
+                        `line ${rowNumber} new location ${location.id} ${
+                            location.timeType === 'departure' ? 'dts=' : 'ats='
+                        }${location.timeOfTrip}
+                            `
+                    );
+                }
 
                 locations.push(location);
             } catch (error) {

--- a/packages/transition-backend/src/services/odTrip/odTripProvider.ts
+++ b/packages/transition-backend/src/services/odTrip/odTripProvider.ts
@@ -28,6 +28,7 @@ export interface OdTripOptions {
     timeAttributeDepartureOrArrival: 'arrival' | 'departure';
     timeFormat: string;
     timeAttribute: string;
+    debug?: boolean;
 }
 
 const extractOdTrip = (
@@ -149,12 +150,14 @@ export const parseOdTripsFromCsv = async (
             try {
                 const odTrip = extractOdTrip(line, options, projections);
 
-                console.log(
-                    `line ${rowNumber} new odTrip ${odTrip.attributes.id} ${
-                        odTrip.attributes.timeType === 'departure' ? 'dts=' : 'ats='
-                    }${odTrip.attributes.timeOfTrip}
-                           `
-                );
+                if (options.debug) {
+                    console.log(
+                        `line ${rowNumber} new odTrip ${odTrip.attributes.id} ${
+                            odTrip.attributes.timeType === 'departure' ? 'dts=' : 'ats='
+                        }${odTrip.attributes.timeOfTrip}
+                            `
+                    );
+                }
 
                 odTrips.push(odTrip);
             } catch (error) {

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
@@ -115,6 +115,8 @@ export const batchAccessibilityMap = async (
 
         const promiseQueue = new pQueue({ concurrency: poolOfTrRoutingPorts.length });
 
+        // Log progress at most for each 1% progress
+        const logInterval = Math.ceil(locationsCount / 100);
         const accessMapLocationTask = async ({
             location,
             locationIndex
@@ -126,6 +128,9 @@ export const batchAccessibilityMap = async (
             try {
                 if (trRoutingPort === undefined) {
                     throw 'TrRoutingBatch: No available routing port. This should not happen';
+                }
+                if ((locationIndex + 1) % logInterval === 0) {
+                    console.log(`Calculating accessibility map ${locationIndex + 1}/${locationsCount}`);
                 }
 
                 const calculationAttributes = _cloneDeep(accessMapAttributes);

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
@@ -94,12 +94,6 @@ const routeOdTrip = async function(
             false
         );
 
-        console.log(
-            `odTrip ${parameters.odTripIndex + 1}/${parameters.odTripsCount} transit routed @port ${
-                parameters.trRoutingPort
-            }`
-        );
-
         let features: GeoJSON.Feature[] | undefined = undefined;
         if (parameters.withGeometries === true) {
             features = await generateShapeGeojsons(


### PR DESCRIPTION
Each odTrip calculated was logged when read and when calculated. For large input files, that is a lot of log lines, that are useless for debugging and any actual error logged during the execution is kicked out of the log buffer.

Log entries at read time are shown only if the debug option is set to true. Execution logs are shown for every 1% progress.