### PR TITLE
db: Let the `create` function's returning parameter be an array too

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
@@ -58,13 +58,13 @@ const create = async <T extends GenericAttributes, U>(
     tableName: string,
     parser: ((arg: T) => U) | undefined,
     newObject: T,
-    returning = 'id'
-): Promise<string> => {
+    returning: string | string[] = 'id'
+): Promise<string | { [key: string]: unknown }> => {
     try {
         const _newObject = parser ? parser(newObject) : newObject;
 
         const returningArray = await knex(tableName).insert(_newObject).returning(returning);
-        return returningArray[0][returning];
+        return typeof returning === 'string' ? returningArray[0][returning] : returningArray[0];
     } catch (error) {
         throw new TrError(
             `Cannot insert object with id ${newObject.id} in table ${tableName} database (knex error: ${error})`,

--- a/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
@@ -298,7 +298,7 @@ describe(`${objectName}`, function() {
         delete pathWithoutGeography.id;
         pathWithoutGeography.integer_id = 5;
         const newObject = new ObjectClass(pathWithoutGeography, true);
-        const id = await dbQueries.create(newObject.attributes);
+        const id = await dbQueries.create(newObject.attributes) as string;
         
         // 3 features in the complete collection
         const _collection = await dbQueries.collection();

--- a/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
@@ -181,11 +181,12 @@ describe(`${objectName}`, () => {
 
     });
 
-    test('should create a second new object in database', async () => {
+    test('should create a second new object in database, with array returning', async () => {
 
         const newObject = new ObjectClass(newObjectAttributes2, true);
-        const id = await dbQueries.create(newObject.attributes)
+        const { id, integer_id } = await dbQueries.create(newObject.attributes, ['id', 'integer_id']) as {[key: string]: unknown}
         expect(id).toBe(newObjectAttributes2.id);
+        expect(integer_id).toBeDefined();
 
     });
 

--- a/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
@@ -268,7 +268,7 @@ const deleteMultipleUnused = function (ids: string[]): Promise<string[]> {
 export default {
     exists: exists.bind(null, knex, tableName),
     read,
-    create: (newObject: NodeAttributes, returning?: string) => {
+    create: (newObject: NodeAttributes, returning?: string | string[]) => {
         return create(knex, tableName, attributesCleaner, newObject, returning);
     },
     createMultiple: (newObjects: NodeAttributes[], returning?: string[]) => {

--- a/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
@@ -111,7 +111,7 @@ const createFromTrip = async function (periodTrip: SchedulePeriodTrip, scheduleI
     if (!periodTrip.schedule_period_id) {
         periodTrip.schedule_period_id = periodId;
     }
-    const id = await create(knex, tripTable, scheduleTripsAttributesCleaner, periodTrip, 'id');
+    const id = (await create(knex, tripTable, scheduleTripsAttributesCleaner, periodTrip, 'id')) as string;
     return id;
 };
 
@@ -122,7 +122,7 @@ const createFromPeriod = async function (periodSchedule: SchedulePeriod, schedul
     if (!periodSchedule.schedule_id) {
         periodSchedule.schedule_id = schedule_id;
     }
-    const id = await create(knex, periodTable, schedulePeriodsAttributesCleaner, periodSchedule, 'id');
+    const id = (await create(knex, periodTable, schedulePeriodsAttributesCleaner, periodSchedule, 'id')) as string;
     if (periodSchedule.trips) {
         for (let i = 0; i < periodSchedule.trips.length; i++) {
             await createFromTrip(periodSchedule.trips[i], schedule_id, id);
@@ -133,7 +133,7 @@ const createFromPeriod = async function (periodSchedule: SchedulePeriod, schedul
 
 // create all needed inserts from scheduleData (from scheduleByServiceId[serviceId])
 const createFromScheduleData = async function (scheduleData: ScheduleAttributes) {
-    const id = await create(knex, scheduleTable, scheduleAttributesCleaner, scheduleData, 'id');
+    const id = (await create(knex, scheduleTable, scheduleAttributesCleaner, scheduleData, 'id')) as string;
     for (let i = 0; i < scheduleData.periods.length; i++) {
         await createFromPeriod(scheduleData.periods[i], id);
     }
@@ -144,7 +144,14 @@ const updateFromTrip = async function (periodTrip: Partial<SchedulePeriodTrip>) 
     if (!periodTrip.id || !periodTrip.schedule_id || !periodTrip.schedule_period_id) {
         throw 'Missing trip, schedule or period id for trip, cannot update';
     }
-    const id = await update(knex, tripTable, scheduleTripsAttributesCleaner, periodTrip.id, periodTrip, 'id');
+    const id = (await update(
+        knex,
+        tripTable,
+        scheduleTripsAttributesCleaner,
+        periodTrip.id,
+        periodTrip,
+        'id'
+    )) as string;
     return id;
 };
 
@@ -180,7 +187,7 @@ const updateFromPeriod = async function (periodSchedule: Partial<SchedulePeriod>
 };
 
 const updateFromScheduleData = async function (scheduleId: string, scheduleData: ScheduleAttributes) {
-    const id = await update(knex, scheduleTable, scheduleAttributesCleaner, scheduleId, scheduleData, 'id');
+    const id = (await update(knex, scheduleTable, scheduleAttributesCleaner, scheduleId, scheduleData, 'id')) as string;
     const periodIds = await getPeriodIdsForSchedule(id);
     const currentPeriods: string[] = [];
     // Update or create periods in schedule


### PR DESCRIPTION
Fixes #562

In effect, sometimes, this function is called with an array of fields to return. If it is the case, the returned object is expected to be an object.

cc @nik498 