### PR TITLE
batchRoute: Allow batch routing jobs to be resumed

### DIFF
--- a/packages/transition-backend/src/api/__tests__/jobs.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/jobs.socketRoutes.test.ts
@@ -47,7 +47,7 @@ describe('Jobs list', () => {
     });
 
     test('List jobs properly', (done) => {
-        const jobs = [{id: 1, user_id: userId, name: 'test', status: 'pending' as const, data: {}}];
+        const jobs = [{id: 1, user_id: userId, name: 'test', status: 'pending' as const, internal_data: {}, data: {}}];
         mockedCollection.mockResolvedValueOnce({ jobs, totalCount: 1 });
         socketStub.emit('executableJobs.list', {}, async (status) => {
             expect(Status.isStatusOk(status)).toEqual(true);
@@ -89,6 +89,7 @@ describe('Job files', () => {
         name: 'test' as const,
         user_id: 3,
         status: 'completed',
+        internal_data: {},
         data: { parameters: { foo: 'bar' } },
         resources: { files: { testFile: 'file.csv', testFile2: 'noExtension', testFile3: 'doesNotExist.csv' } },
         created_at: '2022-08-08 13:21:34',

--- a/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
@@ -45,17 +45,24 @@ const newObjectAttributes: Omit<JobAttributes<TestJobType>, 'id'> = {
     status: 'pending' as const,
     name: 'test' as const,
     user_id: userAttributes.id,
+    internal_data: {},
     data: data.data
 };
 
 const updatedAttributes = {
-    status: 'inProgress' as const
+    status: 'inProgress' as const,
+    internal_data: {
+        checkpoint: 34
+    }
 }
 
 const newObjectAttributes2: Omit<JobAttributes<TestJobType2>, 'id'> = {
     status: 'completed' as const,
     name: 'test2' as const,
     user_id: userAttributes.id,
+    internal_data: {
+        checkpoint: 0
+    },
     data: data.data,
     resources: { files: { myFile: '/path/to/file' } }
 };
@@ -119,7 +126,7 @@ describe(`${objectName}`, () => {
         const updatedObject = await dbQueries.read(currentIdForObject1 as number);
         for (const attribute in updatedAttributes)
         {
-            expect(updatedObject[attribute]).toBe(updatedAttributes[attribute]);
+            expect(updatedObject[attribute]).toEqual(updatedAttributes[attribute]);
         }
 
     });
@@ -162,7 +169,7 @@ describe(`${objectName}`, () => {
         expect(error).toBeDefined();
 
         // Update the object1 to its original value
-        await dbQueries.update(currentIdForObject1 as number, { status: newObjectAttributes.status });
+        await dbQueries.update(currentIdForObject1 as number, { status: newObjectAttributes.status, internal_data: newObjectAttributes.internal_data });
     });
 
     test('Read collections by job type', async() => {

--- a/packages/transition-backend/src/models/db/jobs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/jobs.db.queries.ts
@@ -152,15 +152,15 @@ const create = async (job: Omit<JobAttributes<JobDataType>, 'id'>): Promise<numb
 };
 
 /**
- * Update a job. Most properties should be immutable, only status, data and
- * resources can be updated
+ * Update a job. Most properties should be immutable, only status, data,
+ * internal_data and resources can be updated
  * @param id ID of the object to update
  * @param attributes The attributes to update
  * @returns The ID of the updated object
  */
 const update = async (
     id: number,
-    attributes: Partial<Pick<JobAttributes<JobDataType>, 'status' | 'data' | 'resources'>>
+    attributes: Partial<Pick<JobAttributes<JobDataType>, 'status' | 'data' | 'resources' | 'internal_data'>>
 ): Promise<number> => {
     try {
         const returningArray = await knex(tableName).update(attributes).where('id', id).returning('id');

--- a/packages/transition-backend/src/models/db/migrations/20230309104300_addJobsInternalData.ts
+++ b/packages/transition-backend/src/models/db/migrations/20230309104300_addJobsInternalData.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const tableName = 'tr_jobs';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table) => {
+        table.json('internal_data').defaultTo({}).notNullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table) => {
+        table.dropColumn('internal_data');
+    });
+}

--- a/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
+++ b/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+
+/**
+ * Class that allows to keep track of task execution progress. Ideal for jobs
+ * that include individual steps, this allows to inform the task when a chunk
+ * has been completed and save this checkpoint.
+ *
+ * Using this class is suggested for asynchronous steps, where steps can be
+ * completed out of order, to keep track of each individual step. Listeners can
+ * listen to the 'checkpoint' event.
+ */
+export class CheckpointTracker {
+    private indexes: number[] = [];
+    private lastCheckpointIdx: number;
+
+    /**
+     * Constructor
+     * @param chunkSize Number of steps in a chunk.
+     * @param progressEmitter event emitter that will be notified when chunks
+     * are finished. It will send a 'checkpoint' event with the checkpoint, ie
+     * chunk size * nb of terminated chunks
+     * @param currentCheckpoint If resuming a task, this is the last checkpoint
+     * that was registered in previous run
+     */
+    constructor(private chunkSize: number, private progressEmitter: EventEmitter, currentCheckpoint = 0) {
+        this.lastCheckpointIdx = Math.floor(currentCheckpoint / chunkSize) - 1;
+        // Add items to the last checkpoint, in case the chunk size is not a multiple of the current checkpoint
+        const lastChunkItems = currentCheckpoint % chunkSize;
+        if (lastChunkItems > 0) {
+            this.indexes[this.lastCheckpointIdx + 1] = lastChunkItems;
+        }
+    }
+
+    /**
+     * Tell the tracker that the step at index was completed
+     * @param handledIndex 0-based index of the step that was just completed
+     */
+    handled = (handledIndex: number): void => {
+        if (handledIndex < 0) {
+            console.log('Invalid index received in checkpoint tracker', handledIndex);
+            return;
+        }
+        // Increment the count for this checkpoint
+        const chkIndex = this.getCheckpointIndex(handledIndex);
+        this.indexes[chkIndex] = (this.indexes[chkIndex] || 0) + 1;
+        if (this.indexes[chkIndex] === this.chunkSize) {
+            // See if we need to notify for this checkopint
+            this.maybeNotifyCheckpoint(chkIndex);
+        }
+    };
+
+    private getCheckpointIndex = (handledIndex: number) => {
+        return Math.floor(handledIndex / this.chunkSize);
+    };
+
+    private maybeNotifyCheckpoint(chkIndex: number) {
+        // If the previous checkpoint is completed, then notify for the next
+        // checkpoint, otherwise do nothing, we need to wait for the previous to
+        // complete first
+        if (this.lastCheckpointIdx === chkIndex - 1) {
+            let indexToNotify = chkIndex;
+            // Get the last completed checkpoint
+            while (this.indexes[indexToNotify + 1] === this.chunkSize) {
+                indexToNotify++;
+            }
+            this.progressEmitter.emit('checkpoint', (indexToNotify + 1) * this.chunkSize);
+            this.lastCheckpointIdx = indexToNotify;
+        }
+    }
+
+    /**
+     * Call when all steps have been completed. If the last chunk is not full,
+     * it will emit a 'checkpoint' event with the last index handled.
+     */
+    completed = (): void => {
+        const lastChunkIndex = this.lastCheckpointIdx + 1;
+        const lastChunkSize = this.indexes[lastChunkIndex];
+        if (lastChunkSize !== undefined && lastChunkSize > 0) {
+            this.progressEmitter.emit('checkpoint', lastChunkIndex * this.chunkSize + lastChunkSize);
+        }
+    };
+}

--- a/packages/transition-backend/src/services/executableJob/__tests__/JobCheckpointTracker.test.ts
+++ b/packages/transition-backend/src/services/executableJob/__tests__/JobCheckpointTracker.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+
+import { CheckpointTracker } from '../JobCheckpointTracker';
+
+const mockProgressEmitter = new EventEmitter();
+const mockCheckpoint = jest.fn();
+mockProgressEmitter.on('checkpoint', mockCheckpoint);
+
+beforeEach(() => {
+    mockCheckpoint.mockClear();
+})
+
+test('Test smaller number of handled data than chunk size', () => {
+    const tracker = new CheckpointTracker(10, mockProgressEmitter);
+    tracker.handled(0);
+    tracker.handled(1);
+    tracker.handled(2);
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+});
+
+test('Test in order step completion', () => {
+    const chunkSize = 5;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter);
+    for (let i = 0; i < 2 * chunkSize; i++) {
+        tracker.handled(i);
+    }
+    expect(mockCheckpoint).toHaveBeenCalledTimes(2);
+    expect(mockCheckpoint).toHaveBeenCalledWith(chunkSize);
+    expect(mockCheckpoint).toHaveBeenCalledWith(2 * chunkSize);
+});
+
+test('Test out of order step completion', () => {
+    const chunkSize = 5;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter);
+    // handle the first 4
+    for (let i = 0; i < chunkSize - 1; i++) {
+        tracker.handled(i);
+    }
+    // handle 6th, make sure the checkpoint has not been called
+    tracker.handled(5);
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+
+    // handle 5th, the checkpoint should have been called now
+    tracker.handled(4);
+    expect(mockCheckpoint).toHaveBeenCalledTimes(1);
+    expect(mockCheckpoint).toHaveBeenCalledWith(5);
+});
+
+test('Finish second chunk before first', () => {
+    const chunkSize = 5;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter);
+    // handle the first 4
+    for (let i = 0; i < 4; i++) {
+        tracker.handled(i);
+    }
+    // handle 6th through 10th, make sure the checkpoint has not been called
+    for (let i = 5; i < 10; i++) {
+        tracker.handled(i);
+    }
+    expect(mockCheckpoint).not.toHaveBeenCalled();
+
+    // handle 5th, the checkpoint should have been called now, with number 10
+    tracker.handled(4);
+    expect(mockCheckpoint).toHaveBeenCalledTimes(1);
+    expect(mockCheckpoint).toHaveBeenCalledWith(2 * chunkSize);
+});
+
+test('Test the completed method', () => {
+    const chunkSize = 5;
+    const extraItems = chunkSize - 2;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter);
+    // handle 2 chunks + a few items less
+    for (let i = 0; i < (2 * chunkSize) + extraItems; i++) {
+        tracker.handled(i);
+    }
+    // Expect the 2 checkpoints to have been called
+    expect(mockCheckpoint).toHaveBeenCalledTimes(2);
+    expect(mockCheckpoint).toHaveBeenCalledWith(chunkSize);
+    expect(mockCheckpoint).toHaveBeenCalledWith(2 * chunkSize);
+
+    // Call the completed method, expect a third checkpoint call
+    tracker.completed();
+    expect(mockCheckpoint).toHaveBeenCalledTimes(3);
+    expect(mockCheckpoint).toHaveBeenCalledWith(2 * chunkSize + extraItems);
+});
+
+test('Resume from checkpoint, multiple of chunk size', () => {
+    const chunkSize = 5;
+    const lastCheckpoint = 2 * chunkSize;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter, lastCheckpoint);
+    // handle 2 other chunks
+    for (let i = lastCheckpoint; i <= 4 * chunkSize; i++) {
+        tracker.handled(i);
+    }
+    // Expect the 2 checkpoints to have been called
+    expect(mockCheckpoint).toHaveBeenCalledTimes(2);
+    expect(mockCheckpoint).toHaveBeenCalledWith(3 * chunkSize);
+    expect(mockCheckpoint).toHaveBeenCalledWith(4 * chunkSize);
+});
+
+test('Resume from checkpoint, with extra elements', () => {
+    const chunkSize = 5;
+    const lastCheckpoint = 2 * chunkSize + 2;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter, lastCheckpoint);
+    // handle 2 other chunks
+    for (let i = lastCheckpoint; i <= 4 * chunkSize; i++) {
+        tracker.handled(i);
+    }
+    // Expect the 2 checkpoints to have been called
+    expect(mockCheckpoint).toHaveBeenCalledTimes(2);
+    expect(mockCheckpoint).toHaveBeenCalledWith(3 * chunkSize);
+    expect(mockCheckpoint).toHaveBeenCalledWith(4 * chunkSize);
+});
+
+test('Resume from checkpoint, smaller than chunk size', () => {
+    const chunkSize = 5;
+    const lastCheckpoint = chunkSize - 2;
+    const tracker = new CheckpointTracker(chunkSize, mockProgressEmitter, lastCheckpoint);
+    // handle 2 other chunks
+    for (let i = lastCheckpoint; i <= 2 * chunkSize; i++) {
+        tracker.handled(i);
+    }
+    // Expect the 2 checkpoints to have been called
+    expect(mockCheckpoint).toHaveBeenCalledTimes(2);
+    expect(mockCheckpoint).toHaveBeenCalledWith(chunkSize);
+    expect(mockCheckpoint).toHaveBeenCalledWith(2 * chunkSize);
+});

