### PR TITLE
Scenario Analysis: Move the batch routing feature to a Scenario analysis section

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -25,6 +25,8 @@
   "Delete": "Delete",
   "loading": "loading",
   "Loading": "Loading",
+  "Next": "Next",
+  "Previous": "Previous",
   "DiscardChanges": "Discard Changes",
   "ConfirmBackModal": "There are unsaved changes. Discard current changes and leave this section?",
   "UnsavedChanges": "There are unsaved changes on the current objects. Please save them before leaving this section.",

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -31,7 +31,7 @@
   "connectionIsOffline": "You are offline, please verify your connection.",
   "Routing": "Routing",
   "AccessibilityMap": "Accessibility map",
-  "OdRouting": "OD batch routing",
+  "BatchCalculation": "Batch calculations",
   "RestartTrRouting": "[Re]start routing engine",
   "SaveAllData": "Save all data for the routing engine",
   "PrepareData": "Prepare data",

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -931,6 +931,9 @@
         "New": "New calculation",
         "UploadFile": "Upload file",
         "DemandData": "Demand data",
-        "AnalysisParameters": "Parameters"
+        "AnalysisParameters": "Parameters",
+        "ConfigureDemand": "Configure demand data",
+        "ConfigureParameters": "Configure analysis parameters",
+        "AnalysisSummary": "Analysis summary"
     }
 }

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -926,6 +926,7 @@
     },
     "batchCalculation": {
         "List": "Calculation jobs",
-        "New": "New calculation"
+        "New": "New calculation",
+        "UploadFile": "Upload file"
     }
 }

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -923,5 +923,9 @@
                 "geojson": "GeoJSON"
             }
         }
+    },
+    "batchCalculation": {
+        "List": "Calculation jobs",
+        "New": "New calculation"
     }
 }

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -927,6 +927,8 @@
     "batchCalculation": {
         "List": "Calculation jobs",
         "New": "New calculation",
-        "UploadFile": "Upload file"
+        "UploadFile": "Upload file",
+        "DemandData": "Demand data",
+        "AnalysisParameters": "Parameters"
     }
 }

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -567,6 +567,8 @@
         },
         "NewDataSource": "New data source name",
         "OverwriteDataSource": "Data source to overwrite",
+        "BatchRoutingHasMoved": "The batch routing calculation has moved to the batch calculations section. This section is available through the left menu.",
+        "GoToBatchRouting": "Go to batch calculations section",
         "errors": {
             "RoutingModesIsEmpty": "Please select at least one routing mode.",
             "DepartureAndArrivalTimeAreBlank": "Departure or arrival time is required.",

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -25,6 +25,8 @@
   "Delete": "Supprimer",
   "loading": "chargement",
   "Loading": "Chargement",
+  "Next": "Suivant",
+  "Previous": "Précédent",
   "DiscardChanges": "Ignorer les changements",
   "ConfirmBackModal": "Il y a des changements non sauvegardés. Voulez-vous ignorer les changements et quitter cette section?",
   "UnsavedChanges": "Il y a des changements non sauvegardés. Veuillez les sauvegarder avant de quitter cette section.",

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -31,7 +31,7 @@
   "connectionIsOffline": "Vous êtes déconnectés, veuillez vérifier votre connexion.",
   "Routing": "Calcul de chemin",
   "AccessibilityMap": "Carte d'accessibilité",
-  "OdRouting": "Chargement OD",
+  "BatchCalculation": "Calculs multiples",
   "RestartTrRouting": "[Re]démarrer le calculateur de chemins",
   "SaveAllData": "Sauvegarder toutes les données pour le calculateur de chemin",
   "PrepareData": "Préparer les données",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -567,6 +567,8 @@
         },
         "NewDataSource": "Nouvelle source de données",
         "OverwriteDataSource": "Source de données à écraser",
+        "BatchRoutingHasMoved": "La fonctionnalité de calcul multiple se trouve maintenant dans la section \"Calculs multiples\". Cette section est disponible via le menu de gauche.",
+        "GoToBatchRouting": "Aller à la section \"Calculs multiples\"",
         "errors": {
             "RoutingModesIsEmpty": "Veuillez sélectionner au moins un mode pour le calcul de chemin.",
             "DepartureAndArrivalTimeAreBlank": "L'heure de départ ou d'arrivée est requise.",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -925,6 +925,8 @@
     "batchCalculation": {
         "List": "Tâches de calcul",
         "New": "Nouveau calcul",
-        "UploadFile": "Téléverser le fichier"
+        "UploadFile": "Téléverser le fichier",
+        "DemandData": "Données de la demande",
+        "AnalysisParameters": "Paramètres"
     }
 }

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -924,6 +924,7 @@
     },
     "batchCalculation": {
         "List": "Tâches de calcul",
-        "New": "Nouveau calcul"
+        "New": "Nouveau calcul",
+        "UploadFile": "Téléverser le fichier"
     }
 }

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -929,6 +929,9 @@
         "New": "Nouveau calcul",
         "UploadFile": "Téléverser le fichier",
         "DemandData": "Données de la demande",
-        "AnalysisParameters": "Paramètres"
+        "AnalysisParameters": "Paramètres",
+        "ConfigureDemand": "Configuration des données de la demande",
+        "ConfigureParameters": "Configuration des paramètres d'analyse",
+        "AnalysisSummary": "Sommaire de l'analyse"
     }
 }

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -921,5 +921,9 @@
                 "geojson": "GeoJSON"
             }
         }
+    },
+    "batchCalculation": {
+        "List": "Tâches de calcul",
+        "New": "Nouveau calcul"
     }
 }

--- a/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
+++ b/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
@@ -65,8 +65,8 @@ const defaultPreferences: PreferencesModel = {
                 icon: '/dist/images/icons/interface/accessibility_map_white.svg',
                 hasMapLayers: true
             },
