### PR TITLE
jobs: Allow to restart running and pending jobs when server restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ PROJECT_SAMPLE=demo
 #SSL_PRIVATE_KEY=/path/to/privkey.pem
 #SSL_CERT=/path/to/sslcert.pem
 STARTUP_RECREATE_CACHE=false
+# whether to restart jobs that were running or pending when server stopped
+STARTUP_RESTART_JOBS=true
 
 # Uncomment and update to change the URL of the API to get the OpenStreetMap data
 #OSM_OVERPASS_API_URL=http://overpass-api.de/api/interpreter

--- a/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
@@ -229,18 +229,54 @@ describe(`${objectName}`, () => {
         const secondId = result.jobs[0].id;
 
         // Read first page for first user, sort ascending
-        result = await dbQueries.collection({ userId: userAttributes.id, pageIndex: 0, pageSize: 1, sort: { field: 'created_at', direction: 'asc' } });
+        result = await dbQueries.collection({ userId: userAttributes.id, pageIndex: 0, pageSize: 1, sort: [{ field: 'created_at', direction: 'asc' }] });
         expect(result.totalCount).toBe(2);
         expect(result.jobs.length).toBe(1);
         expect(result.jobs[0].name).toEqual(newObjectAttributes.name);
         expect(result.jobs[0].id).toEqual(secondId);
 
         // Read second page for first user, sort ascending
-        result = await dbQueries.collection({ userId: userAttributes.id, pageIndex: 1, pageSize: 1, sort: { field: 'created_at', direction: 'asc' } });
+        result = await dbQueries.collection({ userId: userAttributes.id, pageIndex: 1, pageSize: 1, sort: [{ field: 'created_at', direction: 'asc' }] });
         expect(result.totalCount).toBe(2);
         expect(result.jobs.length).toBe(1);
         expect(result.jobs[0].name).toEqual(newObjectAttributes2.name);
         expect(result.jobs[0].id).toEqual(firstId);
+
+    });
+
+    test('Various sort', async() => {
+
+        // Sort all by status ascending (statuses are sorted by their enum value, not alphabetically, pending is first)
+        let result = await dbQueries.collection({ pageIndex: 0, pageSize: 0, sort: [{ field: 'status', direction: 'asc' }] });
+        expect(result.totalCount).toBe(3);
+        expect(result.jobs.length).toBe(3);
+        expect(result.jobs[0].status).toEqual('pending');
+        expect(result.jobs[1].status).toEqual('pending');
+        expect(result.jobs[2].status).toEqual('completed');
+
+        // Sort all by status descending
+        result = await dbQueries.collection({ pageIndex: 0, pageSize: 0, sort: [{ field: 'status', direction: 'desc' }] });
+        expect(result.totalCount).toBe(3);
+        expect(result.jobs.length).toBe(3);
+        expect(result.jobs[0].status).toEqual('completed');
+        expect(result.jobs[1].status).toEqual('pending');
+        expect(result.jobs[2].status).toEqual('pending');
+
+        // Sort by status ascending and user id descending
+        result = await dbQueries.collection({ pageIndex: 0, pageSize: 0, sort: [{ field: 'status', direction: 'asc' }, { field: 'user_id', direction: 'desc' }] });
+        expect(result.totalCount).toBe(3);
+        expect(result.jobs.length).toBe(3);
+        expect(result.jobs[0]).toEqual(expect.objectContaining({ status: 'pending', user_id: userAttributes.id + 1 }));
+        expect(result.jobs[1]).toEqual(expect.objectContaining({ status: 'pending', user_id: userAttributes.id }));
+        expect(result.jobs[2]).toEqual(expect.objectContaining({ status: 'completed', user_id: userAttributes.id }));
+
+        // Sort by status ascending and user id ascending
+        result = await dbQueries.collection({ pageIndex: 0, pageSize: 0, sort: [{ field: 'status', direction: 'asc' }, { field: 'user_id', direction: 'asc' }] });
+        expect(result.totalCount).toBe(3);
+        expect(result.jobs.length).toBe(3);
+        expect(result.jobs[0]).toEqual(expect.objectContaining({ status: 'pending', user_id: userAttributes.id }));
+        expect(result.jobs[1]).toEqual(expect.objectContaining({ status: 'pending', user_id: userAttributes.id + 1 }));
+        expect(result.jobs[2]).toEqual(expect.objectContaining({ status: 'completed', user_id: userAttributes.id }));
 
     });
 

