### PR TITLE
jobs: Support custom action in the UI's job list

### DIFF
--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@alienfast/i18next-loader": "^1.1.4",
+    "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@mapbox/mapbox-gl-draw": "^1.3.0",

--- a/packages/transition-frontend/src/components/parts/executableJob/ExecutableJobComponent.tsx
+++ b/packages/transition-frontend/src/components/parts/executableJob/ExecutableJobComponent.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Column } from 'react-table';
 import moment from 'moment';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faStopCircle } from '@fortawesome/free-solid-svg-icons/faStopCircle';
 
 import ExecutableJobList, { ReturnedJobAttributes } from './ExecutableJobList';
@@ -18,12 +19,17 @@ import ExpandableText from './ExpandableText';
 import ExpandableFiles from './ExpandableFileWidget';
 import Button from '../Button';
 import ButtonList from '../ButtonList';
-import { ButtonCellWithConfirm } from '../ButtonCell';
+import ButtonCell, { ButtonCellWithConfirm } from '../ButtonCell';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface ExecutableJobComponentProps {
     jobType?: string;
     defaultPageSize?: number;
+    customActions?: {
+        callback: (jobId: number) => void;
+        title: string;
+        icon: IconProp;
+    }[];
 }
 
 const fetchFromSocket = (parameters: {
@@ -195,6 +201,18 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                                     <FontAwesomeIcon icon={faStopCircle} />
                                 </ButtonCellWithConfirm>
                             )}
+                            {props.customActions !== undefined &&
+                                props.customActions.length > 0 &&
+                                props.customActions.map((action, index) => (
+                                    <ButtonCell
+                                        key={`execJob_customAction${index}`}
+                                        alignment="flush"
+                                        onClick={() => action.callback(cellProps.value)}
+                                        title={props.t(action.title)}
+                                    >
+                                        <FontAwesomeIcon icon={action.icon} />
+                                    </ButtonCell>
+                                ))}
                         </Button>
                     </ButtonList>
                 )


### PR DESCRIPTION
Add a customActions prop to the ExecutableJobComponent, which takes a callback with the jobId, a title string and an icon to represent the job. This icon is added before the `delete` icon in the actions cell.