-            odRouting: {
-                localizedTitle: 'main:OdRouting',
+            batchCalculation: {
+                localizedTitle: 'main:BatchCalculation',
                 icon: '/dist/images/icons/interface/od_routing_white.svg',
                 hasMapLayers: true
             },

--- a/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
@@ -44,10 +44,6 @@ export abstract class TransitDemandFromCsv<T extends TransitDemandFromCsvAttribu
         this.errors = [];
         const attributes = this.getAttributes();
         if (attributes.csvFile) {
-            if (_isBlank(attributes.calculationName)) {
-                this._isValid = false;
-                this.errors.push('transit:transitRouting:errors:CalculationNameIsMissing');
-            }
             if (_isBlank(attributes.idAttribute)) {
                 this._isValid = false;
                 this.errors.push('transit:transitRouting:errors:IdAttributeIsMissing');

--- a/packages/transition-frontend/src/app-transition.tsx
+++ b/packages/transition-frontend/src/app-transition.tsx
@@ -22,6 +22,7 @@ import {
     SupplyManagementDashboardContribution,
     DemandManagementDashboardContribution
 } from './components/dashboard/TransitionDashboardContribution';
+import { SupplyDemandAnalysisDashboardContribution } from './components/dashboard/supplyDemandAnalysisModule/SupplyDemandAnalysisDashboardContribution';
 import { setApplicationConfiguration } from 'chaire-lib-frontend/lib/config/application.config';
 
 import 'chaire-lib-frontend/lib/styles/styles-transition.scss';
@@ -34,7 +35,11 @@ setApplicationConfiguration({ homePage: '/dashboard' });
 config.appTitle = 'Transition';
 
 const store = configureStore();
-const contributions = [new SupplyManagementDashboardContribution(), new DemandManagementDashboardContribution()];
+const contributions = [
+    new SupplyManagementDashboardContribution(),
+    new DemandManagementDashboardContribution(),
+    new SupplyDemandAnalysisDashboardContribution()
+];
 const jsx = (
     <Provider store={store}>
         <I18nextProvider i18n={i18n}>

--- a/packages/transition-frontend/src/components/dashboard/supplyDemandAnalysisModule/SupplyDemandAnalysisDashboardContribution.tsx
+++ b/packages/transition-frontend/src/components/dashboard/supplyDemandAnalysisModule/SupplyDemandAnalysisDashboardContribution.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+
+import {
+    DashboardContribution,
+    Contribution,
+    LayoutSectionProps
+} from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
+import BatchCalculationPanel from '../../forms/batchCalculation/BatchCalculationPanel';
+
+/**
+ * Dashboard contribution for the 'supply/demand interaction analysis and
+ * modelisation' module of Transition: batch analysis of routing and accessibility, etc.
+ */
+export class SupplyDemandAnalysisDashboardContribution extends DashboardContribution {
+    getLayoutContributions = (): Contribution<LayoutSectionProps>[] => [
+        {
+            id: 'scenarioAnalysisRightPanel',
+            placement: 'primarySidebar' as const,
+            section: 'batchCalculation',
+            create: (props: any) => <BatchCalculationPanel {...props}></BatchCalculationPanel>
+        }
+    ];
+}

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+
+export interface ScenarioAnalysisFormProps {
+    availableRoutingModes?: string[];
+    onEnd: () => void;
+}
+/**
+ * Scenario Analysis form, to configure what to analyse:
+ *
+ * step 1: Select a demand and upload file if necessary
+ *
+ * step 2: Select analysis parameters
+ *
+ * step 3: Confirm and run analysis
+ *
+ * @param {(ScenarioAnalysisFormProps & WithTranslation)} props
+ * @return {*}
+ */
+const ScenarioAnalysisForm: React.FunctionComponent<ScenarioAnalysisFormProps & WithTranslation> = (
+    props: ScenarioAnalysisFormProps & WithTranslation
+) => {
+    return (
+        <React.Fragment>
+            {props.t('transit:batchCalculation:New')}
+            <div className="tr__form-buttons-container">
+                <span title={props.t('main:Cancel')}>
+                    <Button key="back" color="grey" label={props.t('main:Cancel')} onClick={props.onEnd} />
+                </span>
+            </div>
+        </React.Fragment>
+    );
+};
+
+export default withTranslation(['transit', 'main'])(ScenarioAnalysisForm);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -16,13 +16,14 @@ import { TransitDemandFromCsvFile } from '../../../services/transitDemand/types'
 import ConfigureBatchCalculationForm from './stepForms/ConfigureBatchCalculationForm';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { BatchCalculationParameters } from '../../../services/batchCalculation/types';
+import ConfirmScenarioAnalysiForm from './stepForms/ConfirmCalculationForm';
 
 export interface BatchCalculationFormProps {
     availableRoutingModes?: string[];
     onEnd: () => void;
 }
 
-const stepCount = 3;
+const stepCount = 4;
 /**
  * Scenario Analysis form, to configure what to analyse:
  *
@@ -108,6 +109,14 @@ const BatchCalculationForm: React.FunctionComponent<BatchCalculationFormProps & 
             {currentStep === 1 && (
                 <ConfigureBatchCalculationForm
                     availableRoutingModes={props.availableRoutingModes}
+                    routingParameters={routingParameters}
+                    onUpdate={onParametersUpdate}
+                    scenarioCollection={scenarioCollection}
+                />
+            )}
+            {currentStep === 2 && (
+                <ConfirmScenarioAnalysiForm
+                    currentDemand={demand as TransitDemandFromCsvFile}
                     routingParameters={routingParameters}
                     onUpdate={onParametersUpdate}
                     scenarioCollection={scenarioCollection}

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -108,27 +108,36 @@ const BatchCalculationForm: React.FunctionComponent<BatchCalculationFormProps & 
                 {props.t('transit:batchCalculation:New')}
             </h3>
             {currentStep === 0 && (
-                <ConfigureDemandFromCsvForm
-                    currentDemand={demand}
-                    onComplete={onDemandStepComplete}
-                    onFileReset={onFileReset}
-                />
+                <React.Fragment>
+                    <h4>{props.t('transit:scenarioAnalysis:ConfigureDemand')}</h4>
+                    <ConfigureDemandFromCsvForm
+                        currentDemand={demand}
+                        onComplete={onDemandStepComplete}
+                        onFileReset={onFileReset}
+                    />
+                </React.Fragment>
             )}
             {currentStep === 1 && (
-                <ConfigureBatchCalculationForm
-                    availableRoutingModes={props.availableRoutingModes}
-                    routingParameters={routingParameters}
-                    onUpdate={onParametersUpdate}
-                    scenarioCollection={scenarioCollection}
-                />
+                <React.Fragment>
+                    <h4>{props.t('transit:batchCalculation:ConfigureParameters')}</h4>
+                    <ConfigureBatchCalculationForm
+                        availableRoutingModes={props.availableRoutingModes}
+                        routingParameters={routingParameters}
+                        onUpdate={onParametersUpdate}
+                        scenarioCollection={scenarioCollection}
+                    />
+                </React.Fragment>
             )}
             {currentStep === 2 && (
-                <ConfirmCalculationForm
-                    currentDemand={demand as TransitDemandFromCsvFile}
-                    routingParameters={routingParameters}
-                    onUpdate={onParametersUpdate}
-                    scenarioCollection={scenarioCollection}
-                />
+                <React.Fragment>
+                    <h4>{props.t('transit:batchCalculation:AnalysisSummary')}</h4>
+                    <ConfirmCalculationForm
+                        currentDemand={demand as TransitDemandFromCsvFile}
+                        routingParameters={routingParameters}
+                        onUpdate={onParametersUpdate}
+                        scenarioCollection={scenarioCollection}
+                    />
+                </React.Fragment>
             )}
             {
                 // TODO The below buttons should be handled by the steps themselves, with proper validations on click. It's ackward for the individual form workflow to have them in the parent form.

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -16,7 +16,8 @@ import { TransitDemandFromCsvFile } from '../../../services/transitDemand/types'
 import ConfigureBatchCalculationForm from './stepForms/ConfigureBatchCalculationForm';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { BatchCalculationParameters } from '../../../services/batchCalculation/types';
-import ConfirmScenarioAnalysiForm from './stepForms/ConfirmCalculationForm';
+import ConfirmCalculationForm from './stepForms/ConfirmCalculationForm';
+import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
 
 export interface BatchCalculationFormProps {
     availableRoutingModes?: string[];
@@ -70,6 +71,13 @@ const BatchCalculationForm: React.FunctionComponent<BatchCalculationFormProps & 
     };
 
     const incrementStep = () => {
+        if (currentStep === stepCount - 2) {
+            if (demand !== undefined) {
+                // TODO Don't just return, wait for the return value to make sure the calculation is running
+                TransitBatchRoutingCalculator.calculate(demand.demand, routingParameters);
+                props.onEnd();
+            }
+        }
         setCurrentStep(currentStep + 1);
     };
 
@@ -115,13 +123,16 @@ const BatchCalculationForm: React.FunctionComponent<BatchCalculationFormProps & 
                 />
             )}
             {currentStep === 2 && (
-                <ConfirmScenarioAnalysiForm
+                <ConfirmCalculationForm
                     currentDemand={demand as TransitDemandFromCsvFile}
                     routingParameters={routingParameters}
                     onUpdate={onParametersUpdate}
                     scenarioCollection={scenarioCollection}
                 />
             )}
+            {
+                // TODO The below buttons should be handled by the steps themselves, with proper validations on click. It's ackward for the individual form workflow to have them in the parent form.
+            }
             <div className="tr__form-buttons-container">
                 <span title={props.t('main:Cancel')}>
                     <Button key="back" color="grey" label={props.t('main:Cancel')} onClick={props.onEnd} />
@@ -137,7 +148,7 @@ const BatchCalculationForm: React.FunctionComponent<BatchCalculationFormProps & 
                             disabled={!nextEnabled}
                             key="next"
                             color="green"
-                            label={props.t('main:Next')}
+                            label={props.t(`main:${currentStep === stepCount - 2 ? 'Calculate' : 'Next'}`)}
                             onClick={incrementStep}
                         />
                     </span>

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import _get from 'lodash.get';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+
+import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
+
+interface BatchCalculationListProps extends WithTranslation {
+    onNewAnalysis: () => void;
+}
+
+const BatchCalculationList: React.FunctionComponent<BatchCalculationListProps> = (props: BatchCalculationListProps) => {
+    return (
+        <div className="tr__list-simulations-container">
+            <h3>
+                <img
+                    src={'/dist/images/icons/interface/od_routing_white.svg'}
+                    className="_icon"
+                    alt={props.t('transit:batchCalculation:List')}
+                />{' '}
+                {props.t('transit:batchCalculation:List')}
+            </h3>
+            <div className="tr__form-buttons-container">
+                <Button
+                    color="blue"
+                    icon={faPlus}
+                    iconClass="_icon"
+                    label={props.t('transit:batchCalculation:New')}
+                    onClick={props.onNewAnalysis}
+                />
+            </div>
+            <ExecutableJobComponent defaultPageSize={10} jobType="batchRoute" />
+        </div>
+    );
+};
+
+export default withTranslation(['transit', 'main', 'form', 'notifications'])(BatchCalculationList);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -41,6 +41,7 @@ const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & Wit
             {isNewAnalysis && (
                 <BatchCalculationForm
                     availableRoutingModes={props.availableRoutingModes}
+                    // TODO This function should receive some parameter, whether it is cancelled or a calculation is pending.
                     onEnd={() => setIsNewAnalysis(false)}
                 />
             )}

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -30,7 +30,7 @@ const CalculationPanel: React.FunctionComponent<WithTranslation> = (props: WithT
     }, []);
 
     return (
-        <div id="tr__form-transit-simulations-panel" className="tr__form-transit-simulations-panel tr__panel">
+        <div id="tr__form-transit-calculation-panel" className="tr__form-transit-calculation-panel tr__panel">
             {isNewAnalysis === false && <BatchCalculationList onNewAnalysis={() => setIsNewAnalysis(true)} />}
             {isNewAnalysis && <BatchCalculationForm onEnd={() => setIsNewAnalysis(false)} />}
         </div>

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import BatchCalculationList from './BatchCalculationList';
+import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
+import BatchCalculationForm from './BatchCalculationForm';
+
+const CalculationPanel: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => {
+    const [scenarioCollection, setScenarioCollection] = React.useState<ScenarioCollection | undefined>(
+        serviceLocator.collectionManager.get('scenarios')
+    );
+    const [isNewAnalysis, setIsNewAnalysis] = React.useState(false);
+
+    const onScenarioCollectionUpdate = () => {
+        setScenarioCollection(serviceLocator.collectionManager.get('scenarios'));
+    };
+
+    React.useEffect(() => {
+        serviceLocator.eventManager.on('collection.update.scenarios', onScenarioCollectionUpdate);
+        return () => {
+            serviceLocator.eventManager.off('collection.update.scenarios', onScenarioCollectionUpdate);
+        };
+    }, []);
+
+    return (
+        <div id="tr__form-transit-simulations-panel" className="tr__form-transit-simulations-panel tr__panel">
+            {isNewAnalysis === false && <BatchCalculationList onNewAnalysis={() => setIsNewAnalysis(true)} />}
+            {isNewAnalysis && <BatchCalculationForm onEnd={() => setIsNewAnalysis(false)} />}
+        </div>
+    );
+};
+
+export default withTranslation(['transit', 'main', 'form'])(CalculationPanel);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -12,7 +12,13 @@ import BatchCalculationList from './BatchCalculationList';
 import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import BatchCalculationForm from './BatchCalculationForm';
 
-const CalculationPanel: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => {
+export interface CalculationPanelPanelProps {
+    availableRoutingModes?: string[];
+}
+
+const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & WithTranslation> = (
+    props: CalculationPanelPanelProps & WithTranslation
+) => {
     const [scenarioCollection, setScenarioCollection] = React.useState<ScenarioCollection | undefined>(
         serviceLocator.collectionManager.get('scenarios')
     );
@@ -32,7 +38,12 @@ const CalculationPanel: React.FunctionComponent<WithTranslation> = (props: WithT
     return (
         <div id="tr__form-transit-calculation-panel" className="tr__form-transit-calculation-panel tr__panel">
             {isNewAnalysis === false && <BatchCalculationList onNewAnalysis={() => setIsNewAnalysis(true)} />}
-            {isNewAnalysis && <BatchCalculationForm onEnd={() => setIsNewAnalysis(false)} />}
+            {isNewAnalysis && (
+                <BatchCalculationForm
+                    availableRoutingModes={props.availableRoutingModes}
+                    onEnd={() => setIsNewAnalysis(false)}
+                />
+            )}
         </div>
     );
 };

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import _cloneDeep from 'lodash.clonedeep';
+
+import { _toBool } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
+import InputMultiselect from 'chaire-lib-frontend/lib/components/input/InputMultiselect';
+import { isBatchParametersValid, BatchCalculationParameters } from '../../../../services/batchCalculation/types';
+import TransitRoutingBaseComponent from '../../transitRouting/widgets/TransitRoutingBaseComponent';
+import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
+import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
+import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
+
+export interface ConfigureCalculationParametersFormProps {
+    routingParameters: BatchCalculationParameters;
+    availableRoutingModes?: string[];
+    scenarioCollection: ScenarioCollection;
+    onUpdate: (routingParameters: BatchCalculationParameters, isValid: boolean) => void;
+}
+/**
+ * Configure the scenario parameters
+ *
+ * @param {(ConfigureCalculationParametersFormProps  &
+ * WithTranslation)} props
+ * @return {*}
+ */
+const ConfigureCalculationParametersForm: React.FunctionComponent<
+    ConfigureCalculationParametersFormProps & WithTranslation
+> = (props: ConfigureCalculationParametersFormProps & WithTranslation) => {
+    const [updateCnt, setUpdateCnt] = React.useState(0);
+    const [errors, setErrors] = React.useState<string[]>([]);
+
+    React.useEffect(() => {
+        // validate the data on first load
+        const { valid } = isBatchParametersValid(props.routingParameters);
+        props.onUpdate(props.routingParameters, valid);
+    }, []);
+
+    const onValueChange = (path: keyof BatchCalculationParameters, newValue: { value: any; valid?: boolean }): void => {
+        props.routingParameters[path] = newValue.value as never;
+        const { valid, errors } = isBatchParametersValid(props.routingParameters);
+        props.onUpdate(props.routingParameters, valid);
+        setErrors(errors);
+        setUpdateCnt(updateCnt + 1);
+    };
+
+    const routingModeChoices = React.useMemo(() => {
+        const routingModes = _cloneDeep(props.availableRoutingModes || []);
+        routingModes.push('transit');
+        return routingModes.map((routingMode) => {
+            return {
+                value: routingMode
+            };
+        });
+    }, [props.availableRoutingModes]);
+
+    const scenarios = React.useMemo(
+        () =>
+            props.scenarioCollection.features.map((scenario) => ({
+                value: scenario.id,
+                label: scenario.toString(false)
+            })),
+        [props.scenarioCollection]
+    );
+
+    return (
+        <div className="tr__form-section">
+            {routingModeChoices.length > 0 && (
+                <InputWrapper twoColumns={false} label={props.t('transit:transitRouting:RoutingModes')}>
+                    <InputMultiselect
+                        choices={routingModeChoices}
+                        t={props.t}
+                        id={'formFieldScenarioParametersRoutingModes'}
+                        value={props.routingParameters.routingModes}
+                        localePrefix="transit:transitPath:routingModes"
+                        onValueChange={(e) => onValueChange('routingModes', { value: e.target.value })}
+                    />
+                </InputWrapper>
+            )}
+            {props.routingParameters.routingModes.includes('transit') && (
+                <React.Fragment>
+                    <TransitRoutingBaseComponent onValueChange={onValueChange} attributes={props.routingParameters} />
+
+                    <InputWrapper label={props.t('transit:transitRouting:Scenario')}>
+                        <InputSelect
+                            id={'formFieldScenarioParametersScenario'}
+                            value={props.routingParameters.scenarioId}
+                            choices={scenarios}
+                            t={props.t}
+                            onValueChange={(e) => onValueChange('scenarioId', { value: e.target.value })}
+                        />
+                    </InputWrapper>
+                    <InputWrapper label={props.t('transit:transitRouting:WithAlternatives')}>
+                        <InputRadio
+                            id={'formFieldScenarioParametersWithAlternatives'}
+                            value={props.routingParameters.withAlternatives}
+                            sameLine={true}
+                            disabled={false}
+                            choices={[
+                                {
+                                    value: true
+                                },
+                                {
+                                    value: false
+                                }
+                            ]}
+                            localePrefix="transit:transitRouting"
+                            t={props.t}
+                            isBoolean={true}
+                            onValueChange={(e) => onValueChange('withAlternatives', { value: _toBool(e.target.value) })}
+                        />
+                    </InputWrapper>
+                </React.Fragment>
+            )}
+            {errors.length > 0 && <FormErrors errors={errors} />}
+        </div>
+    );
+};
+
+export default withTranslation(['transit', 'main'])(ConfigureCalculationParametersForm);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureDemandFromCsvForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureDemandFromCsvForm.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import _cloneDeep from 'lodash.clonedeep';
+import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload';
+
+import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
+import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
+import InputFile from 'chaire-lib-frontend/lib/components/input/InputFile';
+import TransitOdDemandFromCsv, {
+    TransitOdDemandFromCsvAttributes
+} from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import BatchAttributesSelection from '../../transitRouting/widgets/BatchAttributesSelection';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+import { TransitDemandFromCsvFile } from '../../../../services/transitDemand/types';
+import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
+
+interface ConfigureDemandFromCsvFormProps {
+    currentDemand?: TransitDemandFromCsvFile;
+    onComplete: (demand: TransitDemandFromCsvFile) => void;
+    onFileReset: () => void;
+}
+/**
+ * Select a CSV file, map fields to required parameters, then upload file to
+ * server
+ *
+ * @param {(ConfigureDemandFromCsvFormProps & FileUploaderHOCProps &
+ * WithTranslation)} props
+ * @return {*}
+ */
+const ConfigureDemandFromCsvForm: React.FunctionComponent<
+    ConfigureDemandFromCsvFormProps & FileUploaderHOCProps & WithTranslation
+> = (props: ConfigureDemandFromCsvFormProps & FileUploaderHOCProps & WithTranslation) => {
+    const [demand] = React.useState(
+        props.currentDemand?.demand ||
+            new TransitOdDemandFromCsv(
+                Object.assign(_cloneDeep(Preferences.get('transit.routing.batch')), { saveToDb: false }),
+                false
+            )
+    );
+    const [csvFileAttributes, setCsvFileAttributes] = React.useState<string[]>(props.currentDemand?.csvFields || []);
+    const [loading, setLoading] = React.useState(false);
+    const [updateCnt, setUpdateCnt] = React.useState(0);
+    const [ready, setReady] = React.useState(false);
+
+    const onCsvFileChange = async (file) => {
+        setLoading(true);
+        try {
+            setCsvFileAttributes(await demand.setCsvFile(file));
+            setReady(demand.validate());
+            props.onFileReset();
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const onValueChange = (
+        path: keyof TransitOdDemandFromCsvAttributes,
+        newValue: { value: unknown; valid?: boolean }
+    ): void => {
+        demand.attributes[path] = newValue.value as never;
+        setReady(demand.validate());
+        setUpdateCnt(updateCnt + 1);
+    };
+
+    const onUpload = () => {
+        // upload csv file to server:
+        props.fileUploader.upload(props.fileImportRef.current, {
+            uploadTo: 'imports',
+            data: {
+                objects: 'csv',
+                filename: 'batchRouting.csv'
+            }
+        });
+
+        demand.updateRoutingPrefs();
+    };
+
+    React.useEffect(() => {
+        if (props.uploadStatus.status === 'completed') {
+            props.onComplete({ type: 'csv', demand, csvFields: csvFileAttributes });
+        }
+    }, [props.uploadStatus.status]);
+
+    return (
+        <div className="tr__form-section">
+            <InputWrapper twoColumns={true} label={props.t('main:CsvFile')}>
+                <InputFile
+                    id={'formFieldTransitDemandCsvFile'}
+                    accept={'.csv'}
+                    inputRef={props.fileImportRef}
+                    onChange={(e) => {
+                        const files = e.target.files;
+                        if (files && files.length > 0) onCsvFileChange(files[0]);
+                    }}
+                />
+            </InputWrapper>
+            {loading && <LoadingPage />}
+            {!loading && csvFileAttributes.length !== 0 && (
+                <BatchAttributesSelection
+                    onValueChange={onValueChange}
+                    attributes={demand.attributes}
+                    csvAttributes={csvFileAttributes}
+                />
+            )}
+            {csvFileAttributes.length !== 0 && (
+                <React.Fragment>
+                    <FormErrors errors={demand.getErrors()} />
+                    {ready && (
+                        <div className="tr__form-buttons-container">
+                            <span title={props.t('transit:batchCalculation:UploadFile')}>
+                                <Button
+                                    disabled={!ready}
+                                    key="next"
+                                    color="blue"
+                                    label={props.t('transit:batchCalculation:UploadFile')}
+                                    icon={faUpload}
+                                    iconClass="_icon-alone"
+                                    onClick={onUpload}
+                                />
+                            </span>
+                        </div>
+                    )}
+                </React.Fragment>
+            )}
+        </div>
+    );
+};
+
+export default FileUploaderHOC(withTranslation(['transit', 'main'])(ConfigureDemandFromCsvForm), undefined, false);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureDemandFromCsvForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureDemandFromCsvForm.tsx
@@ -50,10 +50,10 @@ const ConfigureDemandFromCsvForm: React.FunctionComponent<
     const [updateCnt, setUpdateCnt] = React.useState(0);
     const [ready, setReady] = React.useState(false);
 
-    const onCsvFileChange = async (file) => {
+    const onCsvFileChange = async (file: File) => {
         setLoading(true);
         try {
-            setCsvFileAttributes(await demand.setCsvFile(file));
+            setCsvFileAttributes(await demand.setCsvFile(file as any));
             setReady(demand.validate());
             props.onFileReset();
         } finally {

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import _toString from 'lodash.tostring';
+import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
+import { secondsToMinutes } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+
+import { BatchCalculationParameters } from '../../../../services/batchCalculation/types';
+import { TransitDemandFromCsvFile } from '../../../../services/transitDemand/types';
+
+export interface ConfirmCalculationFormProps {
+    currentDemand: TransitDemandFromCsvFile;
+    routingParameters: BatchCalculationParameters;
+    scenarioCollection: ScenarioCollection;
+    onUpdate: (routingParameters: BatchCalculationParameters, isValid: boolean) => void;
+}
+/**
+ * Confirm the demand and scenario parameters before running the calculations
+ *
+ * @param {(ConfirmCalculationFormProps  & WithTranslation)} props
+ * @return {*}
+ */
+const ConfirmCalculationForm: React.FunctionComponent<ConfirmCalculationFormProps & WithTranslation> = (
+    props: ConfirmCalculationFormProps & WithTranslation
+) => {
+    const demandAttributes = props.currentDemand.demand.attributes;
+    return (
+        <div className="tr__form-section">
+            <table className="_statistics" key="confirmScenarioAnalysisProperties">
+                <tbody>
+                    <tr>
+                        <th className="_header" colSpan={2}>
+                            {props.t('transit:batchCalculation:DemandData')}
+                        </th>
+                    </tr>
+                    <tr>
+                        <th>{props.t('main:CsvFile')}</th>
+                        <td>{(demandAttributes.csvFile as File).name}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:Detailed')}</th>
+                        <td>{props.t(`transit:transitRouting:${demandAttributes.detailed || false}`)}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:WithGeometries')}</th>
+                        <td>{props.t(`transit:transitRouting:${demandAttributes.withGeometries || false}`)}</td>
+                    </tr>
+                    <tr>
+                        <th className="_header" colSpan={2}>
+                            {props.t('transit:batchCalculation:AnalysisParameters')}
+                        </th>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:RoutingModes')}</th>
+                        <td>
+                            {props.routingParameters.routingModes
+                                .map((mode) => props.t(`transit:transitPath:routingModes:${mode}`))
+                                .join(',')}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:Scenario')}</th>
+                        <td>
+                            {props.scenarioCollection.getById(props.routingParameters.scenarioId as string)?.toString()}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:MaximumTotalTravelTimeMinutes')}</th>
+                        <td>{_toString(secondsToMinutes(props.routingParameters.maxTotalTravelTimeSeconds))}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:MinimumWaitingTimeMinutes')}</th>
+                        <td>{_toString(secondsToMinutes(props.routingParameters.minWaitingTimeSeconds))}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:MaximumAccessEgressTravelTimeMinutes')}</th>
+                        <td>{_toString(secondsToMinutes(props.routingParameters.maxAccessEgressTravelTimeSeconds))}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:MaximumTransferTravelTimeMinutes')}</th>
+                        <td>{_toString(secondsToMinutes(props.routingParameters.maxTransferTravelTimeSeconds))}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:MaximumFirstWaitingTimeMinutes')}</th>
+                        <td>{_toString(secondsToMinutes(props.routingParameters.maxFirstWaitingTimeSeconds))}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:WithAlternatives')}</th>
+                        <td>{props.t(`transit:transitRouting:${props.routingParameters.withAlternatives}`)}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default withTranslation(['transit', 'main'])(ConfirmCalculationForm);

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -7,64 +7,25 @@
 import React from 'react';
 import Collapsible from 'react-collapsible';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import Loader from 'react-spinners/BeatLoader';
 
-import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload';
-import _get from 'lodash.get';
 import _cloneDeep from 'lodash.clonedeep';
-import _toString from 'lodash.tostring';
-import { parseCsvFile } from 'chaire-lib-common/lib/utils/files/CsvFile';
 
-import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
-import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
-import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
-import InputFile from 'chaire-lib-frontend/lib/components/input/InputFile';
-import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
-import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import TransitRouting from 'transition-common/lib/services/transitRouting/TransitRouting';
 import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
-import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
-import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
-// ** File upload
-import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
-import { _toInteger, _toBool, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import BatchAttributesSelection from './widgets/BatchAttributesSelection';
-import BatchSaveToDb from './widgets/BatchSaveToDb';
-import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
 
-export interface TransitBatchRoutingFormProps extends FileUploaderHOCProps {
+export interface TransitBatchRoutingFormProps {
     routingEngine: TransitRouting;
     isRoutingEngineValid?: () => boolean;
 }
 
-interface TransitBatchRoutingFormState extends ChangeEventsState<TransitOdDemandFromCsv> {
-    scenarioCollection: any;
-    cacheCsvAttributes: any;
-    csvUploadedToServer: boolean;
-    csvAttributes?: string[];
-    csvContent: null;
-    geojsonDownloadUrl: any;
-    jsonDownloadUrl: any;
-    csvDownloadUrl: any;
-    batchRoutingInProgress: boolean;
-    errors: ErrorMessage[];
-    warnings: ErrorMessage[];
-    // array of trRouting raw results
-    detailedResult: any;
-}
-
-// TODO tahini type this class
 class TransitRoutingBatchForm extends ChangeEventsForm<
     TransitBatchRoutingFormProps & WithTranslation,
-    TransitBatchRoutingFormState
+    ChangeEventsState<TransitOdDemandFromCsv>
 > {
-    private fileReader: any;
-
     constructor(props: TransitBatchRoutingFormProps & WithTranslation) {
         super(props);
 
@@ -75,128 +36,11 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
 
         this.state = {
             object: batchRoutingEngine,
-            formValues: {},
-            scenarioCollection: serviceLocator.collectionManager.get('scenarios'),
-            cacheCsvAttributes: _cloneDeep(Preferences.get('transit.routing.batch')),
-            csvUploadedToServer: false,
-            csvContent: null,
-            geojsonDownloadUrl: null,
-            jsonDownloadUrl: null,
-            csvDownloadUrl: null,
-            batchRoutingInProgress: false,
-            errors: [],
-            warnings: [],
-            detailedResult: []
+            formValues: {}
         };
-
-        this.onCalculationNameChange = this.onCalculationNameChange.bind(this);
-
-        this.onSubmitCsv = this.onSubmitCsv.bind(this);
-        this.onCsvFileChange = this.onCsvFileChange.bind(this);
-        this.onUploadCsv = this.onUploadCsv.bind(this);
-        this.onCalculateBatch = this.onCalculateBatch.bind(this);
-
-        // ** File upload
-        if (!serviceLocator.hasService('fileReader')) {
-            serviceLocator.addService('fileReader', new FileReader());
-        }
-        this.fileReader = serviceLocator.fileReader;
     }
 
-    onCsvFileChange(file) {
-        // ** File upload
-
-        const batchRouting = this.state.object;
-
-        batchRouting.attributes.csvFile = file;
-
-        this.state.object.validate();
-
-        this.setState({
-            object: batchRouting,
-            csvAttributes: undefined,
-            geojsonDownloadUrl: null,
-            jsonDownloadUrl: null,
-            csvDownloadUrl: null,
-            csvUploadedToServer: false,
-            errors: [],
-            warnings: []
-        });
-    }
-
-    async onSubmitCsv() {
-        if (this.state.object.attributes.csvFile !== undefined) {
-            const csvAttributes = await this.state.object.setCsvFile(this.state.object.attributes.csvFile);
-            this.setState({
-                object: this.state.object,
-                csvAttributes
-            });
-        }
-    }
-
-    onCalculationNameChange(path: string, value: { value: any; valid?: boolean }) {
-        this.onValueChange(path, value);
-    }
-
-    onUploadCsv() {
-        // ** File upload
-
-        // upload csv file to server:
-        const uploadIds = this.props.fileUploader.upload(this.props.fileImportRef.current, {
-            uploadTo: 'imports',
-            data: {
-                objects: 'csv',
-                filename: 'batchRouting.csv'
-            }
-        });
-
-        this.state.object.updateRoutingPrefs();
-
-        this.setState((oldState) => {
-            return {
-                csvUploadedToServer: true
-            };
-        });
-    }
-
-    async onCalculateBatch() {
-        if (this.props.isRoutingEngineValid !== undefined && !this.props.isRoutingEngineValid()) {
-            this.setState({ errors: ['transit:transitRouting:errors:RoutingParametersInvalidForBatch'] });
-            return;
-        }
-        this.setState({
-            batchRoutingInProgress: true,
-            errors: [],
-            warnings: []
-        });
-        const attributes = this.state.object.attributes;
-        try {
-            const routingResult: any = await TransitBatchRoutingCalculator.calculate(
-                this.state.object,
-                this.props.routingEngine.getAttributes()
-            );
-            this.setState({
-                batchRoutingInProgress: false,
-                detailedResult: routingResult.results,
-                errors: routingResult.errors,
-                warnings: routingResult.warnings
-            });
-            if (attributes.saveToDb !== false && attributes.saveToDb.type === 'new') {
-                await serviceLocator.collectionManager
-                    .get('dataSources')
-                    .loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager);
-                serviceLocator.collectionManager.refresh('dataSources');
-            }
-        } catch (error) {
-            this.setState({
-                batchRoutingInProgress: false,
-                detailedResult: [],
-                errors: [TrError.isTrError(error) ? error.export().localizedMessage : String(error)],
-                warnings: []
-            });
-        }
-    }
-
+    // FIXME Keep the max parallel calculator code for now, until it is completely migrated in the new scenario analysis
     private setMaxParallelCalculators(max: number) {
         const batchRoutingEngine = this.state.object;
         batchRoutingEngine.attributes.maxCpuCount = max;
@@ -214,150 +58,23 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
     }
 
     render() {
-        if (!this.state.scenarioCollection) {
-            return <LoadingPage />;
-        }
-
-        const batchRouting = this.state.object;
-        const batchRoutingId = batchRouting.getId();
-
-        const hasAllAttributesSet =
-            !_isBlank(batchRouting.attributes.idAttribute) &&
-            !_isBlank(batchRouting.attributes.originXAttribute) &&
-            !_isBlank(batchRouting.attributes.originYAttribute) &&
-            !_isBlank(batchRouting.attributes.destinationXAttribute) &&
-            !_isBlank(batchRouting.attributes.destinationYAttribute) &&
-            !_isBlank(batchRouting.attributes.timeAttribute) &&
-            !_isBlank(batchRouting.attributes.timeFormat) &&
-            !_isBlank(batchRouting.attributes.timeAttributeDepartureOrArrival);
-
-        const errors = this.state.errors;
-        const warnings = this.state.warnings;
-
+        // TODO This feature has moved in february 2023. Keep this message for a
+        // few months, just so users get a warning if they are used to coming
+        // here for batch calculation
         return (
             <Collapsible trigger={this.props.t('transit:transitRouting:BatchRoutingCsv')} transitionTime={100}>
                 <div className="tr__form-section">
-                    {
-                        /* not yet implemented */ false && this.state.csvAttributes && (
-                            <div className="apptr__form-input-container _two-columns _small-inputs">
-                                <label>{this.props.t('transit:transitRouting:WithGeometry')}</label>
-                                <InputRadio
-                                    id={`formFieldTransitBatchRoutingWithGeometry${batchRoutingId}`}
-                                    value={batchRouting.attributes.withGeometries}
-                                    sameLine={true}
-                                    choices={[
-                                        {
-                                            value: true
-                                        },
-                                        {
-                                            value: false
-                                        }
-                                    ]}
-                                    localePrefix="transit:transitRouting:withGeometryChoices"
-                                    t={this.props.t}
-                                    isBoolean={true}
-                                    onValueChange={(e) =>
-                                        this.onValueChange('withGeometries', { value: _toBool(e.target.value) })
-                                    }
-                                />
-                            </div>
-                        )
-                    }
+                    <label>{this.props.t('transit:transitRouting:BatchRoutingHasMoved')}</label>
+                    <Button
+                        color="blue"
+                        iconClass="_icon small"
+                        label={this.props.t('transit:transitRouting:GoToBatchRouting')}
+                        onClick={() => {
+                            // notifications are handled inside saveAndUpdateAll function:
+                            serviceLocator.eventManager.emit('section.change', 'batchCalculation', false);
+                        }}
+                    />
                 </div>
-                <div className="tr__form-section">
-                    <div className="apptr__form-input-container _two-columns">
-                        <label>{this.props.t('transit:transitRouting:CalculationName')}</label>
-                        <InputString
-                            id={`formFieldTransitBatchRoutingCalculationName${batchRoutingId}`}
-                            value={batchRouting.attributes.calculationName}
-                            onValueUpdated={(newValue) => this.onCalculationNameChange('calculationName', newValue)}
-                        />
-                    </div>
-                    <div className="apptr__form-input-container _two-columns">
-                        <label>{this.props.t('main:CsvFile')}</label>
-                        <InputFile
-                            id={`formFieldTransitBatchRoutingCsvFile${batchRoutingId}`}
-                            accept={'.csv'}
-                            inputRef={this.props.fileImportRef}
-                            onChange={(e) => {
-                                const files = e.target.files;
-                                if (files && files.length > 0) this.onCsvFileChange(files[0]);
-                            }}
-                        />
-                    </div>
-                    {this.state.csvAttributes && (
-                        <BatchAttributesSelection
-                            onValueChange={this.onValueChange}
-                            attributes={batchRouting.attributes}
-                            csvAttributes={this.state.csvAttributes}
-                        />
-                    )}
-                    {this.state.csvAttributes &&
-                        Preferences.get('transit.routing.batch.allowSavingOdTripsToDb', false) && (
-                        <BatchSaveToDb
-                            onValueChange={this.onValueChange}
-                            attributes={batchRouting.attributes}
-                            defaultDataSourceName={(batchRouting.attributes.csvFile as File).name || ''}
-                        />
-                    )}
-                    {
-                        <InputWrapper smallInput={true} label={this.props.t('transit:transitRouting:CpuCount')}>
-                            <InputStringFormatted
-                                id={`formFieldTransitBatchRoutingCpuCount${batchRoutingId}`}
-                                value={batchRouting.attributes.cpuCount}
-                                onValueUpdated={(value) => this.onValueChange('cpuCount', value)}
-                                stringToValue={_toInteger}
-                                valueToString={_toString}
-                                type={'number'}
-                            />
-                        </InputWrapper>
-                    }
-                </div>
-
-                {this.state.csvAttributes && <FormErrors errors={batchRouting.getErrors()} />}
-                {errors.length > 0 && <FormErrors errors={errors} />}
-                {warnings.length > 0 && <FormErrors errors={warnings} errorType="Warning" />}
-
-                {
-                    <div>
-                        <div className="tr__form-buttons-container _right">
-                            {!this.state.csvAttributes &&
-                                batchRouting.attributes.csvFile &&
-                                !this.state.batchRoutingInProgress && (
-                                <Button
-                                    icon={faUpload}
-                                    iconClass="_icon-alone"
-                                    label=""
-                                    color="blue"
-                                    onClick={this.onSubmitCsv}
-                                />
-                            )}
-                            {this.state.batchRoutingInProgress && (
-                                <Loader size={8} color={'#aaaaaa'} loading={true}></Loader>
-                            )}
-                            {this.state.csvAttributes &&
-                                !this.state.csvUploadedToServer &&
-                                !this.state.batchRoutingInProgress && (
-                                <Button
-                                    label={this.props.t('main:PrepareData')}
-                                    color="green"
-                                    onClick={this.onUploadCsv}
-                                />
-                            )}
-                            {this.state.csvAttributes &&
-                                this.state.csvUploadedToServer &&
-                            /*!this.state.batchRoutingInProgress &&*/ batchRouting.validate() &&
-                                hasAllAttributesSet && (
-                                <Button
-                                    label={this.props.t('main:Calculate')}
-                                    color="green"
-                                    onClick={this.onCalculateBatch}
-                                />
-                            )}
-                        </div>
-                    </div>
-                }
-                <ExecutableJobComponent defaultPageSize={5} jobType="batchRoute" />
             </Collapsible>
         );
     }
@@ -365,4 +82,4 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
 
 // ** File upload
 //export default FileUploaderHOC(TransitRoutingForm, null, false);
-export default FileUploaderHOC(withTranslation(['transit', 'main'])(TransitRoutingBatchForm), undefined, false);
+export default withTranslation(['transit', 'main'])(TransitRoutingBatchForm);

--- a/packages/transition-frontend/src/services/batchCalculation/__tests__/types.test.ts
+++ b/packages/transition-frontend/src/services/batchCalculation/__tests__/types.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { BatchCalculationParameters, isBatchParametersValid } from '../types';
+
+describe('Test is valid', () => {
+    test('Test valid, without transit', () => {
+        const parameters = { routingModes: ['walking' as const]};
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+    });
+
+    test('Test valid, with transit, minimal', () => {
+        const parameters: BatchCalculationParameters = { 
+            routingModes: ['walking' as const, 'transit' as const],
+            scenarioId: 'arbitrary'
+        };
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+    });
+
+    test('Test valid, with transit, complete', () => {
+        const parameters: BatchCalculationParameters = { 
+            routingModes: ['walking' as const, 'transit' as const],
+            scenarioId: 'arbitrary',
+            withAlternatives: true,
+            minWaitingTimeSeconds: 180,
+            maxTransferTravelTimeSeconds: 900,
+            maxAccessEgressTravelTimeSeconds: 900,
+            maxWalkingOnlyTravelTimeSeconds: 900,
+            maxFirstWaitingTimeSeconds: 600,
+            maxTotalTravelTimeSeconds: 3600,
+            walkingSpeedMps: 5,
+            walkingSpeedFactor: 1
+        };
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+    });
+
+    test('Test invalid, missing routing modes', () => {
+        const parameters = { routingModes: []};
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: false, errors: ['transit:transitRouting:errors:RoutingModesIsEmpty']});
+    });
+
+    test('Test invalid, with transit missing scenario id', () => {
+        const parameters: BatchCalculationParameters = { 
+            routingModes: ['walking' as const, 'transit' as const]
+        };
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: false, errors: ['transit:transitRouting:errors:ScenarioIsMissing']});
+    });
+
+});

--- a/packages/transition-frontend/src/services/batchCalculation/types.ts
+++ b/packages/transition-frontend/src/services/batchCalculation/types.ts
@@ -1,0 +1,26 @@
+import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import {
+    TransitRoutingQueryAttributes,
+    validateTrQueryAttributes
+} from 'transition-common/lib/services/transitRouting/TransitRoutingQueryAttributes';
+
+export const isBatchParametersValid = (parameters: BatchCalculationParameters) => {
+    let parametersValid = true;
+    const errors: string[] = [];
+    if (parameters.routingModes.length === 0) {
+        parametersValid = false;
+        errors.push('transit:transitRouting:errors:RoutingModesIsEmpty');
+    }
+    if (parameters.routingModes.includes('transit')) {
+        const { valid: queryAttrValid, errors: queryAttrErrors } = validateTrQueryAttributes(parameters);
+        if (!queryAttrValid) {
+            parametersValid = false;
+            errors.push(...queryAttrErrors);
+        }
+    }
+    return { valid: parametersValid, errors };
+};
+
+export type BatchCalculationParameters = {
+    routingModes: RoutingOrTransitMode[];
+} & TransitRoutingQueryAttributes;

--- a/packages/transition-frontend/src/services/transitDemand/types.ts
+++ b/packages/transition-frontend/src/services/transitDemand/types.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
+
+export type TransitDemandFromCsvFile = {
+    type: 'csv';
+    demand: TransitOdDemandFromCsv;
+    csvFields: string[];
+};


### PR DESCRIPTION
* Add a new section, "Scenario analysis", which is part of the "supply/demand analysis" module.

* The current batch routing functionality is moved to this new section as follows:
  - The main panel displays by default the list of batchRouting tasks that belongs to the user. It also contains a button to do a new analysis
  - The new analysis button opens a 3-steps wizard, where the user can 
    1- select the demand CSV file and map the fields, 
    2- Specify the calculation parameters (travel times, scenario, withAlternatives) 
    3- Visualize the various parameters and either go back to modify or click Calculate. Clicking calculate triggers the calculation and the user is back to the job list and can see the progress.

* The current batch calculation is replaced by a message telling the user to go to the "Scenario analysis" section instead.

**Coming improvements:**

- Add texts to the forms
- Move the "detailed results" and "with geometries", which used to be part of the batch routing form, to a calculation options object, and maybe put them in the form where the user can visualize the parameters (step 3) and decide on the calculation option.
- Review how/where the buttons are handled. Now, each individual form makes its own validation of the data, but has to tell the parent form to enabled the next/previous button. It looks awkward.
- Replace the job list component by something prettier, like in the other list, with buttons, where the user can select one and expand it in a div below