### PR TITLE
batchRoute: Refactor result handling

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/ResultAttributes.ts
+++ b/packages/transition-backend/src/services/transitRouting/ResultAttributes.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash.clonedeep';
+import {
+    base as baseAttributes,
+    transit as transitAttributes,
+    steps as transitStepsAttributes
+} from '../../config/trRoutingAttributes';
+import { routingModes, RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+
+export const getDefaultCsvAttributes = (modes: RoutingOrTransitMode[]): { [key: string]: string | number | null } => {
+    const csvAttributes = _cloneDeep(baseAttributes);
+    if (modes.includes('transit')) {
+        Object.assign(csvAttributes, _cloneDeep(transitAttributes));
+    }
+    // Add a time and distance column per non-transit mode
+    modes.forEach((mode: any) => {
+        if (routingModes.includes(mode)) {
+            csvAttributes[`only${mode.charAt(0).toUpperCase() + mode.slice(1)}TravelTimeSeconds`] = null;
+            csvAttributes[`only${mode.charAt(0).toUpperCase() + mode.slice(1)}DistanceMeters`] = null;
+        }
+    });
+    return csvAttributes;
+};
+
+export const getDefaultStepsAttributes = () => {
+    return _cloneDeep(transitStepsAttributes);
+};

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import fs from 'fs';
+
+import { TransitBatchRoutingDemandFromCsvAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import TransitRouting from 'transition-common/lib/services/transitRouting/TransitRouting';
+import { getDefaultCsvAttributes, getDefaultStepsAttributes } from './ResultAttributes';
+import { OdTripRouteOutput } from './types';
+
+const CSV_FILE_NAME = 'batchRoutingResults.csv';
+const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';
+const GEOMETRY_FILE_NAME = 'batchRoutingGeometryResults.geojson';
+
+export interface BatchRoutingResultProcessor {
+    processResult: (routingResult: OdTripRouteOutput) => void;
+    end: () => void;
+    getFiles: () => { input: string; csv?: string; detailedCsv?: string; geojson?: string };
+}
+
+/**
+ * Factory method to create a batch routing result processor to files
+ *
+ * @param absoluteDirectory Directory, relative to the project directory,
+ * where to save the result files
+ */
+export const createRoutingFileResultProcessor = (
+    absoluteDirectory: string,
+    parameters: TransitBatchRoutingDemandFromCsvAttributes,
+    routing: TransitRouting,
+    inputFileName: string
+): BatchRoutingResultProcessor => {
+    return new BatchRoutingResultProcessorFile(absoluteDirectory, parameters, routing, inputFileName);
+};
+
+class BatchRoutingResultProcessorFile implements BatchRoutingResultProcessor {
+    private readonly resultsCsvFilePath = `${this.absoluteDirectory}/${CSV_FILE_NAME}`;
+    private readonly resultsCsvDetailedFilePath = `${this.absoluteDirectory}/${DETAILED_CSV_FILE_NAME}`;
+    private readonly resultsGeojsonGeometryFilePath = `${this.absoluteDirectory}/${GEOMETRY_FILE_NAME}`;
+    private readonly inputFile = `${this.absoluteDirectory}/${this.inputFileName}`;
+    private csvStream: fs.WriteStream | undefined;
+    private csvDetailedStream: fs.WriteStream | undefined;
+    private geometryStream: fs.WriteStream | undefined;
+    private geometryStreamHasData = false;
+
+    constructor(
+        private absoluteDirectory: string,
+        private parameters: TransitBatchRoutingDemandFromCsvAttributes,
+        private routing: TransitRouting,
+        private inputFileName: string
+    ) {
+        this.initResultFiles();
+    }
+    private initResultFiles = () => {
+        const csvAttributes = getDefaultCsvAttributes(this.routing.attributes.routingModes || []);
+
+        this.csvStream = fs.createWriteStream(this.resultsCsvFilePath);
+        this.csvStream.on('error', console.error);
+        this.csvStream.write(Object.keys(csvAttributes).join(',') + '\n');
+        if (this.parameters.detailed) {
+            this.csvDetailedStream = fs.createWriteStream(this.resultsCsvDetailedFilePath);
+            this.csvDetailedStream.on('error', console.error);
+            this.csvDetailedStream.write(Object.keys(getDefaultStepsAttributes()).join(',') + '\n');
+        }
+        if (this.parameters.withGeometries) {
+            this.geometryStream = fs.createWriteStream(this.resultsGeojsonGeometryFilePath);
+            this.geometryStream.on('error', console.error);
+            this.geometryStream.write('{ "type": "FeatureCollection", "features": [');
+        }
+    };
+
+    processResult = (routingResult: OdTripRouteOutput) => {
+        if (this.geometryStream && routingResult.geometries && routingResult.geometries.length > 0) {
+            // Write the geometry in the stream
+            this.geometryStream.write(
+                (this.geometryStreamHasData ? ',\n' : '\n') +
+                    routingResult.geometries.map((geometry) => JSON.stringify(geometry)).join(',\n')
+            );
+            this.geometryStreamHasData = true;
+        }
+        if (this.csvStream && routingResult.csv && routingResult.csv.length > 0) {
+            this.csvStream.write(routingResult.csv.join('\n') + '\n');
+        }
+        if (this.csvDetailedStream && routingResult.csvDetailed && routingResult.csvDetailed.length > 0) {
+            this.csvDetailedStream.write(routingResult.csvDetailed.join('\n') + '\n');
+        }
+    };
+
+    end = () => {
+        if (this.csvStream) {
+            this.csvStream.end();
+        }
+        if (this.csvDetailedStream) {
+            this.csvDetailedStream.end();
+        }
+        if (this.geometryStream) {
+            this.geometryStream.write('\n]}');
+            this.geometryStream.end();
+        }
+    };
+
+    getFiles = () => ({
+        input: this.inputFileName,
+        csv: CSV_FILE_NAME,
+        detailedCsv: this.parameters.detailed ? DETAILED_CSV_FILE_NAME : undefined,
+        geojson: this.parameters.withGeometries ? GEOMETRY_FILE_NAME : undefined
+    });
+}

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
@@ -24,6 +24,7 @@ import { ErrorCodes, TrRoutingRoute } from 'chaire-lib-common/lib/services/trRou
 import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
 import { routeToUserObject } from 'chaire-lib-common/lib/services/trRouting/TrRoutingResultConversion';
 import { getDefaultCsvAttributes, getDefaultStepsAttributes } from './ResultAttributes';
+import { OdTripRouteOutput } from './types';
 // TODO Should this file go in the backend?
 
 interface RouteOdTripParameters {
@@ -45,10 +46,7 @@ interface RouteOdTripParameters {
     pathCollection?: PathCollection;
 }
 
-const routeOdTrip = async function (
-    odTrip: BaseOdTrip,
-    parameters: RouteOdTripParameters
-): Promise<{ csv?: string[]; csvDetailed?: string[]; geometries?: GeoJSON.Feature[]; result?: TransitRoutingResult }> {
+const routeOdTrip = async function (odTrip: BaseOdTrip, parameters: RouteOdTripParameters): Promise<OdTripRouteOutput> {
     const routingAttributes: TransitRoutingAttributes = Object.assign({}, parameters.routing.getAttributes());
     // TODO Manage routing port in a better way
     (routingAttributes as any).routingPort = parameters.trRoutingPort;

--- a/packages/transition-backend/src/services/transitRouting/__tests__/ResultAttributes.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/ResultAttributes.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash.clonedeep';
+
+import {
+    base as baseAttributes,
+    transit as transitAttributes,
+    steps as stepAttributes
+} from '../../../config/trRoutingAttributes';
+import { getDefaultCsvAttributes, getDefaultStepsAttributes } from '../ResultAttributes';
+
+describe('getDefaultCsvAttributes', () => {
+    test('No modes', () => {
+        const csvAttributes = getDefaultCsvAttributes([]);
+        expect(csvAttributes).toEqual(baseAttributes);
+
+        // Make sure the received attributes are modifiable and unique, by modifying the object and making sure a new object is identical to the original
+        const originalAttributes = _cloneDeep(csvAttributes);
+        csvAttributes.uuid = 'blabla';
+        const csvAttributes2 = getDefaultCsvAttributes([]);
+        expect(csvAttributes2.uuid).not.toEqual(csvAttributes.uuid);
+        expect(csvAttributes2).toEqual(originalAttributes);
+    });
+
+    test('Single non-transit mode', () => {
+        const modes = ['walking' as const];
+        const csvAttributes = getDefaultCsvAttributes(modes);
+        expect(csvAttributes).toEqual(expect.objectContaining(baseAttributes));
+        expect(Object.keys(csvAttributes).length).toEqual(Object.keys(baseAttributes).length + 2);
+        expect(csvAttributes[`only${modes[0].charAt(0).toUpperCase() + modes[0].slice(1)}TravelTimeSeconds`]).toBeNull();
+        expect(csvAttributes[`only${modes[0].charAt(0).toUpperCase() + modes[0].slice(1)}DistanceMeters`]).toBeNull();
+
+    });
+
+    test('Multiple non-transit modes', () => {
+        const modes = ['walking' as const, 'cycling' as const];
+        const csvAttributes = getDefaultCsvAttributes(modes);
+        expect(csvAttributes).toEqual(expect.objectContaining(baseAttributes));
+        expect(Object.keys(csvAttributes).length).toEqual(Object.keys(baseAttributes).length + 4);
+        expect(csvAttributes[`only${modes[0].charAt(0).toUpperCase() + modes[0].slice(1)}TravelTimeSeconds`]).toBeNull();
+        expect(csvAttributes[`only${modes[0].charAt(0).toUpperCase() + modes[0].slice(1)}DistanceMeters`]).toBeNull();
+        expect(csvAttributes[`only${modes[1].charAt(0).toUpperCase() + modes[1].slice(1)}TravelTimeSeconds`]).toBeNull();
+        expect(csvAttributes[`only${modes[1].charAt(0).toUpperCase() + modes[1].slice(1)}DistanceMeters`]).toBeNull();
+
+    });
+
+    test('Only transit mode', () => {
+        const modes = ['transit' as const];
+        const csvAttributes = getDefaultCsvAttributes(modes);
+        expect(csvAttributes).toEqual(expect.objectContaining(baseAttributes));
+        expect(csvAttributes).toEqual(expect.objectContaining(transitAttributes));
+        expect(Object.keys(csvAttributes).length).toEqual(Object.keys(baseAttributes).length + Object.keys(transitAttributes).length);
+    });
+
+    test('Transit and other mode', () => {
+        const modes = ['walking' as const, 'cycling' as const, 'transit' as const];
+        const csvAttributes = getDefaultCsvAttributes(modes);
+        expect(csvAttributes).toEqual(expect.objectContaining(baseAttributes));
+        expect(csvAttributes).toEqual(expect.objectContaining(transitAttributes));
+        expect(Object.keys(csvAttributes).length).toEqual(Object.keys(baseAttributes).length + Object.keys(transitAttributes).length + 4);
+        expect(csvAttributes[`only${modes[0].charAt(0).toUpperCase() + modes[0].slice(1)}TravelTimeSeconds`]).toBeNull();
+        expect(csvAttributes[`only${modes[0].charAt(0).toUpperCase() + modes[0].slice(1)}DistanceMeters`]).toBeNull();
+        expect(csvAttributes[`only${modes[1].charAt(0).toUpperCase() + modes[1].slice(1)}TravelTimeSeconds`]).toBeNull();
+        expect(csvAttributes[`only${modes[1].charAt(0).toUpperCase() + modes[1].slice(1)}DistanceMeters`]).toBeNull();
+
+    });
+});
+
+describe('getDefaultStepsAttributes', () => {
+    test('Default', () => {
+        const csvAttributes = getDefaultStepsAttributes();
+        expect(csvAttributes).toEqual(stepAttributes);
+
+        // Make sure the received attributes are modifiable and unique, by modifying the object and making sure a new object is identical to the original
+        const originalAttributes = _cloneDeep(csvAttributes);
+        csvAttributes.uuid = 'blabla';
+        const csvAttributes2 = getDefaultStepsAttributes();
+        expect(csvAttributes2.uuid).not.toEqual(csvAttributes.uuid);
+        expect(csvAttributes2).toEqual(originalAttributes);
+    });
+
+});

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -116,7 +116,7 @@ beforeEach(() => {
 
 test('Batch route to csv', async () => {
     const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, absoluteDir, inputFileName, socketMock, isCancelledMock);
+    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
@@ -137,7 +137,7 @@ test('Batch route with some errors', async () => {
     const errors = [ 'error1', 'error2' ];
     mockParseOdTripsFromCsv.mockResolvedValueOnce({ odTrips, errors });
     const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, absoluteDir, inputFileName, socketMock, isCancelledMock);
+    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
@@ -158,7 +158,7 @@ test('Batch route with too many errors', async () => {
     const errors = [ 'error1', 'error2' ];
     mockParseOdTripsFromCsv.mockRejectedValueOnce(errors);
     const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, absoluteDir, inputFileName, socketMock, isCancelledMock);
+    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(0);
     expect(mockCreateStream).toHaveBeenCalledTimes(0);
     expect(result).toEqual({
@@ -176,7 +176,7 @@ test('Batch route and save to db', async () => {
     (odPairsDbQueries.deleteForDataSourceId as any).mockClear();
 
     const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { saveToDb: {type: 'new', dataSourceName: 'name'}, calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, absoluteDir, inputFileName, socketMock, isCancelledMock);
+    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash.clonedeep';
+import { ObjectWritableMock } from 'stream-mock';
+
+
+import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+import { simplePathResult } from './TrRoutingResultStub';
+import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
+import { createRoutingFileResultProcessor } from '../TrRoutingBatchResult';
+import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
+import TransitRouting from 'transition-common/lib/services/transitRouting/TransitRouting';
+import { getDefaultCsvAttributes, getDefaultStepsAttributes } from '../ResultAttributes';
+
+const absoluteDir = `${directoryManager.userDataDirectory}/1/exports`;
+
+let fileStreams: {[key: string]: ObjectWritableMock } = {};
+const mockCreateStream = jest.fn().mockImplementation((filename: string) => {
+    fileStreams[filename] = new ObjectWritableMock();
+    return fileStreams[filename];
+});
+
+jest.mock('fs', () => {
+    // Require the original module to not be mocked...
+    const originalModule = jest.requireActual('fs');
+
+    return {
+        ...originalModule,
+        createWriteStream: (fileName: string) => mockCreateStream(fileName)
+    };
+});
+
+const odTrip = new BaseOdTrip({
+    internal_id: '1',
+    origin_geography: { type: 'Point' as const, coordinates: [ -73, 45 ]},
+    destination_geography: { type: 'Point' as const, coordinates: [ -73.1002, 45.1002 ]},
+    timeOfTrip: 8000,
+    timeType: 'departure'
+});
+
+const defaultParameters = {
+    calculationName: 'test',
+    csvFile: { location: 'upload' as const, filename: 'input.csv' },
+    projection: 'test',
+    idAttribute: 'id',
+    originXAttribute: 'origX',
+    originYAttribute: 'origX',
+    destinationXAttribute: 'origX',
+    destinationYAttribute: 'origX',
+    timeAttributeDepartureOrArrival: 'departure' as const,
+    timeFormat: 'HMM',
+    timeAttribute: 'timeattrib',
+    withGeometries: false,
+    detailed: false,
+    cpuCount: 2,
+    saveToDb: false as false
+};
+
+const results = {
+    csv: ['any,string,not,important'],
+    result: new TransitRoutingResult({
+        origin: { type: 'Feature' as const, geometry: odTrip.attributes.origin_geography, properties: {} },
+        destination: { type: 'Feature' as const, geometry: odTrip.attributes.destination_geography, properties: {} },
+        paths: simplePathResult.routes,
+        maxWalkingTime: 300
+    })
+}
+
+const resetFileStreams = () => {
+    mockCreateStream.mockClear();
+    fileStreams = {};
+}
+
+const CSV_FILE_NAME = 'batchRoutingResults.csv';
+const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';
+const GEOMETRY_FILE_NAME = 'batchRoutingGeometryResults.geojson';
+const inputFileName = 'input.csv';
+
+const getCsvFile = () => {
+    const csvFileName = Object.keys(fileStreams).find(filename => filename.endsWith(CSV_FILE_NAME));
+    expect(csvFileName).toBeDefined();
+    return fileStreams[csvFileName as string];
+}
+
+const getDetailedCsvFile = () => {
+    const fileName = Object.keys(fileStreams).find(filename => filename.endsWith(DETAILED_CSV_FILE_NAME));
+    expect(fileName).toBeDefined();
+    return fileStreams[fileName as string];
+}
+
+const getGeojsonFile = () => {
+    const fileName = Object.keys(fileStreams).find(filename => filename.endsWith(GEOMETRY_FILE_NAME));
+    expect(fileName).toBeDefined();
+    return fileStreams[fileName as string];
+}
+
+const testRoutingModes = ['walking' as const, 'transit' as const];
+describe('Only CSV results', () => {
+    let resultProcessor;
+
+    beforeAll(() => {
+        resetFileStreams();
+        resultProcessor = createRoutingFileResultProcessor(absoluteDir, Object.assign({}, defaultParameters, { detailed: false, withGeometry: false }), new TransitRouting({ routingModes: testRoutingModes }), inputFileName);
+    })
+
+    test('File initialization', () => {
+        expect(mockCreateStream).toHaveBeenCalledTimes(1);
+
+        // Only 1 stream should have been created
+        expect(Object.keys(fileStreams).length).toEqual(1);
+        const csvStream = getCsvFile();
+
+        // Make sure file header is correct
+        expect(csvStream.data.length).toEqual(1);
+        expect(csvStream.data[0]).toEqual(Object.keys(getDefaultCsvAttributes(testRoutingModes)).join(',') + '\n');
+    });
+
+    test('get files', () => {
+        expect(resultProcessor.getFiles()).toEqual({ input: inputFileName, csv: CSV_FILE_NAME, detailed: undefined, geojson: undefined });
+    });
+
+    test('Process results', () => {
+        resultProcessor.processResult(results);
+        const csvStream = getCsvFile();
+
+        // Check the data that was appended
+        expect(csvStream.data.length).toEqual(2);
+        expect(csvStream.data[1]).toEqual(results.csv[0] + '\n');
+    });
+
+    test('Process invalid results', () => {
+        resultProcessor.processResult({});
+        const csvStream = getCsvFile();
+
+        // Check that no other data was appended
+        expect(csvStream.data.length).toEqual(2);
+
+    });
+
+    test('End', () => {
+        const csvStream = getCsvFile();
+        expect(csvStream.writableEnded).toBeFalsy();
+
+        resultProcessor.end();
+        expect(csvStream.writableEnded).toBeTruthy();
+        expect(resultProcessor.getFiles()).toEqual({ input: inputFileName, csv: CSV_FILE_NAME, detailed: undefined, geojson: undefined });
+    })
+});
+
+describe('CSV and detailed results', () => {
+    let resultProcessor;
+    beforeAll(() => {
+        resetFileStreams();
+        resultProcessor = createRoutingFileResultProcessor(absoluteDir, Object.assign({}, defaultParameters, { detailed: true, withGeometry: false }), new TransitRouting({ routingModes: testRoutingModes }), inputFileName);
+    })
+
+    test('File initialization', () => {
+        expect(mockCreateStream).toHaveBeenCalledTimes(2);
+
+        // 2 streams should have been created
+        expect(Object.keys(fileStreams).length).toEqual(2);
+        const csvStream = getCsvFile();
+        const detailedStream = getDetailedCsvFile();
+
+        // Make sure file header is correct
+        expect(csvStream.data.length).toEqual(1);
+        expect(csvStream.data[0]).toEqual(Object.keys(getDefaultCsvAttributes(testRoutingModes)).join(',') + '\n');
+
+        expect(detailedStream.data.length).toEqual(1);
+        expect(detailedStream.data[0]).toEqual(Object.keys(getDefaultStepsAttributes()).join(',') + '\n');
+        
+    });
+
+    test('get files', () => {
+        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: DETAILED_CSV_FILE_NAME, geojson: undefined });
+    });
+
+    test('Process results', () => {
+        const detailedResults = ['csv,for,first,step','csv,for,second,step'];
+        const resultsWithDetailed = Object.assign({}, results, {csvDetailed: detailedResults});
+        resultProcessor.processResult(resultsWithDetailed);
+        const csvStream = getCsvFile();
+        const detailedStream = getDetailedCsvFile();
+
+        // Check the data that was appended
+        expect(csvStream.data.length).toEqual(2);
+        expect(csvStream.data[1]).toEqual(results.csv[0] + '\n');
+
+        expect(detailedStream.data.length).toEqual(2);
+        expect(detailedStream.data[1]).toEqual(detailedResults[0] + '\n' + detailedResults[1] + '\n');
+    });
+
+    test('Process invalid results', () => {
+        // No detailed results
+        resultProcessor.processResult(results);
+        const detailedStream = getDetailedCsvFile();
+
+        // Check that no other data was appended
+        expect(detailedStream.data.length).toEqual(2);
+    });
+
+    test('End', () => {
+        const csvStream = getCsvFile();
+        const detailedStream = getDetailedCsvFile();
+        expect(csvStream.writableEnded).toBeFalsy();
+        expect(detailedStream.writableEnded).toBeFalsy();
+
+        resultProcessor.end();
+        expect(csvStream.writableEnded).toBeTruthy();
+        expect(detailedStream.writableEnded).toBeTruthy();
+        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: DETAILED_CSV_FILE_NAME, geojson: undefined });
+    })
+});
+
+
+describe('CSV and geojson results', () => {
+    let resultProcessor;
+    beforeAll(() => {
+        resetFileStreams();
+        resultProcessor = createRoutingFileResultProcessor(absoluteDir, Object.assign({}, defaultParameters, { detailed: false, withGeometries: true }), new TransitRouting({ routingModes: testRoutingModes }), inputFileName);
+    })
+
+    test('File initialization', () => {
+        expect(mockCreateStream).toHaveBeenCalledTimes(2);
+
+        // 2 streams should have been created
+        expect(Object.keys(fileStreams).length).toEqual(2);
+        const csvStream = getCsvFile();
+        const geojsonStream = getGeojsonFile();
+
+        // Make sure file header is correct
+        expect(csvStream.data.length).toEqual(1);
+        expect(csvStream.data[0]).toEqual(Object.keys(getDefaultCsvAttributes(testRoutingModes)).join(',') + '\n');
+
+        expect(geojsonStream.data.length).toEqual(1);
+        expect(geojsonStream.data[0]).toEqual('{ "type": "FeatureCollection", "features": [');
+        
+    });
+
+    test('get files', () => {
+        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: undefined, geojson: GEOMETRY_FILE_NAME });
+    });
+
+    test('Process results', () => {
+        // Just add any geojson feature, taken from the data we already have
+        const features = [odTrip.attributes.origin_geography, odTrip.attributes.destination_geography];
+        const resultsWithGeometries = Object.assign({}, results, {geometries: features});
+        resultProcessor.processResult(resultsWithGeometries);
+        const csvStream = getCsvFile();
+        const geojsonStream = getGeojsonFile();
+
+        // Check the data that was appended
+        expect(csvStream.data.length).toEqual(2);
+        expect(csvStream.data[1]).toEqual(results.csv[0] + '\n');
+
+        expect(geojsonStream.data.length).toEqual(2);
+        expect(geojsonStream.data[1]).toEqual(`\n${JSON.stringify(features[0])},\n${JSON.stringify(features[1])}`);
+
+        // Process the results a second time to make sure a comma was added
+        resultProcessor.processResult(resultsWithGeometries);
+        expect(geojsonStream.data.length).toEqual(3);
+        expect(geojsonStream.data[2]).toEqual(`,\n${JSON.stringify(features[0])},\n${JSON.stringify(features[1])}`);
+    });
+
+    test('Process invalid results', () => {
+        // No geometries results
+        resultProcessor.processResult(results);
+        const geojsonStream = getGeojsonFile();
+
+        // Check that no other data was appended
+        expect(geojsonStream.data.length).toEqual(3);
+    });
+
+    test('End', () => {
+        const csvStream = getCsvFile();
+        const geojsonStream = getGeojsonFile();
+        expect(csvStream.writableEnded).toBeFalsy();
+        expect(geojsonStream.writableEnded).toBeFalsy();
+        
+        resultProcessor.end();
+        expect(csvStream.writableEnded).toBeTruthy();
+        expect(geojsonStream.writableEnded).toBeTruthy();
+        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: undefined, geojson: GEOMETRY_FILE_NAME });
+
+        // make sure the geojson content is valid geojson
+        const geojsonString = geojsonStream.data.join('');
+        const geojsonObj = JSON.parse(geojsonString);
+        expect(geojsonObj.type).toEqual('FeatureCollection');
+        expect(geojsonObj.features.length).toEqual(4);
+    })
+});

--- a/packages/transition-backend/src/services/transitRouting/types.ts
+++ b/packages/transition-backend/src/services/transitRouting/types.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Feature, GeoJsonProperties, Geometry } from 'geojson';
+import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+
+export type OdTripRouteOutput = {
+    csv?: string[] | undefined;
+    csvDetailed?: string[] | undefined;
+    geometries?: Feature<Geometry, GeoJsonProperties>[] | undefined;
+    result?: TransitRoutingResult | undefined;
+};

--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -74,10 +74,12 @@ const wrapBatchRoute = async (task: ExecutableJob<BatchRouteJobType>) => {
     const { files, ...result } = await batchRoute(
         task.attributes.data.parameters.demandAttributes,
         task.attributes.data.parameters.transitRoutingAttributes,
-        absoluteUserDir,
-        inputFileName,
-        newProgressEmitter(),
-        getTaskCancelledFct(task)
+        {
+            absoluteBaseDirectory: absoluteUserDir,
+            inputFileName,
+            progressEmitter: newProgressEmitter(),
+            isCancelled: getTaskCancelledFct(task)
+        }
     );
     task.attributes.data.results = result;
     task.attributes.resources = { files };


### PR DESCRIPTION
As part of the work to handle checkpoints and job resume, this extracts the result handling to its own class, like it is already done in the batch accessibility map calculation.

The main batchRoute method is refactored to be handled by a class, with parameters and options as local fields, that can more easily be split in modular chunks