### PR TITLE
Fix case insensitive emails

### DIFF
--- a/docs/ABC_of_pull_requests.md
+++ b/docs/ABC_of_pull_requests.md
@@ -54,7 +54,6 @@ Examples of views of PRs to review at this step:
 
 ![Multiple commits](images/PRs/multipleCommits.png)
 
-
 ### Code review
 
 Next is the code review itself. Behavior is one thing, code quality is another. In this step, we want to make sure the code under review reaches the current standards of code in the various workspaces, and also that the proposed solution makes sense.
@@ -91,7 +90,6 @@ So all the PR checks are OK, I'm ready to approve and merge! But wait, there are
 - [ ] **Did I approve the PR?**: In the `Files changed` tab of the PR, click on the green `review changes` button and select `Approve` and submit.
 
 ![Approve the PR](images/PRs/approvePR.png)
-
 
 - [ ] **Did all reviewers approve?**: If anyone was specifically requested for review, make sure the review was done and approved (or that there is no need). In doubt, just ping the other reviewer(s) for comments.
 - [ ] **Were all comments addressed?**: If other reviewers requested changes, make sure they were all addressed (or are outdated).

--- a/packages/chaire-lib-backend/src/config/auth/passport.utils.ts
+++ b/packages/chaire-lib-backend/src/config/auth/passport.utils.ts
@@ -35,7 +35,7 @@ export const saveNewUser = async function (params: newUserParams): Promise<UserM
             last_name: '',
             is_admin: false,
             is_valid: params.isTest === true ? false : true,
-            is_test: params.isTest,
+            is_test: params.isTest === true ? true : false,
             is_confirmed: params.confirmationToken !== undefined ? false : true,
             confirmation_token: params.confirmationToken !== undefined ? params.confirmationToken : null
         });

--- a/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
@@ -82,7 +82,11 @@ const find = async (
             delete whereData.usernameOrEmail;
         }
         Object.keys(whereData).forEach((key) => {
-            orWhere ? query.orWhereILike(key, whereData[key]) : query.andWhereILike(key, whereData[key]);
+            if (key === whereData.email) {
+                orWhere ? query.orWhereILike(key, whereData[key]) : query.andWhereILike(key, whereData[key]);
+            } else {
+                orWhere ? query.orWhere(key, whereData[key]) : query.andWhere(key, whereData[key]);
+            }
         });
 
         const response = await query.limit(1);
@@ -147,12 +151,14 @@ const sanitizeOrderDirection = (order: string): string => {
 const getRawFilter = (filters: UserFilter): [string, string[]] | undefined => {
     const rawFilters: string[] = [];
     const bindings: string[] = [];
-    ['email', 'username'].forEach((field) => {
-        if (filters[field] !== undefined) {
-            rawFilters.push(`${field} ILIKE ?`);
-            bindings.push(`%${filters[field]}%`);
-        }
-    });
+    if (filters['email'] !== undefined) {
+        rawFilters.push(`${'email'} ILIKE ?`);
+        bindings.push(`%${filters['email']}%`);
+    }
+    if (filters['username'] !== undefined) {
+        rawFilters.push(`${'username'} LIKE ?`);
+        bindings.push(`%${filters['username']}%`);
+    }
     if (filters.is_admin !== undefined) {
         rawFilters.push(`is_admin IS ${filters.is_admin === true ? 'TRUE' : 'NOT TRUE'}`);
     }

--- a/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
@@ -82,7 +82,7 @@ const find = async (
             delete whereData.usernameOrEmail;
         }
         Object.keys(whereData).forEach((key) => {
-            if (key === whereData.email) {
+            if (key === 'email') {
                 orWhere ? query.orWhereILike(key, whereData[key]) : query.andWhereILike(key, whereData[key]);
             } else {
                 orWhere ? query.orWhere(key, whereData[key]) : query.andWhere(key, whereData[key]);

--- a/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
@@ -82,7 +82,7 @@ const find = async (
             delete whereData.usernameOrEmail;
         }
         Object.keys(whereData).forEach((key) => {
-            orWhere ? query.orWhere(key, whereData[key]) : query.andWhere(key, whereData[key]);
+            orWhere ? query.orWhereILike(key, whereData[key]) : query.andWhereILike(key, whereData[key]);
         });
 
         const response = await query.limit(1);


### PR DESCRIPTION
This would fix issue #549 .

This has been tested through the command line with yarn create-user and through the registration form. Both reject the creation of a new user when emails or usernames are identical, regardless of the case.