--- a/packages/transition-backend/src/models/db/jobs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/jobs.db.queries.ts
@@ -55,12 +55,7 @@ const collection = async (
                 if (statuses.length === 1) {
                     query.where('status', options.statuses[0]);
                 } else if (statuses.length > 1) {
-                    query.where(function () {
-                        this.where('status', statuses[0] as JobStatus);
-                        statuses.slice(1).forEach((status) => {
-                            this.orWhere('status', status);
-                        });
-                    });
+                    query.whereIn('status', statuses);
                 }
             }
         };

--- a/packages/transition-backend/src/models/db/jobs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/jobs.db.queries.ts
@@ -39,7 +39,7 @@ const collection = async (
         statuses?: JobStatus[];
         pageIndex: number;
         pageSize: number;
-        sort?: { field: string; direction: 'asc' | 'desc' };
+        sort?: { field: keyof JobAttributes<JobDataType>; direction: 'asc' | 'desc' }[];
     } = { pageIndex: 0, pageSize: 0 }
 ): Promise<{ jobs: JobAttributes<JobDataType>[]; totalCount: number }> => {
     try {
@@ -64,7 +64,7 @@ const collection = async (
                 }
             }
         };
-        const sort = options.sort || { field: 'created_at', direction: 'desc' };
+        const sorts = options.sort || [{ field: 'created_at', direction: 'desc' }];
 
         // Get the total count for that query
         const countQuery = knex.count('id').from(tableName);
@@ -80,7 +80,8 @@ const collection = async (
             return { jobs: [], totalCount };
         }
 
-        const jobsQuery = knex.select().from(tableName).orderBy(sort.field, sort.direction);
+        const jobsQuery = knex.select().from(tableName);
+        sorts.forEach((sort) => jobsQuery.orderBy(sort.field, sort.direction));
         addWhere(jobsQuery);
         if (options.pageSize > 0) {
             jobsQuery.limit(options.pageSize).offset(options.pageIndex * options.pageSize);

--- a/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
+++ b/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
@@ -30,7 +30,7 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
         jobType?: string;
         pageIndex: number;
         pageSize: number;
-        sort?: { field: string; direction: 'asc' | 'desc' };
+        sort?: { field: keyof JobAttributes<JobDataType>; direction: 'asc' | 'desc' }[];
     }): Promise<Promise<{ jobs: ExecutableJob<JobDataType>[]; totalCount: number }>> {
         const { jobs, totalCount } = await jobsDbQueries.collection(options);
         return { jobs: jobs.map((attribs) => new ExecutableJob<JobDataType>(attribs)), totalCount };

--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -92,9 +92,9 @@ const wrapBatchAccessMap = async (task: ExecutableJob<BatchAccessMapJobType>) =>
 };
 
 const wrapTaskExecution = async (id: number) => {
-    // Load task from database and execute only if it is pending
+    // Load task from database and execute only if it is pending, or resume tasks in progress
     const task = await ExecutableJob.loadTask(id);
-    if (task.status !== 'pending') {
+    if (task.status !== 'pending' && task.status !== 'inProgress') {
         return;
     }
     const taskListener = taskUpdateListener();


### PR DESCRIPTION
Fixes #476

This enqueues any executable jobs that are in progress or pending when
the server starts so they can be run again. In progress jobs are simply
restarted, running jobs are enqueued first, then the pending ones
ordered by the creation time, earliest first.

Add unit tests for resume functions and queries with multiple sort options