### PR TITLE
batchCalculation: Create a new calculation from an existing one

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -934,6 +934,13 @@
         "AnalysisParameters": "Parameters",
         "ConfigureDemand": "Configure demand data",
         "ConfigureParameters": "Configure analysis parameters",
-        "AnalysisSummary": "Analysis summary"
+        "AnalysisSummary": "Analysis summary",
+        "ReplayJob": "Create new calculation from this one",
+        "UploadedFile": "Uploaded file",
+        "FromPreviousJob": "Data from previous calculation",
+        "errors": {
+            "InputFileUnavailable": "Input file does not exist for this job",
+            "ErrorGettingReplayParameters": "Error getting execution data to replay calculation"
+        }
     }
 }

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -932,6 +932,13 @@
         "AnalysisParameters": "Paramètres",
         "ConfigureDemand": "Configuration des données de la demande",
         "ConfigureParameters": "Configuration des paramètres d'analyse",
-        "AnalysisSummary": "Sommaire de l'analyse"
+        "AnalysisSummary": "Sommaire de l'analyse",
+        "ReplayJob": "Nouveau calcul à partir de cette tâche",
+        "UploadedFile": "Fichier téléversé",
+        "FromPreviousJob": "Données d'un calcul précédent",
+        "errors": {
+            "InputFileUnavailable": "Le fichier d'entrée n'existe pas pour cette tâche",
+            "ErrorGettingReplayParameters": "Un problème est survenu lors de l'obtention de la configuration pour ré-exécuter un calcul"
+        }
     }
 }

