### PR TITLE
Remove transition-common dependency from chaire-lib-frontend

### DIFF
--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -77,7 +77,6 @@
     "redux-thunk": "^2.3.0",
     "remark-gfm": "^1.0.0",
     "socket.io-file-client": "^2.0.2",
-    "transition-common": "0.2.0-2",
     "typescript": "^4.4.4"
   },
   "devDependencies": {


### PR DESCRIPTION
chaire-lib packages do not depend on transition.