### PR TITLE
transit routing: Make sure parameters are valid before batch

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -653,7 +653,8 @@
             "DataSourceAlreadyExists": "A data source with that name already exists for OD calculations.",
             "InvalidOdTripsDataSource": "Invalid OD calculations data source.",
             "ErrorCalculatingLocation":  "Error calculating location {{id}}",
-            "UserDiskQuotaReached": "Maximum allowed disk space has been reached. Please delete old tasks to delete their files."
+            "UserDiskQuotaReached": "Maximum allowed disk space has been reached. Please delete old tasks to delete their files.",
+            "RoutingParametersInvalidForBatch": "Routing parameters are invalid. Make sure the scenario is set and times have a valid value."
         },
         "actions": {
             "walking": "Walk",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -653,7 +653,8 @@
             "DataSourceAlreadyExists": "Une source de données de ce nom existe déjà pour les calculs OD.",
             "InvalidOdTripsDataSource": "Source de données de calculs OD invalide.",
             "ErrorCalculatingLocation":  "Erreur de calcul pour le lieu {{id}}",
-            "UserDiskQuotaReached": "L'espace disque maximal permis a été atteint. Veuillez supprimer des tâches passées pour en supprimer les fichiers"
+            "UserDiskQuotaReached": "L'espace disque maximal permis a été atteint. Veuillez supprimer des tâches passées pour en supprimer les fichiers",
+            "RoutingParametersInvalidForBatch": "Les paramètres pour le calcul de chemin sont invalides. Assurez-vous que le scénario est bien configuré et que les temps sont valides."
         },
         "actions": {
             "walking": "Marche",

--- a/packages/chaire-lib-frontend/src/components/forms/ChangeEventsForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/ChangeEventsForm.tsx
@@ -57,9 +57,9 @@ export abstract class ChangeEventsForm<P, S extends ChangeEventsState<any>> exte
         return this._invalidFields;
     }
 
-    protected hasInvalidFields(): boolean {
+    protected hasInvalidFields = (): boolean => {
         return Object.keys(this._invalidFields).filter((key) => this._invalidFields[key]).length > 0;
-    }
+    };
 }
 
 export default ChangeEventsForm;

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -43,6 +43,7 @@ export interface TransitBatchRoutingFormProps extends WithTranslation {
     fileUploader?: any;
     fileImportRef?: any;
     routingEngine: TransitRouting;
+    isRoutingEngineValid?: () => boolean;
 }
 
 interface TransitBatchRoutingFormState extends ChangeEventsState<TransitBatchRouting> {
@@ -206,6 +207,10 @@ class TransitRoutingBatchForm extends ChangeEventsForm<TransitBatchRoutingFormPr
     }
 
     async onCalculateBatch() {
+        if (this.props.isRoutingEngineValid !== undefined && !this.props.isRoutingEngineValid()) {
+            this.setState({ errors: ['transit:transitRouting:errors:RoutingParametersInvalidForBatch'] });
+            return;
+        }
         this.setState({
             batchRoutingInProgress: true,
             errors: [],

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -217,10 +217,10 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
         serviceLocator.eventManager.off('collection.update.scenarios', this.onScenarioCollectionUpdate);
     }
 
-    private isValid(): boolean {
+    private isValid = (): boolean => {
         // Are all form fields valid and the routing object too
         return !this.hasInvalidFields() && this.state.object.validate();
-    }
+    };
 
     private downloadCsv() {
         const elements = this.state.object.getAttributes().savedForBatch;
@@ -476,7 +476,7 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
                         />
                     )}
                 </form>
-                <TransitRoutingBatchForm routingEngine={this.state.object} />
+                <TransitRoutingBatchForm routingEngine={this.state.object} isRoutingEngineValid={this.isValid} />
             </React.Fragment>
         );
     }


### PR DESCRIPTION
Fixes #538

If scenario is not set or any other routing parameter field is invalid, add an error message when the user clicks on the batch calculation button to validate the routing parameters first.