### PR TITLE
gtfs: Fix format of color in GTFS import/export

### DIFF
--- a/packages/transition-backend/src/services/gtfsExport/LineExporter.ts
+++ b/packages/transition-backend/src/services/gtfsExport/LineExporter.ts
@@ -43,7 +43,7 @@ const objectToGtfs = (line: Line, agencyId: string, includeCustomFields = false)
         route_desc: attributes.description, // optional
         route_type: vehicleType, // required
         route_url: attributes.data.gtfs?.route_url, // optional
-        route_color: attributes.color, // optional
+        route_color: attributes.color !== undefined ? attributes.color.substring(1) : undefined, // optional
         route_text_color: attributes.data.gtfs?.route_text_color || line.getPreferredTextColorBasedOnLineColor(), // optional
         route_sort_order: attributes.data.gtfs?.route_sort_order, // optional
         continuous_pickup: attributes.data.gtfs?.continuous_pickup, // optional

--- a/packages/transition-backend/src/services/gtfsExport/__tests__/LineExporter.test.ts
+++ b/packages/transition-backend/src/services/gtfsExport/__tests__/LineExporter.test.ts
@@ -44,14 +44,15 @@ export const lineAttributes1 = {
     category: 'C',
     allow_same_line_transfers: false,
     is_autonomous: true,
+    color: '#112233',
     data: {
         gtfs: {
             route_id: 'Orig',
             agency_id: 'OrigAg',
             route_type: 3,
             route_url: 'https://foo.com',
-            route_color: '#112233',
-            route_text_color: '#123456',
+            route_color: '112233',
+            route_text_color: '123456',
             route_sort_order: 3,
             continuous_pickup: 0,
             continuous_drop_off: 0
@@ -120,7 +121,7 @@ test('Test exporting one line originally from gtfs', async () => {
     expect(mockWriteStream.write).toHaveBeenCalledTimes(1);
     expect(mockWriteStream.write).toHaveBeenLastCalledWith([
         '"route_id","agency_id","route_short_name","route_long_name","route_desc","route_type","route_url","route_color","route_text_color","route_sort_order","continuous_pickup","continuous_drop_off"',
-        `"${lineAttributes1.id}","${agencyGtfsSlug}","${lineAttributes1.shortname}","${lineAttributes1.longname}",,3,"${lineAttributes1.data.gtfs.route_url}",,"${lineAttributes1.data.gtfs.route_text_color}",${lineAttributes1.data.gtfs.route_sort_order},${lineAttributes1.data.gtfs.continuous_pickup},${lineAttributes1.data.gtfs.continuous_drop_off}`
+        `"${lineAttributes1.id}","${agencyGtfsSlug}","${lineAttributes1.shortname}","${lineAttributes1.longname}",,3,"${lineAttributes1.data.gtfs.route_url}","112233","${lineAttributes1.data.gtfs.route_text_color}",${lineAttributes1.data.gtfs.route_sort_order},${lineAttributes1.data.gtfs.continuous_pickup},${lineAttributes1.data.gtfs.continuous_drop_off}`
     ].join('\n'));
     expect(mockWriteStream.end).toHaveBeenCalledTimes(1);
     expect(mockCreateStream).toHaveBeenCalledWith(expect.stringContaining('test/routes.txt'));
@@ -146,7 +147,7 @@ test('Test exporting multiple lines, with transferable that should not be export
     expect(mockWriteStream.write).toHaveBeenCalledTimes(1);
     expect(mockWriteStream.write).toHaveBeenLastCalledWith([
         '"route_id","agency_id","route_short_name","route_long_name","route_desc","route_type","route_url","route_color","route_text_color","route_sort_order","continuous_pickup","continuous_drop_off"',
-        `"${lineAttributes1.id}","${agencyGtfsSlug}","${lineAttributes1.shortname}","${lineAttributes1.longname}",,3,"${lineAttributes1.data.gtfs.route_url}",,"${lineAttributes1.data.gtfs.route_text_color}",${lineAttributes1.data.gtfs.route_sort_order},${lineAttributes1.data.gtfs.continuous_pickup},${lineAttributes1.data.gtfs.continuous_drop_off}`,
+        `"${lineAttributes1.id}","${agencyGtfsSlug}","${lineAttributes1.shortname}","${lineAttributes1.longname}",,3,"${lineAttributes1.data.gtfs.route_url}","112233","${lineAttributes1.data.gtfs.route_text_color}",${lineAttributes1.data.gtfs.route_sort_order},${lineAttributes1.data.gtfs.continuous_pickup},${lineAttributes1.data.gtfs.continuous_drop_off}`,
         `"${lineAttributes2.id}","${agencyGtfsSlug}","${lineAttributes2.shortname}","${lineAttributes2.longname}",,3,,,,,,`
     ].join('\n'));
     expect(mockWriteStream.end).toHaveBeenCalledTimes(1);

--- a/packages/transition-backend/src/services/gtfsImport/AgencyImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/AgencyImporter.ts
@@ -14,7 +14,7 @@ import { getUniqueAgencyAcronym } from 'transition-common/lib/services/agency/Ag
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { Agency as GtfsAgencySpec } from 'gtfs-types';
 import { GtfsObjectImporter } from './GtfsObjectImporter';
-import { GtfsInternalData } from './GtfsImportTypes';
+import { formatColor, GtfsInternalData } from './GtfsImportTypes';
 
 export class AgencyImporter implements GtfsObjectImporter<AgencyImportData, Agency> {
     public static DEFAULT_AGENCY_ACRONYM = 'single';
@@ -107,7 +107,8 @@ export class AgencyImporter implements GtfsObjectImporter<AgencyImportData, Agen
             name: gtfsObject.agency_name,
             data: {
                 gtfs: gtfsObject
-            }
+            },
+            color: formatColor(gtfsObject.tr_agency_color, agencyDefaultColor)
         };
         if (gtfsObject.tr_agency_description) {
             agencyAttributes.description = gtfsObject.tr_agency_description;
@@ -126,11 +127,6 @@ export class AgencyImporter implements GtfsObjectImporter<AgencyImportData, Agen
             if (descriptionStrings.length > 0) {
                 agencyAttributes.description = descriptionStrings.join(', ');
             }
-        }
-        if (gtfsObject.tr_agency_color) {
-            agencyAttributes.color = gtfsObject.tr_agency_color;
-        } else if (agencyDefaultColor) {
-            agencyAttributes.color = agencyDefaultColor;
         }
         return agencyAttributes;
     }

--- a/packages/transition-backend/src/services/gtfsImport/GtfsImportTypes.ts
+++ b/packages/transition-backend/src/services/gtfsImport/GtfsImportTypes.ts
@@ -73,3 +73,15 @@ export interface GtfsInternalData {
      */
     doNotUpdateAgencies: string[];
 }
+
+/**
+ * Properly formats a color string with a prefixing '#' sign, or returns
+ * undefined if no color or default value
+ *
+ * @param color The color string, prefixed with '#' or not
+ * @param defaultColor The default color, prefixed with '#'
+ * @returns A color string prefixed with '#', or the default color if undefined,
+ * or undefined if no default color specified
+ */
+export const formatColor = (color: string | undefined, defaultColor?: string) =>
+    color !== undefined ? `${color.startsWith('#') ? '' : '#'}${color}` : defaultColor;

--- a/packages/transition-backend/src/services/gtfsImport/ServiceImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ServiceImporter.ts
@@ -18,7 +18,7 @@ import { ServiceImportData, GtfsImportData } from 'transition-common/lib/service
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { getUniqueServiceName } from 'transition-common/lib/services/service/ServiceUtils';
 import { GtfsObjectImporter } from './GtfsObjectImporter';
-import { GtfsInternalData } from './GtfsImportTypes';
+import { formatColor, GtfsInternalData } from './GtfsImportTypes';
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
 import Line from 'transition-common/lib/services/line/Line';
 
@@ -49,12 +49,9 @@ export const gtfsToObjectAttributes = (gtfsObject: GtfsService): Partial<Service
             gtfs: {
                 service_id: gtfsObject.service_id
             }
-        }
+        },
+        color: formatColor(gtfsObject.tr_service_color)
     };
-    if (gtfsObject.tr_service_color) {
-        serviceAttributes.color =
-            (gtfsObject.tr_service_color.startsWith('#') ? '' : '#') + gtfsObject.tr_service_color;
-    }
     if (gtfsObject.tr_service_desc) {
         serviceAttributes.description = gtfsObject.tr_service_desc;
     }

--- a/packages/transition-backend/src/services/gtfsImport/__tests__/GtfsImportData.test.ts
+++ b/packages/transition-backend/src/services/gtfsImport/__tests__/GtfsImportData.test.ts
@@ -5,9 +5,10 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { Trip } from "gtfs-types";
-import { GtfsInternalData, StopTime } from '../GtfsImportTypes';
+import { GtfsInternalData, StopTime, formatColor } from '../GtfsImportTypes';
 import { GtfsImportData } from 'transition-common/lib/services/gtfs/GtfsImportTypes';
 import { secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import each from 'jest-each';
 
 /** Base object for import data, each test can add their own specific data, but use this with basic assignation for unused fields */
 export const defaultImportData = {
@@ -395,6 +396,13 @@ export const gtfsValidTransitionGeneratedData = {
     'stop_times.txt': gtfsValidSimpleData['stop_times.txt']
 }
 
-test('Dummy gtfs import data', () => {
-    // Empty test so this file passes
+
+each([
+    ['123456', undefined, '#123456'],
+    ['#123456', undefined, '#123456'],
+    ['123456', '#ABCDEF', '#123456'],
+    [undefined, '#ABCDEF', '#ABCDEF'],
+    [undefined, undefined, undefined],
+]).test('Format color: %s %s', (color, defaultValue, expected) => {
+    expect(formatColor(color, defaultValue)).toEqual(expected);
 })

--- a/packages/transition-backend/src/services/gtfsImport/__tests__/LineImporter.test.ts
+++ b/packages/transition-backend/src/services/gtfsImport/__tests__/LineImporter.test.ts
@@ -329,4 +329,28 @@ describe('GTFS Line import', () => {
             })
         }));
     });
