### PR TITLE
routing results: Fix formatting of departure and arrival times

### DIFF
--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingResultComponent.tsx
@@ -133,12 +133,12 @@ const TransitRoutingResults: React.FunctionComponent<TransitRoutingResultsProps>
                                     ? props.t('transit:transitRouting:results:OptimisedDepartureTime')
                                     : props.t('transit:transitRouting:results:DepartureTime')}
                             </th>
-                            <td>{path.departureTime}</td>
+                            <td>{secondsSinceMidnightToTimeStr(path.departureTime)}</td>
                         </tr>
                         {path.timeOfTripType === 'departure' && path.departureTime !== path.timeOfTrip && (
                             <tr>
                                 <th>{props.t('transit:transitRouting:results:NonOptimisedDepartureTime')}</th>
-                                <td>{path.timeOfTrip}</td>
+                                <td>{secondsSinceMidnightToTimeStr(path.timeOfTrip)}</td>
                             </tr>
                         )}
                         {path.timeOfTripType === 'departure' && path.departureTime !== path.timeOfTrip && (
@@ -156,7 +156,7 @@ const TransitRoutingResults: React.FunctionComponent<TransitRoutingResultsProps>
                         )}
                         <tr>
                             <th>{props.t('transit:transitRouting:results:ArrivalTime')}</th>
-                            <td>{path.arrivalTime}</td>
+                            <td>{secondsSinceMidnightToTimeStr(path.arrivalTime)}</td>
                         </tr>
                         {path.timeOfTripType === 'arrival' && (
                             <tr>


### PR DESCRIPTION
When the previous trRouting v1 API was directly used in the result, the departure and arrival times were already formatted, they are now in seconds since midnight and need to be formatted at display time.