### PR TITLE
batchRouting: Fix mix up of lat/lon in batch routing result files

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
@@ -249,10 +249,10 @@ const generateCsvWithTransit = (
             !_isBlank(alternative.destination[0])
         ) {
             // TODO csvAttributes will need to be typed
-            csvAttributes.originLat = origin[1];
-            csvAttributes.originLon = origin[0];
-            csvAttributes.destinationLat = destination[1];
-            csvAttributes.destinationLon = destination[0];
+            csvAttributes.originLat = origin[0];
+            csvAttributes.originLon = origin[1];
+            csvAttributes.destinationLat = destination[0];
+            csvAttributes.destinationLon = destination[1];
         }
 
         for (const attribute in _omit(rest, ['steps'])) {

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
@@ -86,8 +86,8 @@ describe('csv only result', () => {
         expect(result.csv).toBeDefined();
         expect((result.csv as string[]).length).toEqual(1);
         expect((result.csv as string[])[0]).toEqual(`${odTrip.getId()},${odTrip.attributes.internal_id},` +
-            `${simplePathResult.path.origin[1]},${simplePathResult.path.origin[0]},` +
-            `${simplePathResult.path.destination[1]},${simplePathResult.path.destination[0]},` +
+            `${simplePathResult.path.origin[0]},${simplePathResult.path.origin[1]},` +
+            `${simplePathResult.path.destination[0]},${simplePathResult.path.destination[1]},` +
             `,,success,${simplePathResult.path.departureTime},` +
             `${simplePathResult.path.departureTimeSeconds},${simplePathResult.path.arrivalTime},${simplePathResult.path.arrivalTimeSeconds},` +
             `${simplePathResult.path.initialDepartureTime},${simplePathResult.path.initialDepartureTimeSeconds},${simplePathResult.path.initialLostTimeAtDepartureMinutes},` +
@@ -154,8 +154,8 @@ describe('csv only result', () => {
         expect(result.csv).toBeDefined();
         expect((result.csv as string[]).length).toEqual(1);
         expect((result.csv as string[])[0]).toEqual(`${odTrip.getId()},${odTrip.attributes.internal_id},` + 
-            `${simplePathResult.path.origin[1]},${simplePathResult.path.origin[0]},` +
-            `${simplePathResult.path.destination[1]},${simplePathResult.path.destination[0]},` +
+            `${simplePathResult.path.origin[0]},${simplePathResult.path.origin[1]},` +
+            `${simplePathResult.path.destination[0]},${simplePathResult.path.destination[1]},` +
             `,,success,${simplePathResult.path.departureTime},` +
             `${simplePathResult.path.departureTimeSeconds},${simplePathResult.path.arrivalTime},${simplePathResult.path.arrivalTimeSeconds},` +
             `${simplePathResult.path.initialDepartureTime},${simplePathResult.path.initialDepartureTimeSeconds},${simplePathResult.path.initialLostTimeAtDepartureMinutes},` +
@@ -218,8 +218,8 @@ describe('csv only result', () => {
         expect(result.csv).toBeDefined();
         expect((result.csv as string[]).length).toEqual(2);
         expect((result.csv as string[])[0]).toEqual(`${odTrip.getId()},${odTrip.attributes.internal_id},` +
-            `${simplePathResult.path.origin[1]},${simplePathResult.path.origin[0]},` +
-            `${simplePathResult.path.destination[1]},${simplePathResult.path.destination[0]},` +
+            `${simplePathResult.path.origin[0]},${simplePathResult.path.origin[1]},` +
+            `${simplePathResult.path.destination[0]},${simplePathResult.path.destination[1]},` +
             `1,2,success,${simplePathResult.path.departureTime},` +
             `${simplePathResult.path.departureTimeSeconds},${simplePathResult.path.arrivalTime},${simplePathResult.path.arrivalTimeSeconds},` +
             `${simplePathResult.path.initialDepartureTime},${simplePathResult.path.initialDepartureTimeSeconds},${simplePathResult.path.initialLostTimeAtDepartureMinutes},` +
@@ -238,8 +238,8 @@ describe('csv only result', () => {
             `${cyclingRouteResult.routes[0].duration},${cyclingRouteResult.routes[0].distance}`
         );
         expect((result.csv as string[])[1]).toEqual(`${odTrip.getId()},${odTrip.attributes.internal_id},` +
-            `${transferPathResult.path.origin[1]},${transferPathResult.path.origin[0]},` +
-            `${transferPathResult.path.destination[1]},${transferPathResult.path.destination[0]},` +
+            `${transferPathResult.path.origin[0]},${transferPathResult.path.origin[1]},` +
+            `${transferPathResult.path.destination[0]},${transferPathResult.path.destination[1]},` +
             `2,2,success,${transferPathResult.path.departureTime},` +
             `${transferPathResult.path.departureTimeSeconds},${transferPathResult.path.arrivalTime},${transferPathResult.path.arrivalTimeSeconds},` +
             `${transferPathResult.path.initialDepartureTime},${transferPathResult.path.initialDepartureTimeSeconds},${transferPathResult.path.initialLostTimeAtDepartureMinutes},` +


### PR DESCRIPTION
Fixes #487

The trRouting API v1 inverses the latitude and longitude order in the response.