### PR TITLE
Improve the docker startup workflow and documentation

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,48 @@
+PROJECT_CONFIG=/app/examples/config.js
+#OSRM_DIRECTORY_PREFIX=demo_osrm (default: empty)
+HOST=http://localhost:8080
+PG_DATABASE_DEVELOPMENT=tr_dev
+PG_DATABASE_PRODUCTION=tr
+#PG_DATABASE_SCHEMA=demo_survey (default: PROJECT_SHORTNAME)
+PG_DATABASE_TEST=tr_test
+PG_CONNECTION_STRING_PREFIX=postgres://postgres:@localhost:5432/
+EXPRESS_SESSION_SECRET_KEY=DefaultDockerSessionKey
+# Path to the directory containing the trRouting executable
+#TR_ROUTING_PATH=/path/to/dir/containing/trRouting
+# Host and port for the trRouting server
+#TR_ROUTING_HOST_URL=http://locahost
+#TR_ROUTING_HOST_PORT=4000
+# Required for the mapbox map
+MAPBOX_ACCESS_TOKEN=MYMAPBOXACCESSTOKEN
+MAPBOX_USER_ID=mapbox
+MAPBOX_STYLE_ID=dark-v10
+#MAGIC_LINK_SECRET_KEY=MYVERYLONGSECRETKEYTOENCRYPTTOKENTOSENDTOUSERFORPASSWORDLESSLOGIN
+#CUSTOM_RASTER_TILES_XYZ_URL=https://exampltest/{z}/{x}/{y}
+#CUSTOM_RASTER_TILES_MIN_ZOOM=8
+#CUSTOM_RASTER_TILES_MAX_ZOOM=22
+#SSL_PRIVATE_KEY=/path/to/privkey.pem
+#SSL_CERT=/path/to/sslcert.pem
+STARTUP_RECREATE_CACHE=false
+
+# Uncomment and update to change the URL of the API to get the OpenStreetMap data
+#OSM_OVERPASS_API_URL=http://overpass-api.de/api/interpreter
+
+##############################################################
+# Mailing configuration, required for sending emails to users
+# strategy can be 'smtp' or 'sendmail'
+MAIL_TRANSPORT_STRATEGY=smtp
+
+# Sendmail strategy requires a path to sendmail
+# MAIL_TRANSPORT_SENDMAIL_PATH=/usr/sbin/sendmail
+
+# smtp requires credentials to the smtp server and additional configurations
+MAIL_TRANSPORT_SMTP_HOST=smtp.example.org
+MAIL_TRANSPORT_SMTP_PORT=587
+# Whether to use TLS 
+MAIL_TRANSPORT_SMTP_SECURE=false
+# SMTP server credentials
+MAIL_TRANSPORT_SMTP_AUTH_USER=myUser
+MAIL_TRANSPORT_SMTP_AUTH_PWD=password
+
+# From email
+MAIL_FROM_ADDRESS=example@example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,11 @@ COPY packages/transition-backend packages/transition-backend
 COPY packages/transition-frontend packages/transition-frontend
 RUN yarn install
 
-
 # Copy the rest. (node_modules are excluded in .dockerignore)
 COPY . /app
+
+# Setup the example as a default configuration for the image
+COPY .env.docker /app/.env
 
 #TODO evaluate if any of those commands are necessary
 #RUN yarn setup
@@ -39,9 +41,6 @@ RUN yarn compile
 
 #TODO We probably need to do something different for the projects configuration directories
 # the docker-compose file have an example of using volume for part of a project
-
-# Setup the example as a default configuration for the image
-COPY .env.example /app/.env
 
 # Copy in json2capnp
 COPY --from=json2capnpbuild /app/services/json2capnp/target/debug/json2capnp services/json2capnp/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ capnproto libcapnp-dev postgresql-postgis postgresql-postgis-scripts rustc cargo
 * `yarn migrate`: Update the database schema with latest changes. This can be run whenever the source code is updated
 * Optionally `yarn create-user`: Run this task to create a new user in the database. The user will be able to login to the web interface. This command can be run entirely in a non-interactive mode with the following parameters: `yarn create-user --username <username> --email <email> --password <clearTextPassword> [--first_name <firstName> --last_name <lastName> --[no-]admin --[no-]valid --[no-]confirmed --prefs <jsonStringOfPreferences>]`. For example, to create and administrator user with the english language as preference, run the following command `yarn create-user --username admin --email admin@example.org --password MyAdminPassword --admin --prefs '{ "lang": "en" }'`
 
-
 ## Getting started
 
 **An example configuration and geographical area can be found in [the examples](examples/) directory.**
