### PR TITLE
dataSources: Add a data source owner to allow private data sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "setup": "yarn workspace chaire-lib-backend run setup",
         "setup-test": "yarn workspace chaire-lib-backend run setup-test",
         "migrate": "yarn workspace chaire-lib-backend run migrate && yarn workspace transition-backend run migrate",
-        "migrate-test": "yarn workspace chaire-lib-backend run migrate-test && yarn workspace transition-backend run migrate-test",
+        "migrate-test": "PROJECT_CONFIG=${PWD}/tests/config_test.js yarn workspace chaire-lib-backend run migrate-test && PROJECT_CONFIG=${PWD}/tests/config_test.js yarn workspace transition-backend run migrate-test",
         "clean": "yarn workspaces run clean",
         "compile": "yarn workspaces run compile",
         "compile:dev": "yarn wsrun compile:dev",

--- a/packages/transition-backend/src/api/all.socketRoutes.ts
+++ b/packages/transition-backend/src/api/all.socketRoutes.ts
@@ -21,7 +21,7 @@ import placesSocketRoutes from './places.socketRoutes';
 import jobsSocketRoutes from './jobs.socketRoutes';
 
 export default function (socket: EventEmitter, userId?: number) {
-    dataSourcesSocketRoutes(socket);
+    dataSourcesSocketRoutes(socket, userId);
     cacheSocketRoutes(socket);
     servicesSocketRoutes(socket, userId);
     transitSocketRoutesNew(socket);

--- a/packages/transition-backend/src/api/dataSources.socketRoutes.ts
+++ b/packages/transition-backend/src/api/dataSources.socketRoutes.ts
@@ -15,10 +15,10 @@ import dataSourcesDbQueries from '../models/db/dataSources.db.queries';
  * @export
  * @param {EventEmitter} socket The socket to register the routes to
  */
-export default function (socket: EventEmitter) {
+export default function (socket: EventEmitter, userId?: number) {
     socket.on('dataSources.collection', async (_dataSourceId, callback) => {
         try {
-            const collection = await dataSourcesDbQueries.collection();
+            const collection = await dataSourcesDbQueries.collection({ userId });
             callback({ collection });
         } catch (error) {
             console.error(error);

--- a/packages/transition-backend/src/models/db/dataSources.db.queries.ts
+++ b/packages/transition-backend/src/models/db/dataSources.db.queries.ts
@@ -26,14 +26,12 @@ const tableName = 'tr_data_sources';
 
 const collection = async (type?: DataSourceType): Promise<DataSourceAttributes[]> => {
     try {
-        const response = await knex.raw(`
-        SELECT 
-          *
-        FROM ${tableName}
-        ${type !== undefined ? `WHERE type = '${type}'` : ''}
-        ORDER BY name;
-      `);
-        const collection = response.rows;
+        const query = knex(tableName);
+        if (type !== undefined) {
+            query.where('type', type);
+        }
+        query.orderBy('name');
+        const collection = await query;
         if (collection) {
             return collection;
         }

--- a/packages/transition-backend/src/models/db/migrations/20230315184600_addDataSourceOwner.ts
+++ b/packages/transition-backend/src/models/db/migrations/20230315184600_addDataSourceOwner.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const tableName = 'tr_data_sources';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.integer('owner').nullable().index();
+        table.foreign('owner').references('users.id').onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.dropColumn('owner');
+    });
+}

--- a/packages/transition-backend/src/services/dataSources/dataSources.ts
+++ b/packages/transition-backend/src/services/dataSources/dataSources.ts
@@ -10,11 +10,12 @@ import DataSourceCollection from 'transition-common/lib/services/dataSource/Data
 import dbQueries from '../../models/db/dataSources.db.queries';
 
 export const getDataSource = async (
-    options: { isNew: true; dataSourceName: string; type: DataSourceType } | { isNew: false; dataSourceId: string }
+    options: { isNew: true; dataSourceName: string; type: DataSourceType } | { isNew: false; dataSourceId: string },
+    userId?: number
 ): Promise<DataSource> => {
     if (options.isNew === true) {
         const dataSourceCollection = new DataSourceCollection([], {});
-        const collection = await dbQueries.collection(options.type);
+        const collection = await dbQueries.collection({ type: options.type, userId: userId });
         dataSourceCollection.loadFromCollection(collection);
         const dataSource = dataSourceCollection.getByShortname(options.dataSourceName);
         if (dataSource !== undefined) {
@@ -25,13 +26,13 @@ export const getDataSource = async (
             );
         }
         const newDataSource = new DataSource(
-            { type: options.type, name: options.dataSourceName, shortname: options.dataSourceName },
+            { type: options.type, name: options.dataSourceName, shortname: options.dataSourceName, owner: userId },
             true
         );
         await dbQueries.create(newDataSource.attributes);
         return newDataSource;
     } else {
-        const dsAttributes = await dbQueries.read(options.dataSourceId);
+        const dsAttributes = await dbQueries.read(options.dataSourceId, userId);
         return new DataSource(dsAttributes, false);
     }
 };

--- a/packages/transition-backend/src/services/simulation/methods/AccessibilityMapSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/AccessibilityMapSimulation.ts
@@ -49,7 +49,7 @@ export class AccessMapSimulationDescriptor implements SimulationAlgorithmDescrip
             i18nName: 'transit:simulation:simulationMethods:AccessMapDataSources',
             type: 'select' as const,
             choices: async () => {
-                const dataSources = await dataSourceDbQueries.collection('places');
+                const dataSources = await dataSourceDbQueries.collection({ type: 'places' });
                 return dataSources.map((ds) => ({
                     value: ds.id,
                     label: ds.shortname

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
@@ -58,7 +58,7 @@ export class OdTripSimulationDescriptor implements SimulationAlgorithmDescriptor
             i18nName: 'transit:simulation:simulationMethods:OdTripsDataSource',
             type: 'select' as const,
             choices: async () => {
-                const dataSources = await dataSourceDbQueries.collection('odTrips');
+                const dataSources = await dataSourceDbQueries.collection({ type: 'odTrips' });
                 return dataSources.map((ds) => ({
                     value: ds.id,
                     label: ds.shortname

--- a/packages/transition-common/src/services/dataSource/DataSource.ts
+++ b/packages/transition-common/src/services/dataSource/DataSource.ts
@@ -30,6 +30,7 @@ export type DataSourceType = typeof dataSourceTypesArray[number];
 
 export interface DataSourceAttributes extends GenericAttributes {
     type: DataSourceType;
+    owner?: number;
 }
 
 class DataSource extends ObjectWithHistory<DataSourceAttributes> {


### PR DESCRIPTION
Add a `owner` column to the data source, which can be null (for global data sources), or a foreign key to the userId. Queries are updated so they take an optional userId parameter to retrieve only allowed data sources (since data sources are currently mostly used in tasks, like simulations, which do not have a userId, we can't make this parameter mandatory for now).

For now, the main intention is to allow users to import private odTrip data, without sharing it with all users (odTrip import feature is currently not working, but when it is brought back, the option to import a global data source (with null owner) will be available)