### PR TITLE
Fix imports from transition-common package to lib in tests

### DIFF
--- a/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
@@ -9,7 +9,7 @@ import { v4 as uuidV4 } from 'uuid';
 import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import dbQueries from '../jobs.db.queries';
 import UserModel from 'chaire-lib-backend/lib/services/auth/user';
-import { JobAttributes, Job as ObjectClass } from 'transition-common/src/services/jobs/Job';
+import { JobAttributes, Job as ObjectClass } from 'transition-common/lib/services/jobs/Job';
 
 const objectName   = 'job';
 

--- a/packages/transition-backend/src/services/executableJob/__tests__/ExecutableJob.test.ts
+++ b/packages/transition-backend/src/services/executableJob/__tests__/ExecutableJob.test.ts
@@ -12,7 +12,7 @@ import { JobAttributes } from 'transition-common/lib/services/jobs/Job';
 import { execJob } from '../../../tasks/serverWorkerPool';
 import { ExecutableJob } from '../ExecutableJob';
 import jobsDbQueries from '../../../models/db/jobs.db.queries'
-import { JobStatus } from 'transition-common/src/services/jobs/Job';
+import { JobStatus } from 'transition-common/lib/services/jobs/Job';
 
 const progressEmitter = new EventEmitter();
 

--- a/packages/transition-backend/src/services/gtfsExport/__tests__/LineExporter.test.ts
+++ b/packages/transition-backend/src/services/gtfsExport/__tests__/LineExporter.test.ts
@@ -8,7 +8,7 @@ import { createWriteStream } from 'fs';
 import { v4 as uuidV4 } from 'uuid';
 
 import { exportLine } from '../LineExporter';
-import { LineAttributes } from 'transition-common/src/services/line/Line';
+import { LineAttributes } from 'transition-common/lib/services/line/Line';
 
 jest.mock('fs', () => {
     // Require the original module to not be mocked...

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
@@ -14,7 +14,7 @@ import { TransitRoutingResult } from 'transition-common/lib/services/transitRout
 import { UnimodalRouteCalculationResult } from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { ErrorCodes } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
-import Path from 'transition-common/src/services/path/Path';
+import Path from 'transition-common/lib/services/path/Path';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import { routeToUserObject, TrRoutingBoardingStep, TrRoutingUnboardingStep, TrRoutingWalkingStep } from 'chaire-lib-common/src/services/trRouting/TrRoutingResultConversion';
 


### PR DESCRIPTION
The imports were mistakenly imported from the src/ directory instead of lib