### PR TITLE
Fix the Collapsible lazy rendered elements not displaying

### DIFF
--- a/packages/chaire-lib-frontend/src/styles/_collapsible.scss
+++ b/packages/chaire-lib-frontend/src/styles/_collapsible.scss
@@ -34,3 +34,9 @@
     background-color: grey;
   }
 }
+
+// FIXME react-collapsible's lazyRender requires the children to have at least a minimum height to be rendered on the first click.
+// See https://github.com/glennflanagan/react-collapsible/issues/36
+.Collapsible__contentInner {
+  padding-top: 1px;
+}


### PR DESCRIPTION
Fixes #494

This bug occurred since the upgrade to react-collapsible 2.10

On first click to a lazy rendered element, the height is 0 and the children are not expanded. Only on third click did it show. It is a bug in the react-collapsible library (see
https://github.com/glennflanagan/react-collapsible/issues/36)

To bypass this, add a 1px padding on top of the collapsible's inner content, to make sure the chilren have a height.