### PR TITLE
Route calculation: Keep the selected tab between calculation

### DIFF
--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultsComponent.tsx
@@ -17,15 +17,13 @@ import { TransitRoutingAttributes } from 'transition-common/lib/services/transit
 export interface TransitRoutingResultsProps extends WithTranslation {
     results: ResultsByMode;
     request: TransitRoutingAttributes;
+    selectedMode?: RoutingOrTransitMode;
+    setSelectedMode: (mode: RoutingOrTransitMode) => void;
 }
 
 const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (props: TransitRoutingResultsProps) => {
     const selectedRoutingModes: RoutingOrTransitMode[] = (Object.keys(props.results) as RoutingOrTransitMode[]) || [];
     const selectedRoutingModesCount = selectedRoutingModes.length;
-
-    const [_selectedRoutingMode, setSelectedRoutingMode] = useState(
-        selectedRoutingModes.includes('transit') ? 'transit' : selectedRoutingModes[0]
-    );
 
     // prepare routing mode results tabs:
     const routingModesResultsTabs: Tab[] = [];
@@ -36,15 +34,7 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
             continue;
         }
         routingModesResultsTabs.push(
-            <Tab
-                key={selectedRoutingModes[i]}
-                onSelect={function (index, lastIndex, e) {
-                    if (index !== lastIndex) {
-                        // check if selection changed
-                        setSelectedRoutingMode(selectedRoutingModes[i]);
-                    }
-                }}
-            >
+            <Tab key={selectedRoutingModes[i]}>
                 {props.t(`transit:transitPath:routingModes:${selectedRoutingModes[i]}`)}
             </Tab>
         );
@@ -57,7 +47,15 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
 
     return (
         <React.Fragment>
-            <Tabs>
+            <Tabs
+                selectedIndex={props.selectedMode !== undefined ? selectedRoutingModes.indexOf(props.selectedMode) : 0}
+                onSelect={function (index, lastIndex, e) {
+                    if (index !== lastIndex) {
+                        // check if selection changed
+                        props.setSelectedMode(selectedRoutingModes[index]);
+                    }
+                }}
+            >
                 <TabList>{routingModesResultsTabs}</TabList>
                 <React.Fragment>{routingModesResultsTabPanels}</React.Fragment>
             </Tabs>

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -37,6 +37,7 @@ import { ResultsByMode } from 'transition-common/lib/services/transitRouting/Tra
 import TransitRoutingBaseComponent from './widgets/TransitRoutingBaseComponent';
 import ODCoordinatesComponent from './widgets/ODCoordinatesComponent';
 import TimeOfTripComponent from './widgets/TimeOfTripComponent';
+import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
 
 export interface TransitRoutingFormProps extends WithTranslation {
     // TODO tahini batch routing
@@ -52,6 +53,7 @@ interface TransitRoutingFormState extends ChangeEventsState<TransitRouting> {
     scenarioCollection: any;
     loading: boolean;
     routingErrors?: ErrorMessage[];
+    selectedMode?: RoutingOrTransitMode;
 }
 
 class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, TransitRoutingFormState> {
@@ -95,6 +97,10 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
             );
         }
     }
+
+    setSelectedMode = (selectedMode: RoutingOrTransitMode) => {
+        this.setState({ selectedMode });
+    };
 
     onScenarioCollectionUpdate() {
         this.setState({ scenarioCollection: serviceLocator.collectionManager.get('scenarios') });
@@ -465,6 +471,8 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
                         <RoutingResultsComponent
                             results={this.state.currentResult}
                             request={this.state.object.attributes}
+                            selectedMode={this.state.selectedMode}
+                            setSelectedMode={this.setSelectedMode}
                         />
                     )}
                 </form>


### PR DESCRIPTION
Fixes #528

Propagates the currently selected mode to the main transit calculation form and pass it to the results component.