### PR TITLE
jobs: Remove await from job when restarted at the beginning

### DIFF
--- a/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
+++ b/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
@@ -40,7 +40,7 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
             console.log(`Enqueuing ${runningAndPending.jobs.length} in progress and pending jobs`);
             for (let i = 0; i < runningAndPending.jobs.length; i++) {
                 const job = new ExecutableJob<TData>(runningAndPending.jobs[i] as JobAttributes<TData>);
-                await job.enqueue(progressEmitter);
+                job.enqueue(progressEmitter);
             }
 
             return true;

--- a/packages/transition-backend/src/services/executableJob/__tests__/ExecutableJob.test.ts
+++ b/packages/transition-backend/src/services/executableJob/__tests__/ExecutableJob.test.ts
@@ -8,6 +8,7 @@ import _cloneDeep from 'lodash.clonedeep';
 import { EventEmitter } from 'events';
 import each from 'jest-each';
 
+import { TestUtils } from 'chaire-lib-common/lib/test';
 import { JobAttributes } from 'transition-common/lib/services/jobs/Job';
 import { execJob } from '../../../tasks/serverWorkerPool';
 import { ExecutableJob } from '../ExecutableJob';
@@ -164,6 +165,8 @@ describe('Test resume running and pending', () => {
         }];
         mockedJobCollection.mockResolvedValueOnce({ jobs: jobsToRun, totalCount: jobsToRun.length })
         expect(await ExecutableJob.enqueueRunningAndPendingJobs(progressEmitter)).toEqual(true);
+        // Wait for the jobs to have been enqueued and saved
+        await TestUtils.flushPromises();
         expect(mockedJobCollection).toHaveBeenCalledWith(expect.objectContaining({
             statuses: ['inProgress', 'pending'],
             pageIndex: 0,


### PR DESCRIPTION
The await for the enqueue effectively waits for the whole job to be complete! This is not desired.