### PR TITLE
i18n: Remove initial language check

### DIFF
--- a/packages/chaire-lib-frontend/src/config/i18n.config.ts
+++ b/packages/chaire-lib-frontend/src/config/i18n.config.ts
@@ -10,7 +10,7 @@ import moment from 'moment-business-days';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi from 'i18next-http-backend';
 
-import config from 'chaire-lib-common/lib/config/shared/project.config';
+import config from './project.config';
 
 const detectorOrder = config.detectLanguage ? ['cookie', 'localStorage', 'navigator'] : ['cookie', 'localStorage'];
 
@@ -49,7 +49,8 @@ if (i18n.language) {
     i18n.changeLanguage(i18n.language.split('-')[0]); // force remove region specific
 }
 
-if (!i18n.language || config.languages.indexOf(i18n.language) <= -1) {
+// Make sure the currently set language exists, if any
+if (i18n.language && config.languages.indexOf(i18n.language) <= -1) {
     i18n.changeLanguage(config.defaultLocale);
 }
 


### PR DESCRIPTION
This language check caused the defaultLocale to always be set when reloading the page instead of using the detection mechanism. It previously worked because the config used in the i18n file was from chaire-lib-common, which was imported before getting the actual config from chaire-lib-frontend. When correctly importing the frontend config, or if setting default values for the languages in the common config, the issue arose.