### PR TITLE
map: Use ul/li in the main map context menu

### DIFF
--- a/packages/chaire-lib-frontend/src/styles/_main.scss
+++ b/packages/chaire-lib-frontend/src/styles/_main.scss
@@ -22,6 +22,11 @@
   list-style-type: none;
   list-style: none;
 
+  ul {
+    padding: 0.5rem;
+    margin: 0;
+  }
+
   li {
     margin-bottom: 0.2rem;
   }

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -487,9 +487,9 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
         contextMenu.style.display = 'block';
 
         ReactDom.render(
-            <React.Fragment>
+            <ul>
                 {elements.map((element) => (
-                    <span
+                    <li
                         key={element.key ? element.key : element.title}
                         style={{ display: 'block', padding: '5px' }}
                         onClick={() => {
@@ -499,9 +499,9 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
                         onMouseOver={() => element.onHover && element.onHover()}
                     >
                         {this.props.t(element.title)}
-                    </span>
+                    </li>
                 ))}
-            </React.Fragment>,
+            </ul>,
             contextMenu
         );
     };


### PR DESCRIPTION
Fixes #500

These were already styled in the tr__main-map-context-menu and it makes sense to add elements as a list in this case.