### PR TITLE
chaire-lib: Move the FrontendUser type to common workspace

### DIFF
--- a/packages/chaire-lib-common/src/services/user/userType.ts
+++ b/packages/chaire-lib-common/src/services/user/userType.ts
@@ -16,3 +16,23 @@ export interface BaseUser {
     serializedPermissions: PackRule<any>[];
     homePage?: string;
 }
+
+export type UserPages = { path: string; permissions: UserPermissions; title: string };
+
+export type UserPermissions = {
+    [subject: string]: string | string[];
+};
+
+export type PermUser = {
+    isAuthorized: (permissions: UserPermissions) => boolean;
+    is_admin: boolean;
+    pages: UserPages[];
+    showUserInfo: boolean;
+};
+
+/**
+ * User type suitable for client-side code, ie with limited internal and
+ * confidential data, but with all appropriate data to validation user
+ * permissions as required.
+ */
+export type CliUser = BaseUser & PermUser;

--- a/packages/chaire-lib-frontend/src/actions/Auth.tsx
+++ b/packages/chaire-lib-frontend/src/actions/Auth.tsx
@@ -6,7 +6,7 @@
  */
 import { BaseUser } from 'chaire-lib-common/lib/services/user/userType';
 import appConfiguration from '../config/application.config';
-import { toFrontendUser } from '../services/auth/user';
+import { toCliUser } from '../services/auth/user';
 import { AuthAction, AuthActionTypes } from '../store/auth';
 import { History, Location } from 'history';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
