### PR TITLE
Clean up the file uploader HOC

### DIFF
--- a/packages/chaire-lib-frontend/src/components/input/FileUploaderHOC.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/FileUploaderHOC.tsx
@@ -12,8 +12,6 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import ImportValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 
 export interface FileUploaderHOCProps {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
     fileImportRef: React.RefObject<HTMLInputElement>;
     fileUploader: SocketIOFileClient;
     onChange: React.ChangeEventHandler;
@@ -50,12 +48,10 @@ const fileUploaderHOC = <P,>(
             this.onFileUploadComplete = this.onFileUploadComplete.bind(this);
             this.onFileUploadError = this.onFileUploadError.bind(this);
             this.onFileUploadAbort = this.onFileUploadAbort.bind(this);
-            this.addEventListeners = this.addEventListeners.bind(this);
-            this.removeEventListeners = this.removeEventListeners.bind(this);
             this.onChange = this.onChange.bind(this);
         }
 
-        addEventListeners() {
+        componentDidMount() {
             this.fileUploader.on('start', this.onFileUploadStart);
             this.fileUploader.on('stream', this.onFileUploadStream);
             this.fileUploader.on('complete', this.onFileUploadComplete);
@@ -63,7 +59,7 @@ const fileUploaderHOC = <P,>(
             this.fileUploader.on('abort', this.onFileUploadAbort);
         }
 
-        removeEventListeners() {
+        componentWillUnmount() {
             this.fileUploader.off('start', this.onFileUploadStart);
             this.fileUploader.off('stream', this.onFileUploadStream);
             this.fileUploader.off('complete', this.onFileUploadComplete);
@@ -107,8 +103,6 @@ const fileUploaderHOC = <P,>(
             return (
                 <WrappedComponent
                     {...this.props}
-                    addEventListeners={this.addEventListeners}
-                    removeEventListeners={this.removeEventListeners}
                     fileImportRef={this.fileImportRef}
                     fileUploader={this.fileUploader}
                     onChange={this.onChange}

--- a/packages/chaire-lib-frontend/src/components/input/FileUploaderHOC.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/FileUploaderHOC.tsx
@@ -11,27 +11,27 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import ImportValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 
-interface FileUploaderHOCProps {
-    fileUploader: any;
-    fileImportRef: any;
+export interface FileUploaderHOCProps {
+    addEventListeners: () => void;
+    removeEventListeners: () => void;
+    fileImportRef: React.RefObject<HTMLInputElement>;
+    fileUploader: SocketIOFileClient;
+    onChange: React.ChangeEventHandler;
+    validator?: ImportValidator;
 }
 
 interface FileUploaderHOCState {
     validator?: ImportValidator;
 }
 
-/**
- * TODO Fix and type this class. Look at react hooks which are supposed to be
- * the new way to do hoc in typescript?
- */
 const fileUploaderHOC = <P,>(
     WrappedComponent: React.ComponentType<P>,
     importerValidator?: typeof ImportValidator,
     autoImport = true
 ) => {
     class FileUploaderHOC extends React.Component<P & FileUploaderHOCProps, FileUploaderHOCState> {
-        private fileImportRef;
-        private fileUploader;
+        private fileImportRef: React.RefObject<HTMLElement>;
+        private fileUploader: SocketIOFileClient;
 
         constructor(props: P & FileUploaderHOCProps) {
             super(props);
@@ -107,11 +107,6 @@ const fileUploaderHOC = <P,>(
             return (
                 <WrappedComponent
                     {...this.props}
-                    onFileUploadStart={this.onFileUploadStart}
-                    onFileUploadStream={this.onFileUploadStream}
-                    onFileUploadComplete={this.onFileUploadComplete}
-                    onFileUploadError={this.onFileUploadError}
-                    onFileUploadAbort={this.onFileUploadAbort}
                     addEventListeners={this.addEventListeners}
                     removeEventListeners={this.removeEventListeners}
                     fileImportRef={this.fileImportRef}

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -207,15 +207,9 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
     }
 
     componentDidMount() {
-        if (this.props.addEventListeners) this.props.addEventListeners();
-
         serviceLocator.socketEventManager.emit('service.parallelThreadCount', (response) => {
             this.setMaxParallelCalculators(response.count);
         });
-    }
-
-    componentWillUnmount() {
-        if (this.props.removeEventListeners) this.props.removeEventListeners();
     }
 
     render() {

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -32,18 +32,14 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 // ** File upload
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import { _toInteger, _toBool, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 import BatchAttributesSelection from './widgets/BatchAttributesSelection';
 import { BatchAccessibilityMapCalculator } from '../../../services/accessibilityMap/BatchAccessibilityMapCalculator';
 import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
 
-export interface BatchAccessibilityMapFormProps extends WithTranslation {
-    addEventListeners?: () => void;
-    removeEventListeners?: () => void;
-    fileUploader?: any;
-    fileImportRef?: any;
+export interface BatchAccessibilityMapFormProps extends FileUploaderHOCProps {
     routingEngine: TransitAccessibilityMapRouting;
 }
 
@@ -67,10 +63,10 @@ interface BatchAccessibilityMapFormState extends ChangeEventsState<TransitBatchA
 // part. That would require extending 2 different classes, which is possibly
 // permitted in javascript, but not the cleanest.
 class AccessibilityMapBatchForm extends ChangeEventsForm<
-    BatchAccessibilityMapFormProps,
+    BatchAccessibilityMapFormProps & WithTranslation,
     BatchAccessibilityMapFormState
 > {
-    constructor(props: BatchAccessibilityMapFormProps) {
+    constructor(props: BatchAccessibilityMapFormProps & WithTranslation) {
         super(props);
 
         const batchRoutingEngine = new TransitBatchAccessibilityMap(

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyImportForm.tsx
@@ -7,12 +7,10 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface AgencyImportFormProps extends FileUploaderHOCProps {
+interface AgencyImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
@@ -31,22 +29,16 @@ const AgenciesImportForm: React.FunctionComponent<AgencyImportFormProps & WithTr
     };
 
     React.useEffect(() => {
-        props.addEventListeners();
         serviceLocator.socketEventManager.on('importer.agenciesImported', onImported);
         return () => {
-            props.removeEventListeners();
             serviceLocator.socketEventManager.off('importer.agenciesImported', onImported);
         };
     }, []);
 
     return (
         <FileImportForm
-            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'agencies'}
             fileNameWithExtension={'agencies.json'}
-            fileUploader={props.fileUploader}
-            fileImportRef={props.fileImportRef}
-            onChange={props.onChange}
             label={props.t('main:JsonFile')}
             acceptsExtension={'.json'}
             closeImporter={closeImporter}
@@ -54,4 +46,4 @@ const AgenciesImportForm: React.FunctionComponent<AgencyImportFormProps & WithTr
     );
 };
 
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(AgenciesImportForm), ImporterValidator);
+export default withTranslation(['transit', 'main'])(AgenciesImportForm);

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyImportForm.tsx
@@ -9,20 +9,16 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface AgencyImportFormProps extends WithTranslation {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
-    onChange: React.ChangeEventHandler;
+interface AgencyImportFormProps extends FileUploaderHOCProps {
     setImporterSelected: (importerSelected: boolean) => void;
-    fileUploader?: any;
-    fileImportRef?: any;
-    validator: ImporterValidator;
 }
 
-const AgenciesImportForm: React.FunctionComponent<AgencyImportFormProps> = (props: AgencyImportFormProps) => {
+const AgenciesImportForm: React.FunctionComponent<AgencyImportFormProps & WithTranslation> = (
+    props: AgencyImportFormProps & WithTranslation
+) => {
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -45,7 +41,7 @@ const AgenciesImportForm: React.FunctionComponent<AgencyImportFormProps> = (prop
 
     return (
         <FileImportForm
-            validator={props.validator}
+            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'agencies'}
             fileNameWithExtension={'agencies.json'}
             fileUploader={props.fileUploader}

--- a/packages/transition-frontend/src/components/forms/line/TransitLineImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineImportForm.tsx
@@ -7,12 +7,10 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface LineImportFormProps extends FileUploaderHOCProps {
+interface LineImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
@@ -35,22 +33,16 @@ const LineImportForm: React.FunctionComponent<LineImportFormProps & WithTranslat
     };
 
     React.useEffect(() => {
-        props.addEventListeners();
         serviceLocator.socketEventManager.on('importer.linesImported', onImported);
         return () => {
-            props.removeEventListeners();
             serviceLocator.socketEventManager.off('importer.linesImported', onImported);
         };
     }, []);
 
     return (
         <FileImportForm
-            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'lines'}
             fileNameWithExtension={'lines.json'}
-            fileUploader={props.fileUploader}
-            fileImportRef={props.fileImportRef}
-            onChange={props.onChange}
             label={props.t('main:JsonFile')}
             acceptsExtension={'.json'}
             closeImporter={closeImporter}
@@ -58,4 +50,4 @@ const LineImportForm: React.FunctionComponent<LineImportFormProps & WithTranslat
     );
 };
 
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(LineImportForm), ImporterValidator);
+export default withTranslation(['transit', 'main'])(LineImportForm);

--- a/packages/transition-frontend/src/components/forms/line/TransitLineImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineImportForm.tsx
@@ -9,20 +9,16 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface LineImportFormProps extends WithTranslation {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
-    onChange: React.ChangeEventHandler;
+interface LineImportFormProps extends FileUploaderHOCProps {
     setImporterSelected: (importerSelected: boolean) => void;
-    fileUploader?: any;
-    fileImportRef?: any;
-    validator: ImporterValidator;
 }
 
-const LineImportForm: React.FunctionComponent<LineImportFormProps> = (props: LineImportFormProps) => {
+const LineImportForm: React.FunctionComponent<LineImportFormProps & WithTranslation> = (
+    props: LineImportFormProps & WithTranslation
+) => {
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -49,7 +45,7 @@ const LineImportForm: React.FunctionComponent<LineImportFormProps> = (props: Lin
 
     return (
         <FileImportForm
-            validator={props.validator}
+            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'lines'}
             fileNameWithExtension={'lines.json'}
             fileUploader={props.fileUploader}

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
@@ -9,20 +9,16 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface NodeImportFormProps extends WithTranslation {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
-    onChange: React.ChangeEventHandler;
+interface NodeImportFormProps extends FileUploaderHOCProps {
     setImporterSelected: (importerSelected: boolean) => void;
-    fileUploader?: any;
-    fileImportRef?: any;
-    validator: ImporterValidator;
 }
 
-const NodesImportForm: React.FunctionComponent<NodeImportFormProps> = (props: NodeImportFormProps) => {
+const NodesImportForm: React.FunctionComponent<NodeImportFormProps & WithTranslation> = (
+    props: NodeImportFormProps & WithTranslation
+) => {
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -51,7 +47,7 @@ const NodesImportForm: React.FunctionComponent<NodeImportFormProps> = (props: No
 
     return (
         <FileImportForm
-            validator={props.validator}
+            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'nodes'}
             fileNameWithExtension={'nodes.geojson'}
             fileUploader={props.fileUploader}

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
@@ -7,12 +7,10 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface NodeImportFormProps extends FileUploaderHOCProps {
+interface NodeImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
@@ -37,22 +35,16 @@ const NodesImportForm: React.FunctionComponent<NodeImportFormProps & WithTransla
     };
 
     React.useEffect(() => {
-        props.addEventListeners();
         serviceLocator.socketEventManager.on('importer.nodesImported', onImported);
         return () => {
-            props.removeEventListeners();
             serviceLocator.socketEventManager.off('importer.nodesImported', onImported);
         };
     }, []);
 
     return (
         <FileImportForm
-            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'nodes'}
             fileNameWithExtension={'nodes.geojson'}
-            fileUploader={props.fileUploader}
-            fileImportRef={props.fileImportRef}
-            onChange={props.onChange}
             acceptsExtension={'.json,.geojson'}
             label={props.t('main:GeojsonFile')}
             closeImporter={closeImporter}
@@ -60,4 +52,4 @@ const NodesImportForm: React.FunctionComponent<NodeImportFormProps & WithTransla
     );
 };
 
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(NodesImportForm), ImporterValidator);
+export default withTranslation(['transit', 'main'])(NodesImportForm);

--- a/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
@@ -9,20 +9,16 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface PathImportFormProps extends WithTranslation {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
-    onChange: React.ChangeEventHandler;
+interface PathImportFormProps extends FileUploaderHOCProps {
     setImporterSelected: (importerSelected: boolean) => void;
-    fileUploader?: any;
-    fileImportRef?: any;
-    validator: ImporterValidator;
 }
 
-const PathsImportForm: React.FunctionComponent<PathImportFormProps> = (props: PathImportFormProps) => {
+const PathsImportForm: React.FunctionComponent<PathImportFormProps & WithTranslation> = (
+    props: PathImportFormProps & WithTranslation
+) => {
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -58,7 +54,7 @@ const PathsImportForm: React.FunctionComponent<PathImportFormProps> = (props: Pa
 
     return (
         <FileImportForm
-            validator={props.validator}
+            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'paths'}
             fileNameWithExtension={'paths.geojson'}
             fileUploader={props.fileUploader}

--- a/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
@@ -7,12 +7,10 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface PathImportFormProps extends FileUploaderHOCProps {
+interface PathImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
@@ -44,22 +42,16 @@ const PathsImportForm: React.FunctionComponent<PathImportFormProps & WithTransla
     };
 
     React.useEffect(() => {
-        props.addEventListeners();
         serviceLocator.socketEventManager.on('importer.pathsImported', onImported);
         return () => {
-            props.removeEventListeners();
             serviceLocator.socketEventManager.off('importer.pathsImported', onImported);
         };
     }, []);
 
     return (
         <FileImportForm
-            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'paths'}
             fileNameWithExtension={'paths.geojson'}
-            fileUploader={props.fileUploader}
-            fileImportRef={props.fileImportRef}
-            onChange={props.onChange}
             acceptsExtension={'.json,.geojson'}
             label={props.t('main:GeojsonFile')}
             closeImporter={closeImporter}
@@ -67,4 +59,4 @@ const PathsImportForm: React.FunctionComponent<PathImportFormProps & WithTransla
     );
 };
 
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(PathsImportForm), ImporterValidator);
+export default withTranslation(['transit', 'main'])(PathsImportForm);

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
@@ -9,20 +9,16 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface ScenarioImportFormProps extends WithTranslation {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
-    onChange: React.ChangeEventHandler;
+interface ScenarioImportFormProps extends FileUploaderHOCProps {
     setImporterSelected: (importerSelected: boolean) => void;
-    fileUploader?: any;
-    fileImportRef?: any;
-    validator: ImporterValidator;
 }
 
-const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps> = (props: ScenarioImportFormProps) => {
+const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps & WithTranslation> = (
+    props: ScenarioImportFormProps & WithTranslation
+) => {
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -45,7 +41,7 @@ const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps> = (p
 
     return (
         <FileImportForm
-            validator={props.validator}
+            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'scenarios'}
             fileNameWithExtension={'scenarios.json'}
             fileUploader={props.fileUploader}

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
@@ -7,12 +7,10 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface ScenarioImportFormProps extends FileUploaderHOCProps {
+interface ScenarioImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
@@ -31,26 +29,20 @@ const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps & Wit
     };
 
     React.useEffect(() => {
-        props.addEventListeners();
         serviceLocator.socketEventManager.on('importer.scenariosImported', onImported);
         return () => {
-            props.removeEventListeners();
             serviceLocator.socketEventManager.off('importer.scenariosImported', onImported);
         };
     }, []);
 
     return (
         <FileImportForm
-            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'scenarios'}
             fileNameWithExtension={'scenarios.json'}
-            fileUploader={props.fileUploader}
-            fileImportRef={props.fileImportRef}
-            onChange={props.onChange}
             label={props.t('main:JsonFile')}
             closeImporter={closeImporter}
         />
     );
 };
 
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(ScenariosImportForm), ImporterValidator);
+export default withTranslation(['transit', 'main'])(ScenariosImportForm);

--- a/packages/transition-frontend/src/components/forms/service/TransitServicesImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServicesImportForm.tsx
@@ -9,20 +9,16 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface ServicesImportFormProps extends WithTranslation {
-    addEventListeners: () => void;
-    removeEventListeners: () => void;
-    onChange: React.ChangeEventHandler;
+interface ServicesImportFormProps extends FileUploaderHOCProps {
     setImporterSelected: (importerSelected: boolean) => void;
-    fileUploader?: any;
-    fileImportRef?: any;
-    validator: ImporterValidator;
 }
 
-const ServicesImportForm: React.FunctionComponent<ServicesImportFormProps> = (props: ServicesImportFormProps) => {
+const ServicesImportForm: React.FunctionComponent<ServicesImportFormProps & WithTranslation> = (
+    props: ServicesImportFormProps & WithTranslation
+) => {
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -45,7 +41,7 @@ const ServicesImportForm: React.FunctionComponent<ServicesImportFormProps> = (pr
 
     return (
         <FileImportForm
-            validator={props.validator}
+            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'services'}
             fileNameWithExtension={'services.json'}
             fileUploader={props.fileUploader}

--- a/packages/transition-frontend/src/components/forms/service/TransitServicesImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServicesImportForm.tsx
@@ -7,12 +7,10 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import FileImportForm from '../../parts/FileImportForm';
 
-interface ServicesImportFormProps extends FileUploaderHOCProps {
+interface ServicesImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
@@ -31,26 +29,20 @@ const ServicesImportForm: React.FunctionComponent<ServicesImportFormProps & With
     };
 
     React.useEffect(() => {
-        props.addEventListeners();
         serviceLocator.socketEventManager.on('importer.servicesImported', onImported);
         return () => {
-            props.removeEventListeners();
             serviceLocator.socketEventManager.off('importer.servicesImported', onImported);
         };
     }, []);
 
     return (
         <FileImportForm
-            validator={props.validator as ImporterValidator}
             pluralizedObjectsName={'services'}
             fileNameWithExtension={'services.json'}
-            fileUploader={props.fileUploader}
-            fileImportRef={props.fileImportRef}
-            onChange={props.onChange}
             label={props.t('main:JsonFile')}
             closeImporter={closeImporter}
         />
     );
 };
 
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(ServicesImportForm), ImporterValidator);
+export default withTranslation(['transit', 'main'])(ServicesImportForm);

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -30,18 +30,14 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 // ** File upload
-import FileUploaderHOC from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 import { _toInteger, _toBool, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 import BatchAttributesSelection from './widgets/BatchAttributesSelection';
 import BatchSaveToDb from './widgets/BatchSaveToDb';
 import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
 
-export interface TransitBatchRoutingFormProps extends WithTranslation {
-    addEventListeners?: () => void;
-    removeEventListeners?: () => void;
-    fileUploader?: any;
-    fileImportRef?: any;
+export interface TransitBatchRoutingFormProps extends FileUploaderHOCProps {
     routingEngine: TransitRouting;
     isRoutingEngineValid?: () => boolean;
 }
@@ -63,10 +59,13 @@ interface TransitBatchRoutingFormState extends ChangeEventsState<TransitOdDemand
 }
 
 // TODO tahini type this class
-class TransitRoutingBatchForm extends ChangeEventsForm<TransitBatchRoutingFormProps, TransitBatchRoutingFormState> {
+class TransitRoutingBatchForm extends ChangeEventsForm<
+    TransitBatchRoutingFormProps & WithTranslation,
+    TransitBatchRoutingFormState
+> {
     private fileReader: any;
 
-    constructor(props: TransitBatchRoutingFormProps) {
+    constructor(props: TransitBatchRoutingFormProps & WithTranslation) {
         super(props);
 
         const batchRoutingEngine = new TransitOdDemandFromCsv(

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -253,15 +253,9 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
     }
 
     componentDidMount() {
-        if (this.props.addEventListeners) this.props.addEventListeners();
-
         serviceLocator.socketEventManager.emit('service.parallelThreadCount', (response) => {
             this.setMaxParallelCalculators(response.count);
         });
-    }
-
-    componentWillUnmount() {
-        if (this.props.removeEventListeners) this.props.removeEventListeners();
     }
 
     render() {

--- a/packages/transition-frontend/src/components/parts/FileImportForm.tsx
+++ b/packages/transition-frontend/src/components/parts/FileImportForm.tsx
@@ -14,20 +14,20 @@ import InputFile from 'chaire-lib-frontend/lib/components/input/InputFile';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import ImporterValidator from 'chaire-lib-common/lib/services/importers/ImporterValidator';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 
-interface FileImportFormProps extends WithTranslation {
+interface FileImportFormProps extends FileUploaderHOCProps {
     pluralizedObjectsName: string;
     fileNameWithExtension: string;
-    fileUploader: any;
-    fileImportRef: React.RefObject<HTMLInputElement>;
-    onChange: React.ChangeEventHandler;
-    validator: ImporterValidator;
     label: string;
     closeImporter: React.MouseEventHandler;
     acceptsExtension?: string;
 }
 
-const FileImportForm: React.FunctionComponent<FileImportFormProps> = (props: FileImportFormProps) => {
+const FileImportForm: React.FunctionComponent<FileImportFormProps & WithTranslation> = (
+    props: FileImportFormProps & WithTranslation
+) => {
+    const validator = props.validator as ImporterValidator;
     return (
         <form
             id={`tr__form-transit-${props.pluralizedObjectsName}-import`}
@@ -39,9 +39,7 @@ const FileImportForm: React.FunctionComponent<FileImportFormProps> = (props: Fil
                 <div className="apptr__form-input-container _two-columns">
                     <label>{props.label}</label>
                     <InputFile
-                        id={`formField${_upperFirst(props.pluralizedObjectsName)}ImporterFile${props.validator.get(
-                            'id'
-                        )}`}
+                        id={`formField${_upperFirst(props.pluralizedObjectsName)}ImporterFile${validator.get('id')}`}
                         accept={props.acceptsExtension}
                         inputRef={props.fileImportRef}
                         onChange={props.onChange}
@@ -77,9 +75,12 @@ const FileImportForm: React.FunctionComponent<FileImportFormProps> = (props: Fil
                 )}
             </div>
 
-            <FormErrors errors={props.validator.getErrors()} />
+            <FormErrors errors={validator.getErrors()} />
         </form>
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(FileImportForm);
+export default FileUploaderHOC(
+    withTranslation(['transit', 'main', 'form', 'notifications'])(FileImportForm),
+    ImporterValidator
+);


### PR DESCRIPTION
1- Type the FileUploaderHOC's props and have consumers extend those props instead of redefining them

2- Let the FileImportForm use the FileUploaderHOC directly instead of every form using it