--- a/packages/chaire-lib-common/src/api/TrRouting/base.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/base.ts
@@ -17,6 +17,7 @@ export type TransitBatchDemandFromCsvAttributes = {
     withGeometries: boolean;
     detailed: boolean;
     cpuCount: number;
+    csvFile: { location: 'upload' } | { location: 'server'; fromJob: number };
 };
 
 export type TransitBatchRoutingDemandFromCsvAttributes = TransitBatchDemandFromCsvAttributes & {

--- a/packages/chaire-lib-common/src/api/TrRouting/index.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/index.ts
@@ -38,6 +38,18 @@ export class TrRoutingConstants {
      */
     static readonly BATCH_ROUTE = 'service.trRouting.batchRoute';
     /**
+     * Socket route name to call to get the parameters to replay a previously
+     * saved task. It takes the ID of the batch routing job to replay. It
+     * returns a {@link Status}, with a object containing a field named
+     * 'parameters' of type {@link BatchCalculationParameters}, a 'demand' field
+     * of type {@link TransitOdDemandFromCsvAttributes} and a 'csvFields' field
+     * containing the string headers of the fields of the csv file on success
+     *
+     * @static
+     * @memberof TrRoutingConstants
+     */
+    static readonly BATCH_ROUTE_REPLAY = 'service.trRouting.batchRouteReplay';
+    /**
      * Socket route name to call a batch accessibility map calculation. It takes
      * a parameter of type {@link TransitBatchAccessibilityMapAttributes}. It
      * returns a {@link Status}, with a {@link TransitBatchCalculationResult} on

--- a/packages/transition-backend/src/api/__tests__/services.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/services.socketRoutes.test.ts
@@ -258,6 +258,7 @@ describe('trRouting routes', () => {
         type: 'csv',
         configuration: {
             calculationName: 'test',
+            csvFile: { location: 'upload' },
             cpuCount: 1,
             saveToDb: false
         }

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import os from 'os';
+import fs from 'fs';
 import { EventEmitter } from 'events';
 import osrm from 'osrm';
 
@@ -26,6 +27,8 @@ import { ExecutableJob } from '../services/executableJob/ExecutableJob';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import { BatchRouteJobType } from '../services/transitRouting/BatchRoutingJob';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
+import { fileKey } from 'transition-common/lib/services/jobs/Job';
 
 // TODO The socket routes should validate parameters as even typescript cannot guarantee the types over the network
 // TODO Add more unit tests as the called methods are cleaned up
@@ -177,6 +180,26 @@ export default function (socket: EventEmitter, userId?: number) {
             ) => {
                 try {
                     socket.emit('progress', { name: 'BatchRouting', progress: null });
+                    const inputFiles: { [Property in keyof BatchRouteJobType[fileKey]]?: string } = {};
+                    if (parameters.configuration.csvFile.location === 'upload') {
+                        inputFiles.input = `${directoryManager.userDataDirectory}/${userId}/imports/batchRouting.csv`;
+                    } else {
+                        const batchRouteJob = await ExecutableJob.loadTask<BatchRouteJobType>(
+                            parameters.configuration.csvFile.fromJob
+                        );
+                        if (batchRouteJob.attributes.name !== 'batchRoute') {
+                            throw 'Requested job is not a batchRoute job';
+                        }
+                        if (batchRouteJob.attributes.user_id !== userId) {
+                            throw 'Not allowed to get the input file from job';
+                        }
+                        const filePath = batchRouteJob.getFilePath('input');
+                        if (filePath === undefined) {
+                            throw 'InputFileNotAvailable';
+                        }
+                        inputFiles.input = filePath;
+                    }
+
                     // TODO Handle the input file and add it to the task
                     const job: ExecutableJob<BatchRouteJobType> = await ExecutableJob.createJob(
                         {
@@ -188,9 +211,7 @@ export default function (socket: EventEmitter, userId?: number) {
                                     transitRoutingAttributes
                                 }
                             },
-                            inputFiles: {
-                                input: `${directoryManager.userDataDirectory}/${userId}/imports/batchRouting.csv`
-                            },
+                            inputFiles,
                             hasOutputFiles: true
                         },
                         socket
@@ -199,6 +220,54 @@ export default function (socket: EventEmitter, userId?: number) {
                     await job.refresh();
                     // TODO Do a quick return with task detail instead of waiting for task to finish
                     callback(Status.createOk(job.attributes.data.results));
+                } catch (error) {
+                    console.error(error);
+                    callback(Status.createError(TrError.isTrError(error) ? error.message : error));
+                }
+            }
+        );
+
+        socket.on(
+            TrRoutingConstants.BATCH_ROUTE_REPLAY,
+            async (
+                jobId: number,
+                callback: (
+                    status: Status.Status<{
+                        parameters: BatchCalculationParameters;
+                        demand: TransitBatchRoutingDemandAttributes;
+                        csvFields: string[];
+                    }>
+                ) => void
+            ) => {
+                try {
+                    const job = await ExecutableJob.loadTask(jobId);
+                    if (job.attributes.name !== 'batchRoute') {
+                        throw 'Requested job is not a batchRoute job';
+                    }
+                    const batchRouteJob = job as ExecutableJob<BatchRouteJobType>;
+                    const attributes = batchRouteJob.attributes.data.parameters;
+                    const filePath = batchRouteJob.getFilePath('input');
+                    if (filePath === undefined) {
+                        throw 'InputFileUnavailable';
+                    }
+                    const demand = new TransitOdDemandFromCsv(attributes.demandAttributes.configuration);
+                    // Make sure saving to db is set to false, as it was already imported if so
+                    demand.attributes.saveToDb = false;
+                    const csvFileStream = fs.createReadStream(filePath);
+                    const csvFields = await demand.setCsvFile(csvFileStream, { location: 'server', fromJob: jobId });
+                    callback(
+                        Status.createOk({
+                            parameters: attributes.transitRoutingAttributes,
+                            demand: {
+                                type: attributes.demandAttributes.type,
+                                configuration: {
+                                    ...attributes.demandAttributes.configuration,
+                                    csvFile: { location: 'server', fromJob: jobId }
+                                }
+                            },
+                            csvFields
+                        })
+                    );
                 } catch (error) {
                     console.error(error);
                     callback(Status.createError(TrError.isTrError(error) ? error.message : error));

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -188,7 +188,9 @@ export default function (socket: EventEmitter, userId?: number) {
                                     transitRoutingAttributes
                                 }
                             },
-                            inputFiles: [`${directoryManager.userDataDirectory}/${userId}/imports/batchRouting.csv`],
+                            inputFiles: {
+                                input: `${directoryManager.userDataDirectory}/${userId}/imports/batchRouting.csv`
+                            },
                             hasOutputFiles: true
                         },
                         socket
@@ -224,7 +226,9 @@ export default function (socket: EventEmitter, userId?: number) {
                                     accessMapAttributes
                                 }
                             },
-                            inputFiles: [`${directoryManager.userDataDirectory}/${userId}/imports/batchAccessMap.csv`],
+                            inputFiles: {
+                                input: `${directoryManager.userDataDirectory}/${userId}/imports/batchAccessMap.csv`
+                            },
                             hasOutputFiles: true
                         },
                         socket

--- a/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
+++ b/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
@@ -4,6 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import fs from 'fs';
 import { EventEmitter } from 'events';
 import path from 'path';
 
@@ -137,6 +138,23 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
             }
         });
     }
+
+    getFilePath = (fileName: keyof TData['files']): string | undefined => {
+        const jobFiles = this.attributes.resources?.files;
+        if (jobFiles === undefined) {
+            return undefined;
+        }
+        const file = jobFiles[fileName];
+        const files = directoryManager.getFilesAbsolute(this.getJobFileDirectory());
+        if (file === undefined || files === null || !files.includes(file)) {
+            return undefined;
+        }
+        const filePath = path.join(this.getJobFileDirectory(), file);
+        if (!fs.existsSync(filePath)) {
+            return undefined;
+        }
+        return filePath;
+    };
 
     setCancelled(): boolean {
         if (this.status === 'pending' || this.status === 'inProgress') {

--- a/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
+++ b/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
@@ -7,15 +7,17 @@
 import { EventEmitter } from 'events';
 import path from 'path';
 
-import Job, { JobAttributes, JobDataType } from 'transition-common/lib/services/jobs/Job';
+import Job, { JobAttributes, JobDataType, fileKey } from 'transition-common/lib/services/jobs/Job';
 import jobsDbQueries from '../../models/db/jobs.db.queries';
 import { directoryManager } from 'chaire-lib-backend/lib//utils/filesystem/directoryManager';
 import { execJob } from '../../tasks/serverWorkerPool';
 import Users from 'chaire-lib-backend/lib/services/users/users';
 import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
 
-export type InitialJobData = {
-    inputFiles?: string[];
+export type InitialJobData<TData extends JobDataType> = {
+    inputFiles?: {
+        [Property in keyof TData[fileKey]]?: string;
+    };
     hasOutputFiles?: boolean;
 };
 
@@ -64,7 +66,11 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
     }
 
     static async createJob<TData extends JobDataType>(
-        { inputFiles, hasOutputFiles, ...attributes }: Omit<JobAttributes<TData>, 'id' | 'status'> & InitialJobData,
+        {
+            inputFiles,
+            hasOutputFiles,
+            ...attributes
+        }: Omit<JobAttributes<TData>, 'id' | 'status'> & InitialJobData<TData>,
         jobListener?: EventEmitter
     ): Promise<ExecutableJob<TData>> {
         // Check the disk usage if the job has output files
@@ -75,19 +81,35 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
             }
         }
 
+        // Initialize the job's input files
+        const toCopy: {
+            filePath: string;
+            jobFileName: string;
+        }[] = [];
+        if (inputFiles) {
+            const jobFiles: {
+                [Property in keyof TData[fileKey]]?: string;
+            } = {};
+            Object.keys(inputFiles).forEach((inputFileKey: keyof TData[fileKey]) => {
+                const inputFile = inputFiles[inputFileKey];
+                if (inputFile !== undefined && fileManager.fileExistsAbsolute(inputFile)) {
+                    const parsedInput = path.parse(inputFile);
+                    jobFiles[inputFileKey] = `${parsedInput.name}${parsedInput.ext}`;
+                    toCopy.push({
+                        filePath: inputFile,
+                        jobFileName: `${parsedInput.name}${parsedInput.ext}`
+                    });
+                }
+            });
+            attributes.resources = { ...(attributes.resources || {}), files: jobFiles };
+        }
+
         const id = await jobsDbQueries.create({ status: 'pending', ...attributes });
         jobListener?.emit('executableJob.updated', { id, name: attributes.name });
         const job = new ExecutableJob<TData>({ id, status: 'pending', ...attributes });
-        if (inputFiles) {
-            inputFiles.forEach((inputFile) => {
-                const parsedInput = path.parse(inputFile);
-                fileManager.copyFileAbsolute(
-                    inputFile,
-                    `${job.getJobFileDirectory()}/${parsedInput.name}${parsedInput.ext}`,
-                    true
-                );
-            });
-        }
+        toCopy.forEach(({ filePath, jobFileName }) =>
+            fileManager.copyFileAbsolute(filePath, `${job.getJobFileDirectory()}/${jobFileName}`, true)
+        );
         return job;
     }
 

--- a/packages/transition-backend/src/services/executableJob/__tests__/ExecutableJob.test.ts
+++ b/packages/transition-backend/src/services/executableJob/__tests__/ExecutableJob.test.ts
@@ -13,6 +13,7 @@ import { execJob } from '../../../tasks/serverWorkerPool';
 import { ExecutableJob } from '../ExecutableJob';
 import jobsDbQueries from '../../../models/db/jobs.db.queries'
 import { JobStatus } from 'transition-common/lib/services/jobs/Job';
+import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
 
 const progressEmitter = new EventEmitter();
 
@@ -66,6 +67,15 @@ jest.mock('../../../tasks/serverWorkerPool', () => (
 ));
 const mockedPool = execJob as jest.MockedFunction<typeof execJob>;
 
+jest.mock('chaire-lib-backend/lib/utils/filesystem/fileManager', () => ({
+    fileManager: {
+        fileExistsAbsolute: jest.fn().mockReturnValue(true),
+        copyFileAbsolute: jest.fn()
+    }
+}));
+const mockedFileExists = fileManager.fileExistsAbsolute as jest.MockedFunction<typeof fileManager.fileExistsAbsolute>;
+const mockedCopyFile = fileManager.copyFileAbsolute as jest.MockedFunction<typeof fileManager.copyFileAbsolute>;
+
 beforeEach(() => {
     mockedJobRead.mockClear();
     mockedJobCreate.mockClear();
@@ -73,6 +83,8 @@ beforeEach(() => {
     mockedJobDelete.mockClear();
     mockedJobCollection.mockClear();
     mockedPool.mockClear();
+    mockedFileExists.mockClear();
+    mockedCopyFile.mockClear();
 });
 
 test('Test create job', async () => {
@@ -92,6 +104,26 @@ test('Test create job', async () => {
     expect(jobUpdatedListener).toHaveBeenCalledTimes(1);
     expect(jobUpdatedListener).toHaveBeenCalledWith({ id: jobObj.attributes.id, name: jobObj.attributes.name });
 });
+
+test('Test create job with input files', async () => {
+    const filename = 'blabla.csv';
+    const absoluteFilePath = `/path/to/file/${filename}`;
+    const attributes = _cloneDeep(newJobAttributes) as any;
+    attributes.inputFiles = { testFile: absoluteFilePath };
+
+    mockedJobCreate.mockResolvedValueOnce(jobAttributes.id);
+    const jobObj = await ExecutableJob.createJob(attributes);
+    expect(mockedJobCreate).toHaveBeenCalledTimes(1);
+    expect(mockedJobCreate).toHaveBeenCalledWith({ status: 'pending', ...newJobAttributes, resources: { files: { testFile: filename } } });
+    expect(jobObj.attributes).toEqual(expect.objectContaining({ id: jobAttributes.id, ...newJobAttributes, resources: { files: { testFile: filename } } }));
+    expect(jobObj.status).toEqual('pending');
+
+    expect(mockedFileExists).toHaveBeenCalledTimes(1);
+    expect(mockedFileExists).toHaveBeenCalledWith(absoluteFilePath);
+    expect(mockedCopyFile).toHaveBeenCalledTimes(1);
+    expect(mockedCopyFile).toHaveBeenCalledWith(absoluteFilePath, `${jobObj.getJobFileDirectory()}/${filename}`, true);
+});
+
 
 test('Test load job', async () => {
     const jobObj = await ExecutableJob.loadTask(jobAttributes.id);

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
@@ -94,7 +94,8 @@ const defaultParameters = {
     timeAttribute: 'timeattrib',
     withGeometries: false,
     detailed: false,
-    cpuCount: 1
+    cpuCount: 1,
+    csvFile: { location: 'upload' as const }
 };
 
 const defaultAttributes = {

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -93,6 +93,7 @@ jest.mock('../../../models/db/odPairs.db.queries');
 
 const defaultParameters = {
     calculationName: 'test',
+    csvFile: { location: 'upload' as const },
     projection: 'test',
     idAttribute: 'id',
     originXAttribute: 'origX',

--- a/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
@@ -20,7 +20,6 @@ import { TransitBatchDemandFromCsvAttributes } from 'chaire-lib-common/lib/api/T
 export interface TransitDemandFromCsvAttributes
     extends GenericAttributes,
         Partial<TransitBatchDemandFromCsvAttributes> {
-    csvFile?: string | File;
     // TODO Remove these from this object once trRouting is parallel
     maxCpuCount?: number;
 }
@@ -87,9 +86,12 @@ export abstract class TransitDemandFromCsv<T extends TransitDemandFromCsvAttribu
         }
     }
 
-    setCsvFile = async (file: string | File) => {
+    setCsvFile = async (
+        file: string | File | NodeJS.ReadableStream,
+        fileLocation: { location: 'upload' } | { location: 'server'; fromJob: number }
+    ) => {
         let csvFileAttributes: string[] = [];
-        this.attributes.csvFile = file;
+        this.attributes.csvFile = fileLocation;
         await parseCsvFile(
             file,
             (data) => {

--- a/packages/transition-common/src/services/transitDemand/__tests__/TransitOdDemandFromCsv.test.ts
+++ b/packages/transition-common/src/services/transitDemand/__tests__/TransitOdDemandFromCsv.test.ts
@@ -173,14 +173,14 @@ describe('setCsvFile', () => {
             'destinationXAttribute', 'destinationYAttribute'];
         const file = 'justAFile.csv';
 
-        const csvFields = await batchRouting.setCsvFile(file);
+        const csvFields = await batchRouting.setCsvFile(file, { location: 'upload' });
 
         // Validte calls and return values
         expect(csvFields).toEqual(Object.keys(csvObjects));
         expect(parseCsvFileMock).toHaveBeenCalledTimes(1);
         expect(parseCsvFileMock).toHaveBeenCalledWith(file, expect.anything(), { header: true, nbRows: 1});
         expect(batchRouting.attributes).toEqual(expect.objectContaining({
-            csvFile: file,
+            csvFile: { location: 'upload' },
         }));
         
         expect(expectedUndefined.find((name) => batchRouting.attributes[name] !== undefined)).toBeUndefined();
@@ -192,7 +192,7 @@ describe('setCsvFile', () => {
 
         const batchRoutingAttributes = {
             calculationName: 'calculationName',
-            csvFile: 'previousFile.csv',
+            csvFile: { location: 'upload' as const },
             idAttribute: 'field1',
             timeAttributeDepartureOrArrival: 'arrival' as const,
             timeFormat: 'timeFormat',
@@ -208,7 +208,7 @@ describe('setCsvFile', () => {
         const batchRouting = new TransitOdDemandFromCsv(_cloneDeep(batchRoutingAttributes), false);
         const file = 'justAFile.csv';
     
-        const csvFields = await batchRouting.setCsvFile(file);
+        const csvFields = await batchRouting.setCsvFile(file, { location: 'upload' });
 
         // Validte calls and return values
         expect(csvFields).toEqual(Object.keys(csvObjects));
@@ -217,7 +217,7 @@ describe('setCsvFile', () => {
         
         expect(batchRouting.attributes).toEqual(expect.objectContaining({
             ...batchRoutingAttributes,
-            csvFile: file
+            csvFile: { location: 'upload' }
         }));
     });
 
@@ -227,7 +227,7 @@ describe('setCsvFile', () => {
 
         const batchRoutingAttributes = {
             calculationName: 'calculationName',
-            csvFile: 'previousFile.csv',
+            csvFile: { location: 'upload' as const },
             idAttribute: 'idAttribute',
             timeAttributeDepartureOrArrival: 'arrival' as const,
             timeFormat: 'timeFormat',
@@ -245,14 +245,14 @@ describe('setCsvFile', () => {
             'destinationXAttribute', 'destinationYAttribute'];
         const file = 'justAFile.csv';
         
-        const csvFields = await batchRouting.setCsvFile(file);
+        const csvFields = await batchRouting.setCsvFile(file, { location: 'upload' });
 
         // Validte calls and return values
         expect(csvFields).toEqual(Object.keys(csvObjects));
         expect(parseCsvFileMock).toHaveBeenCalledTimes(1);
         expect(parseCsvFileMock).toHaveBeenCalledWith(file, expect.anything(), { header: true, nbRows: 1});
         expect(batchRouting.attributes).toEqual(expect.objectContaining({
-            csvFile: file,
+            csvFile: { location: 'upload' },
             calculationName: batchRoutingAttributes.calculationName,
             timeAttributeDepartureOrArrival: batchRoutingAttributes.timeAttributeDepartureOrArrival,
             timeFormat: batchRoutingAttributes.timeFormat,

--- a/packages/transition-common/src/services/transitRouting/__tests__/TransitBatchRoutingCalculator.test.ts
+++ b/packages/transition-common/src/services/transitRouting/__tests__/TransitBatchRoutingCalculator.test.ts
@@ -38,7 +38,7 @@ describe('Test Calculate', () => {
     const defaultDemandAttributes = {
         calculationName: 'test',
         projection: 'projection',
-        csvFile: 'filename',
+        csvFile: { location: 'upload' as const },
         timeAttributeDepartureOrArrival: 'arrival' as const,
         timeFormat: 'HH:MM',
         timeAttribute: 'time',
@@ -76,7 +76,8 @@ describe('Test Calculate', () => {
             timeAttribute: defaultDemandAttributes.timeAttribute,
             withGeometries: defaultDemandAttributes.withGeometries,
             cpuCount: defaultDemandAttributes.cpuCount,
-            saveToDb: defaultDemandAttributes.saveToDb
+            saveToDb: defaultDemandAttributes.saveToDb,
+            csvFile: { location: 'upload' }
         }
     }
 
@@ -85,7 +86,7 @@ describe('Test Calculate', () => {
         expect(result).toEqual(defaultResponse);
 
         expect(batchRouteSocketMock).toHaveBeenCalledTimes(1);
-        expect(batchRouteSocketMock).toHaveBeenCalledWith(expectedDemand, defaultQueryParams, expect.anything())
+        expect(batchRouteSocketMock).toHaveBeenCalledWith( expectedDemand, defaultQueryParams, expect.anything())
     });
 
     test('Calculate with valid values, but server error', async () => {
@@ -95,12 +96,12 @@ describe('Test Calculate', () => {
             .toThrowError('cannot calculate transit batch route with trRouting: arbitrary error');
 
         expect(batchRouteSocketMock).toHaveBeenCalledTimes(1);
-        expect(batchRouteSocketMock).toHaveBeenCalledWith(expectedDemand, defaultQueryParams, expect.anything())
+        expect(batchRouteSocketMock).toHaveBeenCalledWith( expectedDemand, defaultQueryParams, expect.anything())
     });
 
     test('Calculate with invalid demand parameters', async () => {
         // File set but no other attribute
-        const invalidDemand = new TransitOdDemandFromCsv({ csvFile: 'myfile'});
+        const invalidDemand = new TransitOdDemandFromCsv({ csvFile: { location: 'upload' as const }});
         await expect(async () => await TransitBatchRoutingCalculator.calculate(invalidDemand, defaultQueryParams))
             .rejects
             .toThrowError('cannot calculate transit batch route: the CSV file data is invalid');

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -55,6 +55,7 @@ interface BatchAccessibilityMapFormState extends ChangeEventsState<TransitBatchA
     batchRoutingInProgress: boolean;
     errors: ErrorMessage[];
     warnings: ErrorMessage[];
+    csvFile?: File;
 }
 
 // TODO This class has A LOT in common with TransitRoutingBatchForm. We should
@@ -91,16 +92,17 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
         };
     }
 
-    onCsvFileChange = (file) => {
+    onCsvFileChange = (file: File) => {
         // ** File upload
 
         const batchRouting = this.state.object;
 
-        batchRouting.attributes.csvFile = file;
+        batchRouting.attributes.csvFile = { location: 'upload' };
 
         this.state.object.validate();
 
         this.setState({
+            csvFile: file,
             object: batchRouting,
             csvAttributes: undefined,
             geojsonDownloadUrl: null,
@@ -113,8 +115,8 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
     };
 
     onSubmitCsv = async () => {
-        if (this.state.object.attributes.csvFile !== undefined) {
-            const csvAttributes = await this.state.object.setCsvFile(this.state.object.attributes.csvFile);
+        if (this.state.csvFile !== undefined) {
+            const csvAttributes = await this.state.object.setCsvFile(this.state.csvFile, { location: 'upload' });
             this.setState({
                 object: this.state.object,
                 csvAttributes

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -18,8 +18,16 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 import ConfirmCalculationForm from './stepForms/ConfirmCalculationForm';
 import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
+import { TransitBatchRoutingDemandAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
 
 export interface BatchCalculationFormProps {
+    initialValues?: {
+        parameters: BatchCalculationParameters;
+        demand: TransitBatchRoutingDemandAttributes;
+
+        csvFields: string[];
+    };
     availableRoutingModes?: string[];
     onEnd: () => void;
 }
@@ -45,9 +53,19 @@ const BatchCalculationForm: React.FunctionComponent<BatchCalculationFormProps & 
     );
     const [currentStep, setCurrentStep] = React.useState(0);
     const [nextEnabled, setNextEnabled] = React.useState(false);
-    const [demand, setDemand] = React.useState<TransitDemandFromCsvFile | undefined>(undefined);
+    const [demand, setDemand] = React.useState<TransitDemandFromCsvFile | undefined>(
+        props.initialValues !== undefined
+            ? {
+                type: 'csv' as const,
+                csvFields: props.initialValues.csvFields,
+                demand: new TransitOdDemandFromCsv(props.initialValues.demand.configuration)
+            }
+            : undefined
+    );
     const [routingParameters, setRoutingParameters] = React.useState<BatchCalculationParameters>(
-        _cloneDeep(Preferences.get('transit.routing.transit', { routingModes: [], withAlternatives: false }))
+        props.initialValues !== undefined
+            ? props.initialValues.parameters
+            : _cloneDeep(Preferences.get('transit.routing.transit', { routingModes: [], withAlternatives: false }))
     );
 
     const onScenarioCollectionUpdate = () => {

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
@@ -8,15 +8,38 @@ import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import _get from 'lodash.get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 
 import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
+import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
+import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import { TransitBatchRoutingDemandAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
+import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 
 interface BatchCalculationListProps extends WithTranslation {
-    onNewAnalysis: () => void;
+    onNewAnalysis: (parameters?: {
+        parameters: BatchCalculationParameters;
+        demand: TransitBatchRoutingDemandAttributes;
+        csvFields: string[];
+    }) => void;
 }
 
 const BatchCalculationList: React.FunctionComponent<BatchCalculationListProps> = (props: BatchCalculationListProps) => {
+    const [errors, setErrors] = React.useState<ErrorMessage[]>([]);
+    const replayJob = async (jobId: number) => {
+        try {
+            const parameters = await TransitBatchRoutingCalculator.getCalculationParametersForJob(jobId);
+            props.onNewAnalysis(parameters);
+        } catch (error) {
+            setErrors([
+                TrError.isTrError(error)
+                    ? error.export().localizedMessage
+                    : 'transit:batchCalculation:errors:ErrorGettingReplayParameters'
+            ]);
+        }
+    };
     return (
         <div className="tr__list-simulations-container">
             <h3>
@@ -33,10 +56,15 @@ const BatchCalculationList: React.FunctionComponent<BatchCalculationListProps> =
                     icon={faPlus}
                     iconClass="_icon"
                     label={props.t('transit:batchCalculation:New')}
-                    onClick={props.onNewAnalysis}
+                    onClick={(e) => props.onNewAnalysis()}
                 />
             </div>
-            <ExecutableJobComponent defaultPageSize={10} jobType="batchRoute" />
+            {errors.length > 0 && <FormErrors errors={errors} />}
+            <ExecutableJobComponent
+                customActions={[{ callback: replayJob, title: 'transit:batchCalculation:ReplayJob', icon: faRedoAlt }]}
+                defaultPageSize={10}
+                jobType="batchRoute"
+            />
         </div>
     );
 };

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -11,6 +11,9 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import BatchCalculationList from './BatchCalculationList';
 import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import BatchCalculationForm from './BatchCalculationForm';
+import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import { TransitOdDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
+import { TransitBatchRoutingDemandAttributes } from 'chaire-lib-common/lib/api/TrRouting';
 
 export interface CalculationPanelPanelProps {
     availableRoutingModes?: string[];
@@ -23,9 +26,26 @@ const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & Wit
         serviceLocator.collectionManager.get('scenarios')
     );
     const [isNewAnalysis, setIsNewAnalysis] = React.useState(false);
+    const [initialValues, setInitialValues] = React.useState<
+        | {
+              parameters: BatchCalculationParameters;
+              demand: TransitBatchRoutingDemandAttributes;
+              csvFields: string[];
+          }
+        | undefined
+    >(undefined);
 
     const onScenarioCollectionUpdate = () => {
         setScenarioCollection(serviceLocator.collectionManager.get('scenarios'));
+    };
+
+    const onNewAnalysis = (parameters?: {
+        parameters: BatchCalculationParameters;
+        demand: TransitBatchRoutingDemandAttributes;
+        csvFields: string[];
+    }) => {
+        setInitialValues(parameters);
+        setIsNewAnalysis(true);
     };
 
     React.useEffect(() => {
@@ -37,10 +57,11 @@ const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & Wit
 
     return (
         <div id="tr__form-transit-calculation-panel" className="tr__form-transit-calculation-panel tr__panel">
-            {isNewAnalysis === false && <BatchCalculationList onNewAnalysis={() => setIsNewAnalysis(true)} />}
+            {isNewAnalysis === false && <BatchCalculationList onNewAnalysis={onNewAnalysis} />}
             {isNewAnalysis && (
                 <BatchCalculationForm
                     availableRoutingModes={props.availableRoutingModes}
+                    initialValues={initialValues}
                     // TODO This function should receive some parameter, whether it is cancelled or a calculation is pending.
                     onEnd={() => setIsNewAnalysis(false)}
                 />

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
@@ -40,7 +40,13 @@ const ConfirmCalculationForm: React.FunctionComponent<ConfirmCalculationFormProp
                     </tr>
                     <tr>
                         <th>{props.t('main:CsvFile')}</th>
-                        <td>{(demandAttributes.csvFile as File).name}</td>
+                        <td>
+                            {props.t(
+                                demandAttributes.csvFile?.location === 'upload'
+                                    ? 'transit:batchCalculation:UploadedFile'
+                                    : 'transit:batchCalculation:FromPreviousJob'
+                            )}
+                        </td>
                     </tr>
                     <tr>
                         <th>{props.t('transit:transitRouting:Detailed')}</th>

--- a/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
+++ b/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
@@ -88,7 +88,8 @@ export class BatchAccessibilityMapCalculator {
             timeFormat: attributes.timeFormat as string,
             timeAttribute: attributes.timeAttribute as string,
             withGeometries: attributes.withGeometries || false,
-            cpuCount: attributes.cpuCount || 1
+            cpuCount: attributes.cpuCount || 1,
+            csvFile: { location: 'upload' }
         };
 
         try {


### PR DESCRIPTION
Let the demand support either a file coming from upload or from a preceding task on server.

Add a custom action to the batch calculation tasks list to create a new calculation from this task. It fetches the task's parameter, as well as the csv fields in the file and opens the new calculation form with those initial values.