--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -83,7 +83,8 @@ const wrapBatchRoute = async (task: ExecutableJob<BatchRouteJobType>) => {
             absoluteBaseDirectory: absoluteUserDir,
             inputFileName,
             progressEmitter: newProgressEmitter(task),
-            isCancelled: getTaskCancelledFct(task)
+            isCancelled: getTaskCancelledFct(task),
+            currentCheckpoint: task.attributes.internal_data.checkpoint
         }
     );
     task.attributes.data.results = result;

--- a/packages/transition-common/src/services/jobs/Job.ts
+++ b/packages/transition-common/src/services/jobs/Job.ts
@@ -21,6 +21,12 @@ export interface JobAttributes<TData extends JobDataType> {
     user_id: number;
     name: TData[JobNameKey];
     status: JobStatus;
+    /**
+     * Data internal to the job management, that is not relevant to the users
+     */
+    internal_data: {
+        checkpoint?: number;
+    };
     data: {
         [Property in keyof TData[JobDataKey]]: TData[JobDataKey][Property];
     };

--- a/packages/transition-common/src/services/jobs/__tests__/Job.test.ts
+++ b/packages/transition-common/src/services/jobs/__tests__/Job.test.ts
@@ -25,6 +25,7 @@ const jobAttributes: JobAttributes<TestJobType> = {
     name: 'test' as const,
     user_id: 3,
     status: 'pending',
+    internal_data: {},
     data: { parameters: { foo: 'bar' } },
     resources: { files: { testFile: 'path/to/file' } }
 };


### PR DESCRIPTION
Add an internal_data field to jobs to keep the checkpoint, and eventually all other internal data that the user is not meant to see.

Implement a checkpoint mechanism to track completion of potentially out of order steps of a task.

Let the batchRoute function use this checkpoint tracker mechanism to resume the task

Note that the results are not deleted from the database anymore, as there may be a point in the job execution where the files are generated, the results are deleted, but the job is not yet marked as completed. If the server is shut down at that moment, the results won't be recoverable for this job. We would need some other mechanism to properly complete the task. Besides, jobs are not meant to be kept forever, they will fill the user quota anyway. Results will be deleted when the job is deleted.

