### PR TITLE
Increase overpass queries timeout

### DIFF
--- a/packages/chaire-lib-common/src/config/osm/overpassQueries/allNodes.overpassql
+++ b/packages/chaire-lib-common/src/config/osm/overpassQueries/allNodes.overpassql
@@ -1,4 +1,4 @@
-[out:json][timeout:120];
+[out:json][timeout:240];
 (
     {{polyboundary="BOUNDARY"}}
 

--- a/packages/chaire-lib-common/src/config/osm/overpassQueries/allNodes.ts
+++ b/packages/chaire-lib-common/src/config/osm/overpassQueries/allNodes.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-export default `<osm-script output="OUTPUT" output-config="" timeout="120">
+export default `<osm-script output="OUTPUT" output-config="" timeout="240">
     <union into="_">
         <polygon-query bounds="BOUNDARY"/>
         <recurse from="_" into="_" type="up"/>

--- a/packages/chaire-lib-common/src/config/osm/overpassQueries/allWaysAndRelations.overpassql
+++ b/packages/chaire-lib-common/src/config/osm/overpassQueries/allWaysAndRelations.overpassql
@@ -1,4 +1,4 @@
-[out:json][timeout:120];
+[out:json][timeout:240];
 (
     {{polyboundary="BOUNDARY"}}
 

--- a/packages/chaire-lib-common/src/config/osm/overpassQueries/allWaysAndRelations.ts
+++ b/packages/chaire-lib-common/src/config/osm/overpassQueries/allWaysAndRelations.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-export default `<osm-script output="OUTPUT" output-config="" timeout="120">
+export default `<osm-script output="OUTPUT" output-config="" timeout="240">
     <union into="_">
         <query into="_" type="way">
             <polygon-query bounds="BOUNDARY"/>


### PR DESCRIPTION
We were getting timeout trying to download bigger regions like LA. Doubling the time allows the queries to complete.