@@ -69,6 +68,25 @@ yarn node --max-old-space-size=4096 packages/chaire-lib-backend/lib/scripts/osrm
 yarn node --max-old-space-size=4096 packages/chaire-lib-backend/lib/scripts/osrm/prepareOsmNetworkData.task.js
 ```
 
+### Prepare the environment file
+
+Transition relies on a few environment variables, that can either be set on the system, or contained in a .env file. First, copy the example .env file and edit the variables.
+
+```
+cp .env.example .env
+```
+
+* Change `PG_CONNECTION_STRING_PREFIX=postgres://postgres:@localhost:5432/` to `PG_CONNECTION_STRING_PREFIX=postgres://postgres:YOUR_POSTGRES_PASSWORD@localhost:5432/`
+* Change `EXPRESS_SESSION_SECRET_KEY` to a random string with no space
+* Change `PROJECT_CONFIG` to point to your project's configuration file. The default is an example configuration file that can be copied and configured for your own need.
+
+### Get a Mapbox access token
+* Go to [Mapbox](http://mapxbox.com) and sign up
+* Go to your account dashboard, then generate a new access token
+* Open the `.env` file
+* Copy this access token to `.env` file: `MAPBOX_ACCESS_TOKEN=YOUR_TOKEN`
+* If you have a custom mapbox style, put your username and style id in `MAPBOX_USER_ID` and `MAPBOX_STYLE_ID`
+
 ### Create the client application
 
 Run `yarn build:dev` or `yarn build:prod` to create the html client application that will be run on the browser. 
@@ -102,12 +120,18 @@ You can easily launch the whole transition system using Docker and thus not havi
 ### Building the image
 `docker build -t testtransition .`
 (You can replace testtransition with your prefered image name. Don't forget to update any other command and compose file if you do so)
-To run the application directly, you'll need to add an .env as previously described before building. 
+To run the application directly, you'll need to add a `.env` as previously described, either by editing the `.env.docker` file before building the image, or by adding a `.env` file and pointing to it when running.
+
+**Warning**: The project directory is assumed to be in `/app/examples/runtime` with a project name of `demo_transition`. The cache server starts with a cache at this location. If it is not the case, update line 69 of the `Dockerfile` to fine-tune the cache directory as second argument to `json2capnp`.
 
 ### Running using docker-compose
-An example docker-compose.yml file is available in the reposity. If used, it will spin up a container for the transition
-front-end and for dependent services like the postgis database
+An example docker-compose.yml file is available in the reposity. If used, it will spin up a container for the transition 
+front-end and for dependent services like the postgis database.
+
+*The `docker-compose.yml` file contains customization suggestion.*
+
 * `docker-compose up -d`
+
 On the first run, you'll need to run the the DB setup commands. See the Installation section of this document for the full details. As a short-hand:
 * `docker exec transition_transition-www_1 yarn setup`
 * `docker exec transition_transition-www_1 yarn migrate`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,17 @@
-# Example docker-compose file to run the Transition app in one container and a second one for PostGis
+# Example docker-compose file to run the Transition app in one container and a
+# second one for PostGis
 #
-# Use the official postgis image for the DB, with the default username and password
-# The DB data live in a docker volume. You can adapt to have it live in a specific location
-# To run with an existing DB, change the PG_CONNECTION_STRING_PREFIX and drop the postgres service
-# and related volume
+# Use the official postgis image for the DB, with the default username and
+# password The DB data live in a docker volume. You can adapt to have it live in
+# a specific location To run with an existing DB, change the
+# PG_CONNECTION_STRING_PREFIX and drop the postgres service and related volume
 #
-# It use the application configuration that was in the .env file that was built in the application image
+# It uses the application configuration that was in the .env file that was built
+# in the application image. It expects the project runtime directory to be in
+# /app/examples/runtime.
 # It used "testtransition" as the application image, you can adapt to your prefered image name.
+#
+# See the lines marked CUSTOM to see how to customize the image with frequent customization needs
 
 version: "3.7"
 # docker-compose version 1.22 is required for this version
@@ -19,6 +24,9 @@ services:
       - 8080:8080
     environment:
       PG_CONNECTION_STRING_PREFIX: postgres://postgres:pass@postgres:5432/
+      # CUSTOM Add environment variables. This can be any variable contained in the .env file. These have precedence over their value in .env
+      # PROJECT_CONFIG: /config/config.js
+      # TRANSITION_DOTENV: /path/to/custom/.env
     depends_on:
       - postgres
     #HACK, needed for running trRouting. See https://github.com/kaligrafy/trRouting/issues/23
@@ -29,6 +37,10 @@ services:
       - transition-project-osrm:/app/examples/runtime/osrm
       # TODO Remove this once the cache is actually a cache
       - transition-project-cache:/app/examples/runtime/cache
+      # CUSTOM For custom project with config file and runtime directory, add
+      # additional volumes here. The following lines adds the local
+      # `/home/myHome/transition-example` in the container's `/config` directory
+      # - "/home/myHome/transition-example/:/config"
 
   postgres:
     image: postgis/postgis

--- a/examples/config.js
+++ b/examples/config.js
@@ -5,7 +5,8 @@ module.exports = {
     auth: {
       localLogin: {
         allowRegistration: true,
-        confirmEmail: true
+        // This will send an email to confirm the user's email address. Email send needs to be configured. By default, users can register and directly login.
+        // confirmEmail: true
       }
     },
     


### PR DESCRIPTION
* Copy the .env.example file to .env before the rest, to not override the .env file

* Add edit suggestions to the `docker-compose.yml` file for common use cases

* Update the docker section of the README with additional documentation, as it does not work out of the box and needs some tweaking.