+
+    test('Test default line color', async () => {
+        currentData = gtfsValidSimpleData;
+        
+        // No route color and no import agency color
+        const { route_color, ...rest } = line0ForImport;
+        const importData = [ { line: { ...rest }, selected: true } ];
+        const lines = new LineCollection([], {})
+
+        const lineImporter = new LineImporter({ directoryPath: '', lines });
+        const data = await lineImporter.import(Object.assign({}, defaultImportData, { lines: importData }), Object.assign({}, defaultInternalImportData, { agencyIdsByAgencyGtfsId }));
+        expect(lineSaveFct).toHaveBeenCalledTimes(1);
+        const newLine = data[gtfsValidTransitionGeneratedData['routes.txt'][0].route_id];
+        expect(newLine).toBeDefined();
+        expect(newLine.getAttributes().color).toEqual('#FFFFFF');
+
+        // Import again, this time with a default agency color
+        const defaultColor = '#ABCDEF';
+        const data2 = await lineImporter.import(Object.assign({}, defaultImportData, { lines: importData, agencies_color: defaultColor }), Object.assign({}, defaultInternalImportData, { agencyIdsByAgencyGtfsId }));
+        expect(lineSaveFct).toHaveBeenCalledTimes(2);
+        const newLine2 = data2[gtfsValidTransitionGeneratedData['routes.txt'][0].route_id];
+        expect(newLine2).toBeDefined();
+        expect(newLine2.getAttributes().color).toEqual(defaultColor);
+    });
 })


### PR DESCRIPTION
Fixes #505

In Transition, color fields are prefixed with '#', but in the gtfs specification, colors are the 6 hexadecimal digits of the colors. A helper method takes care of converting the color in the right format during import and exports removes the '#' prefix.