### PR TITLE
chaire-lib: Use a proper typeguard for the `isSaveable` method

### DIFF
--- a/packages/chaire-lib-common/src/utils/objects/Saveable.ts
+++ b/packages/chaire-lib-common/src/utils/objects/Saveable.ts
@@ -9,7 +9,8 @@ export interface Saveable {
     delete(socket: any): Promise<any>;
 }
 
-export const isSaveable = (obj: any) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isSaveable = (obj: any): obj is Saveable => {
     return obj.save && typeof obj.save === 'function' && obj.delete && typeof obj.delete === 'function';
 };
 

--- a/packages/chaire-lib-frontend/src/components/pageParts/SelectedObjectButtons.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/SelectedObjectButtons.tsx
@@ -86,7 +86,6 @@ const SelectedObjectButtons: React.FunctionComponent<SelectedObjectButtonsProps<
                 );
                 return;
             }
-            const saveableObject = object as unknown as Saveable;
             if (isFrozen === true && object.wasFrozen()) {
                 serviceLocator.selectedObjectsManager.deselect(objectSingularName);
                 return true;
@@ -97,7 +96,7 @@ const SelectedObjectButtons: React.FunctionComponent<SelectedObjectButtonsProps<
                         name: `Saving${objectCapitalizedSingularName}`,
                         progress: 0.0
                     });
-                    saveableObject
+                    object
                         .save(serviceLocator.socketEventManager)
                         .then((response) => {
                             if (props.afterSave) {


### PR DESCRIPTION
The typeguard avoids having to cast the object before using it as Saveable.