@@ -22,7 +22,7 @@ export const setShowUserInfoPerm = (perms: { [subject: string]: string | string[
 
 export const login = (user: BaseUser | null, isAuthenticated = false, register = false, login = false): AuthAction => ({
     type: AuthActionTypes.LOGIN,
-    user: user ? toFrontendUser(user, appConfiguration.pages, showUserInfoPerm) : user,
+    user: user ? toCliUser(user, appConfiguration.pages, showUserInfoPerm) : user,
     isAuthenticated,
     register,
     login

--- a/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
@@ -13,11 +13,11 @@ import moment from 'moment-business-days';
 import ConfirmModal from '../modal/ConfirmModal';
 import { startLogout, resetUserProfile } from '../../actions/Auth';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
-import { FrontendUser } from '../../services/auth/user';
 import { History } from 'history';
+import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
 export interface HeaderProps extends WithTranslation {
-    user: FrontendUser;
+    user: CliUser;
     path: any;
     startLogout: () => void;
     resetUserProfile: () => void;
@@ -26,12 +26,12 @@ export interface HeaderProps extends WithTranslation {
 }
 
 interface UserProps {
-    user: FrontendUser;
+    user: CliUser;
     resetUserProfile: () => void;
 }
 
 interface UserMenuProps {
-    user: FrontendUser;
+    user: CliUser;
     resetUserProfile: () => void;
     wrapperRef: React.MutableRefObject<null>;
     closeMenu: () => void;

--- a/packages/chaire-lib-frontend/src/components/routers/AdminRoute.tsx
+++ b/packages/chaire-lib-frontend/src/components/routers/AdminRoute.tsx
@@ -4,17 +4,17 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { FrontendUser } from '../../services/auth/user';
 import React from 'react';
 import { connect } from 'react-redux';
 import { RouteProps } from 'react-router-dom';
 import PrivateRoute from './PrivateRoute';
+import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
 interface AdminRouteProps extends RouteProps {
     isAuthenticated: boolean;
     component: any;
     componentProps: { [prop: string]: unknown };
-    user: FrontendUser;
+    user: CliUser;
 }
 
 const AdminRoute = (props: AdminRouteProps) => <PrivateRoute {...props} permissions={{ all: 'manage' }} />;

--- a/packages/chaire-lib-frontend/src/components/routers/PrivateRoute.tsx
+++ b/packages/chaire-lib-frontend/src/components/routers/PrivateRoute.tsx
@@ -4,18 +4,18 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { FrontendUser } from '../../services/auth/user';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
 
 import { Header } from '../pageParts';
+import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
 interface PrivateRouteProps extends RouteProps {
     isAuthenticated: boolean;
     component: any;
     componentProps: { [prop: string]: unknown };
-    user: FrontendUser;
+    user: CliUser;
     permissions?: { [subject: string]: string | string[] };
     config?: { [key: string]: unknown };
 }

--- a/packages/chaire-lib-frontend/src/config/application.config.ts
+++ b/packages/chaire-lib-frontend/src/config/application.config.ts
@@ -4,7 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { UserPages } from '../services/auth/user';
+
+import { UserPages } from 'chaire-lib-common/lib/services/user/userType';
 
 export type ApplicationConfiguration<AdditionalConfig> = {
     /**

--- a/packages/chaire-lib-frontend/src/services/auth/__tests__/user.test.ts
+++ b/packages/chaire-lib-frontend/src/services/auth/__tests__/user.test.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { toFrontendUser } from '../user';
+import { toCliUser } from '../user';
 
 const baseUser = {
     id: 1,
@@ -16,38 +16,38 @@ const baseUser = {
 const testSubject = 'test';
 
 test('No permissions', () => {
-    const frontendUser = toFrontendUser(baseUser);
-    expect(frontendUser.isAuthorized({ [testSubject]: 'read' })).toBeFalsy();
-    expect(frontendUser.isAuthorized({ all: 'read' })).toBeFalsy();
-    expect(frontendUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeFalsy();
-    expect(frontendUser.is_admin).toBeFalsy();
+    const cliUser = toCliUser(baseUser);
+    expect(cliUser.isAuthorized({ [testSubject]: 'read' })).toBeFalsy();
+    expect(cliUser.isAuthorized({ all: 'read' })).toBeFalsy();
+    expect(cliUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeFalsy();
+    expect(cliUser.is_admin).toBeFalsy();
 });
 
 test('Admin permissions', () => {
     const user = Object.assign({}, baseUser, { serializedPermissions: [ ['manage', 'all'] ] });
-    const frontendUser = toFrontendUser(user);
-    expect(frontendUser.isAuthorized({ [testSubject]: 'read' })).toBeTruthy();
-    expect(frontendUser.isAuthorized({ all: 'read' })).toBeTruthy();
-    expect(frontendUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeTruthy();
-    expect(frontendUser.is_admin).toBeTruthy();
+    const cliUser = toCliUser(user);
+    expect(cliUser.isAuthorized({ [testSubject]: 'read' })).toBeTruthy();
+    expect(cliUser.isAuthorized({ all: 'read' })).toBeTruthy();
+    expect(cliUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeTruthy();
+    expect(cliUser.is_admin).toBeTruthy();
 });
 
 test('Some permissions', () => {
     let serializedPermissions = [ [ 'read', testSubject ], [ 'read', 'other test object' ] ];
     let user = Object.assign({}, baseUser, { serializedPermissions });
-    let frontendUser = toFrontendUser(user);
-    expect(frontendUser.isAuthorized({ [testSubject]: 'read' })).toBeTruthy();
-    expect(frontendUser.isAuthorized({ all: 'read' })).toBeFalsy();
-    expect(frontendUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeFalsy();
-    expect(frontendUser.is_admin).toBeFalsy();
+    let cliUser = toCliUser(user);
+    expect(cliUser.isAuthorized({ [testSubject]: 'read' })).toBeTruthy();
+    expect(cliUser.isAuthorized({ all: 'read' })).toBeFalsy();
+    expect(cliUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeFalsy();
+    expect(cliUser.is_admin).toBeFalsy();
 
     serializedPermissions = [ [ 'read,update', testSubject ], [ 'read', 'other test object' ] ];
     user = Object.assign({}, baseUser, { serializedPermissions });
-    frontendUser = toFrontendUser(user);
-    expect(frontendUser.isAuthorized({ [testSubject]: 'read' })).toBeTruthy();
-    expect(frontendUser.isAuthorized({ all: 'read' })).toBeFalsy();
-    expect(frontendUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeTruthy();
-    expect(frontendUser.is_admin).toBeFalsy();
+    cliUser = toCliUser(user);
+    expect(cliUser.isAuthorized({ [testSubject]: 'read' })).toBeTruthy();
+    expect(cliUser.isAuthorized({ all: 'read' })).toBeFalsy();
+    expect(cliUser.isAuthorized({ [testSubject]: ['read','update'] })).toBeTruthy();
+    expect(cliUser.is_admin).toBeFalsy();
 });
 
 test('Some permissions and home pages', () => {
@@ -60,28 +60,28 @@ test('Some permissions and home pages', () => {
     // User with only one permission on pages
     let serializedPermissions = [ [ 'read', testSubject ], [ 'read', 'other test object' ] ];
     let user = Object.assign({}, baseUser, { serializedPermissions });
-    let frontendUser = toFrontendUser(user, pages);
-    expect(frontendUser.pages.length).toEqual(1);
-    expect(frontendUser.pages[0]).toEqual(pages[1]);
+    let cliUser = toCliUser(user, pages);
+    expect(cliUser.pages.length).toEqual(1);
+    expect(cliUser.pages[0]).toEqual(pages[1]);
 
     // User with 2 permissions on pages
     serializedPermissions = [ [ 'read,update', testSubject ], [ 'read', 'other test object' ] ];
     user = Object.assign({}, baseUser, { serializedPermissions });
-    frontendUser = toFrontendUser(user, pages);
-    expect(frontendUser.pages.length).toEqual(2);
-    expect(frontendUser.pages[0]).toEqual(pages[0]);
-    expect(frontendUser.pages[1]).toEqual(pages[1]);
+    cliUser = toCliUser(user, pages);
+    expect(cliUser.pages.length).toEqual(2);
+    expect(cliUser.pages[0]).toEqual(pages[0]);
+    expect(cliUser.pages[1]).toEqual(pages[1]);
 
     // Admin user
     user = Object.assign({}, baseUser, { serializedPermissions: [ ['manage', 'all'] ] });
-    frontendUser = toFrontendUser(user, pages);
-    expect(frontendUser.pages.length).toEqual(3);
-    expect(frontendUser.pages[0]).toEqual(pages[0]);
-    expect(frontendUser.pages[1]).toEqual(pages[1]);
-    expect(frontendUser.pages[2]).toEqual(pages[2]);
+    cliUser = toCliUser(user, pages);
+    expect(cliUser.pages.length).toEqual(3);
+    expect(cliUser.pages[0]).toEqual(pages[0]);
+    expect(cliUser.pages[1]).toEqual(pages[1]);
+    expect(cliUser.pages[2]).toEqual(pages[2]);
 
     // No permissions
     user = Object.assign({}, baseUser, { serializedPermissions: [] });
-    frontendUser = toFrontendUser(user, pages);
-    expect(frontendUser.pages.length).toEqual(0);
+    cliUser = toCliUser(user, pages);
+    expect(cliUser.pages.length).toEqual(0);
 });

--- a/packages/chaire-lib-frontend/src/services/auth/user.ts
+++ b/packages/chaire-lib-frontend/src/services/auth/user.ts
@@ -4,31 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { BaseUser } from 'chaire-lib-common/lib/services/user/userType';
+import { BaseUser, CliUser, UserPages, UserPermissions } from 'chaire-lib-common/lib/services/user/userType';
 import isAuthorized, { deserializeRules } from './authorization';
 
-export type UserPages = { path: string; permissions: Permission; title: string };
-
-interface Permission {
-    [subject: string]: string | string[];
-}
-
-export type PermUser = {
-    isAuthorized: (permissions: Permission) => boolean;
-    is_admin: boolean;
-    pages: UserPages[];
-    showUserInfo: boolean;
-};
-
-export type FrontendUser = BaseUser & PermUser;
-
-export const toFrontendUser = (
-    user: BaseUser,
-    pages: UserPages[] = [],
-    showUserInfoPerm?: Permission
-): FrontendUser => {
+export const toCliUser = (user: BaseUser, pages: UserPages[] = [], showUserInfoPerm?: UserPermissions): CliUser => {
     const ability = deserializeRules(user);
-    const authFunction = (permissions: Permission) => isAuthorized(ability, permissions);
+    const authFunction = (permissions: UserPermissions) => isAuthorized(ability, permissions);
     const userPages = pages.filter((page) => authFunction(page.permissions));
     return {
         isAuthorized: authFunction,

--- a/packages/chaire-lib-frontend/src/store/auth/types.ts
+++ b/packages/chaire-lib-frontend/src/store/auth/types.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { FrontendUser } from '../../services/auth/user';
+import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
 export enum AuthActionTypes {
     LOGIN = 'LOGIN',
@@ -16,7 +16,7 @@ export enum AuthActionTypes {
 export type AuthAction =
     | {
           type: AuthActionTypes.LOGIN;
-          user: FrontendUser | null | undefined;
+          user: CliUser | null | undefined;
           isAuthenticated: boolean;
           register: boolean;
           login: boolean;
@@ -39,7 +39,7 @@ export type AuthAction =
       };
 
 export interface AuthState {
-    readonly user?: FrontendUser | null;
+    readonly user?: CliUser | null;
     readonly isAuthenticated: boolean;
     readonly register?: boolean;
     readonly login?: boolean;


### PR DESCRIPTION
Fixes #630

The type is renamed to CliUser.

The type itself is not frontend-specific, it contains only the non-private user information, as well as the required data to verify permissions as required. It can be used by any client-side code and not only in the react frontend.

Its current implementation remains in chaire-lib-frontend though (the toCliUser function in `chaire-lib-frontend/lib/services/auth/user`).