### PR TITLE
trRouting: Update the summary return type to match the v2 api

### DIFF
--- a/packages/chaire-lib-common/src/api/TrRouting/index.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/index.ts
@@ -5,4 +5,4 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 export * from './base';
-export * from './trRoutingApiV2';
+export * as TrRoutingV2 from './trRoutingApiV2';

--- a/packages/chaire-lib-common/src/api/TrRouting/trRoutingApiV2.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/trRoutingApiV2.ts
@@ -4,28 +4,35 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-export type TrRoutingV2ResponseCommon = {
-    status: 'success';
+
+export type RouteQueryResponse = {
     origin: [number, number];
     destination: [number, number];
     timeOfTrip: number;
     timeType: 0 | 1;
 };
 
-export type TrRoutingV2SummaryResult = TrRoutingV2ResponseCommon & {
-    nbAlternativesCalculated: number;
-    lines: {
-        lineUuid: string;
-        lineShortname: string;
-        lineLongname: string;
-        agencyUuid: string;
-        agencyAcronym: string;
-        agencyName: string;
-        alternativeCount: number;
-    }[];
+export type RouteSuccessResponseCommon = {
+    status: 'success';
+    query: RouteQueryResponse;
 };
 
-export type TrRoutingV2QueryError = {
+export type SummarySuccessResult = RouteSuccessResponseCommon & {
+    result: {
+        nbRoutes: number;
+        lines: {
+            lineUuid: string;
+            lineShortname: string;
+            lineLongname: string;
+            agencyUuid: string;
+            agencyAcronym: string;
+            agencyName: string;
+            alternativeCount: number;
+        }[];
+    };
+};
+
+export type RouteQueryError = {
     status: 'query_error';
     errorCode:
         | 'EMPTY_SCENARIO'
@@ -39,7 +46,7 @@ export type TrRoutingV2QueryError = {
         | 'PARAM_ERROR_UNKNOWN';
 };
 
-export type TrRoutingV2DataError = {
+export type DataError = {
     status: 'data_error';
     errorCode:
         | 'DATA_ERROR'
@@ -52,4 +59,4 @@ export type TrRoutingV2DataError = {
         | 'MISSING_DATA_SCHEDULES';
 };
 
-export type TrRoutingV2SummaryResponse = TrRoutingV2SummaryResult | TrRoutingV2DataError | TrRoutingV2QueryError;
+export type SummaryResponse = SummarySuccessResult | DataError | RouteQueryError;

--- a/packages/chaire-lib-common/src/services/trRouting/TrRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/trRouting/TrRoutingService.ts
@@ -324,10 +324,10 @@ export class TrRoutingService {
 
     private async internalSummary(
         params: TrRoutingApi.TransitRouteQueryOptions
-    ): Promise<TrRoutingApi.TrRoutingV2SummaryResult> {
+    ): Promise<TrRoutingApi.TrRoutingV2.SummaryResponse> {
         const routingResult = await this.callTrRouting<
             TrRoutingApi.TransitRouteQueryOptions,
-            TrRoutingApi.TrRoutingV2SummaryResponse
+            TrRoutingApi.TrRoutingV2.SummaryResponse
         >(apiCalls.summary, params);
         if (routingResult.status === 'data_error') {
             throw new TrError(
@@ -348,7 +348,7 @@ export class TrRoutingService {
             }
         }
 
-        return routingResult as TrRoutingApi.TrRoutingV2SummaryResult;
+        return routingResult as TrRoutingApi.TrRoutingV2.SummaryResponse;
     }
 
     // FIXME tahini: Type the options
@@ -371,7 +371,7 @@ export class TrRoutingService {
 
     public async summary(
         params: TrRoutingApi.TransitRouteQueryOptions
-    ): Promise<TrRoutingApi.TrRoutingV2SummaryResult> {
+    ): Promise<TrRoutingApi.TrRoutingV2.SummaryResponse> {
         return await this.internalSummary(params);
     }
 }


### PR DESCRIPTION
The API has recently changed for the summary call, with a `query` and `result` fields in the json response instead of everything at the root.