### PR TITLE
transitDemand: Type the csvFile attribute and handle fields in base class

### DIFF
--- a/packages/transition-common/src/services/accessibilityMap/TransitBatchAccessibilityMap.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitBatchAccessibilityMap.ts
@@ -54,6 +54,15 @@ export class TransitBatchAccessibilityMap extends TransitDemandFromCsv<TransitBa
     get routingEngine(): AccessibilityMapRouting {
         return this._routing;
     }
+
+    protected onCsvFileAttributesUpdated = (_csvFields: string[]): void => {
+        if (this.attributes.xAttribute && !_csvFields.includes(this.attributes.xAttribute)) {
+            this.attributes.xAttribute = undefined;
+        }
+        if (this.attributes.yAttribute && !_csvFields.includes(this.attributes.yAttribute)) {
+            this.attributes.yAttribute = undefined;
+        }
+    };
 }
 
 export default TransitBatchAccessibilityMap;

--- a/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
@@ -6,10 +6,8 @@
  */
 import _cloneDeep from 'lodash.clonedeep';
 
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import { TransitRouting } from '../transitRouting/TransitRouting';
 import DataSourceCollection from '../dataSource/DataSourceCollection';
 import { TransitDemandFromCsv, TransitDemandFromCsvAttributes } from './TransitDemandFromCsv';
 
@@ -90,18 +88,20 @@ export class TransitOdDemandFromCsv extends TransitDemandFromCsv<TransitOdDemand
         // TODO: add validations for all attributes fields
     }
 
-    updateRoutingPrefs() {
-        if (serviceLocator.socketEventManager) {
-            const exportedAttributes: TransitOdDemandFromCsvAttributes = _cloneDeep(this._attributes);
-            if (exportedAttributes.data && exportedAttributes.data.results) {
-                delete exportedAttributes.data.results;
-            }
-            exportedAttributes.csvFile = null;
-            Preferences.update(serviceLocator.socketEventManager, serviceLocator.eventManager, {
-                'transit.routing.batch': exportedAttributes
-            });
+    protected onCsvFileAttributesUpdated = (_csvFields: string[]): void => {
+        if (this.attributes.originXAttribute && !_csvFields.includes(this.attributes.originXAttribute)) {
+            this.attributes.originXAttribute = undefined;
         }
-    }
+        if (this.attributes.originYAttribute && !_csvFields.includes(this.attributes.originYAttribute)) {
+            this.attributes.originYAttribute = undefined;
+        }
+        if (this.attributes.destinationXAttribute && !_csvFields.includes(this.attributes.destinationXAttribute)) {
+            this.attributes.destinationXAttribute = undefined;
+        }
+        if (this.attributes.destinationYAttribute && !_csvFields.includes(this.attributes.destinationYAttribute)) {
+            this.attributes.destinationYAttribute = undefined;
+        }
+    };
 }
 
 export default TransitOdDemandFromCsv;

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -112,41 +112,14 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
         });
     };
 
-    onSubmitCsv = () => {
-        parseCsvFile(
-            this.state.object.get('csvFile'),
-            (data) => {
-                const csvAttributes = Object.keys(data);
-                const batchRouting = this.state.object;
-                if (
-                    batchRouting.attributes.idAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.idAttribute)
-                ) {
-                    batchRouting.attributes.idAttribute = undefined;
-                }
-                if (batchRouting.attributes.xAttribute && !csvAttributes.includes(batchRouting.attributes.xAttribute)) {
-                    batchRouting.attributes.xAttribute = undefined;
-                }
-                if (batchRouting.attributes.yAttribute && !csvAttributes.includes(batchRouting.attributes.yAttribute)) {
-                    batchRouting.attributes.yAttribute = undefined;
-                }
-                if (
-                    batchRouting.attributes.timeAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.timeAttribute)
-                ) {
-                    batchRouting.attributes.timeAttribute = undefined;
-                }
-
-                this.setState({
-                    object: batchRouting,
-                    csvAttributes
-                });
-            },
-            {
-                header: true,
-                nbRows: 1 // only get the header
-            }
-        );
+    onSubmitCsv = async () => {
+        if (this.state.object.attributes.csvFile !== undefined) {
+            const csvAttributes = await this.state.object.setCsvFile(this.state.object.attributes.csvFile);
+            this.setState({
+                object: this.state.object,
+                csvAttributes
+            });
+        }
     };
 
     onCalculationNameChange = (path: string, value: { value: any; valid?: boolean }) => {

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -124,59 +124,14 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
         });
     }
 
-    onSubmitCsv() {
-        parseCsvFile(
-            this.state.object.get('csvFile'),
-            (data) => {
-                const csvAttributes = Object.keys(data);
-                const batchRouting = this.state.object;
-                if (
-                    batchRouting.attributes.idAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.idAttribute)
-                ) {
-                    batchRouting.attributes.idAttribute = undefined;
-                }
-                if (
-                    batchRouting.attributes.originXAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.originXAttribute)
-                ) {
-                    batchRouting.attributes.originXAttribute = undefined;
-                }
-                if (
-                    batchRouting.attributes.originYAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.originYAttribute)
-                ) {
-                    batchRouting.attributes.originYAttribute = undefined;
-                }
-                if (
-                    batchRouting.attributes.destinationXAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.destinationXAttribute)
-                ) {
-                    batchRouting.attributes.destinationXAttribute = undefined;
-                }
-                if (
-                    batchRouting.attributes.destinationYAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.destinationYAttribute)
-                ) {
-                    batchRouting.attributes.destinationYAttribute = undefined;
-                }
-                if (
-                    batchRouting.attributes.timeAttribute &&
-                    !csvAttributes.includes(batchRouting.attributes.timeAttribute)
-                ) {
-                    batchRouting.attributes.timeAttribute = undefined;
-                }
-
-                this.setState({
-                    object: batchRouting,
-                    csvAttributes
-                });
-            },
-            {
-                header: true,
-                nbRows: 1 // only get the header
-            }
-        );
+    async onSubmitCsv() {
+        if (this.state.object.attributes.csvFile !== undefined) {
+            const csvAttributes = await this.state.object.setCsvFile(this.state.object.attributes.csvFile);
+            this.setState({
+                object: this.state.object,
+                csvAttributes
+            });
+        }
     }
 
     onCalculationNameChange(path: string, value: { value: any; valid?: boolean }) {
@@ -342,7 +297,7 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
                         <BatchSaveToDb
                             onValueChange={this.onValueChange}
                             attributes={batchRouting.attributes}
-                            defaultDataSourceName={batchRouting.attributes.csvFile.name || ''}
+                            defaultDataSourceName={(batchRouting.attributes.csvFile as File).name || ''}
                         />
                     )}
                     {

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/TransitRoutingBaseComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/TransitRoutingBaseComponent.tsx
@@ -16,7 +16,7 @@ import { secondsToMinutes, minutesToSeconds } from 'chaire-lib-common/lib/utils/
 export interface TransitRoutingBaseComponentProps extends WithTranslation {
     attributes: TransitRoutingBaseAttributes;
     disabled?: boolean;
-    onValueChange: (path: string, newValue: { value: any; valid?: boolean }) => void;
+    onValueChange: (path: keyof TransitRoutingBaseAttributes, newValue: { value: any; valid?: boolean }) => void;
 }
 
 const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseComponentProps> = (


### PR DESCRIPTION
The csvFile attribute can be a string or a File object. Also, setting
and parsing the file to make sure current attribute mapping is still
valid can be done in the common workspace, where it can be used by all
consumers, instead of in the forms.