### PR TITLE
tests: Mock the db.config file

### DIFF
--- a/packages/chaire-lib-backend/jest.config.js
+++ b/packages/chaire-lib-backend/jest.config.js
@@ -10,6 +10,10 @@ const baseConfig = require('../../tests/jest.config.base');
 // Ignore db.queries.test files
 module.exports = {
     ...baseConfig,
+    setupFilesAfterEnv: [
+        ...baseConfig.setupFilesAfterEnv,
+        './jestSetup.ts'
+    ],
     'testPathIgnorePatterns': ['(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$', '(/__tests__/.*(integration\\.test)\\.(jsx?|tsx?))$'],
 };
 

--- a/packages/chaire-lib-backend/jestSetup.ts
+++ b/packages/chaire-lib-backend/jestSetup.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+jest.mock('./src/config/shared/db.config');

--- a/packages/chaire-lib-backend/src/config/shared/__mocks__/db.config.ts
+++ b/packages/chaire-lib-backend/src/config/shared/__mocks__/db.config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { knex } from 'knex';
+
+// Mock the database connection. There should be no real DB access in unit
+// tests (it's an error if there is, DB accesses should be in the sequential
+// tests), so this is just a placeholder.
+export default knex({ client: 'sqlite' });

--- a/packages/transition-backend/jest.config.js
+++ b/packages/transition-backend/jest.config.js
@@ -10,5 +10,9 @@ const baseConfig = require('../../tests/jest.config.base');
 // Ignore db.queries.test files
 module.exports = {
     ...baseConfig,
+    setupFilesAfterEnv: [
+        ...baseConfig.setupFilesAfterEnv,
+        './jestSetup.ts'
+    ],
     'testPathIgnorePatterns': ['(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$', '(/__tests__/.*(integration\\.test)\\.(jsx?|tsx?))$'],
 };

--- a/packages/transition-backend/jestSetup.ts
+++ b/packages/transition-backend/jestSetup.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+jest.mock('chaire-lib-backend/lib/config/shared/db.config');

--- a/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
@@ -40,7 +40,8 @@ const jobAttributes: Omit<JobAttributes<TestJobType>, 'id'> = {
     status: 'pending' as const,
     name: 'test' as const,
     user_id: userAttributes.id,
-    data: data.data
+    data: data.data,
+    internal_data: {}
 };
 
 // Current ids in the DB for the various test objects to use throughout the tests


### PR DESCRIPTION
Fixes #633

In unit tests testing files that import database query files, the database configuration is always loaded and requires the .env file to have been parsed with proper data. This should not be a requirement to run tests, especially that the database queries that are under test are already mocked. This adds a mock for the db.config, which simply initializes a dummy knex object for 'sqlite' that should make the tests pass without configuration.

The `db.config` file is automatically mocked in chaire-lib-backend and transition-backend packages.