### PR TITLE
batchCalculation: Refactor types

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -9,6 +9,7 @@ module.exports = {
         // confirmEmail: true
       }
     },
+    maxParallelCalculators: 2,
     
     // Maximum number of parallel calculation
     // TODO trRouting should support multi-threading so we shouldn't have to start multiple instances

--- a/packages/chaire-lib-common/src/api/TrRouting/base.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/base.ts
@@ -4,48 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { ErrorMessage } from '../../utils/TrError';
-
-// TODO These batch demand attributes are not trRouting specific. They should go elsewhere
-export type TransitBatchDemandFromCsvAttributes = {
-    calculationName: string;
-    projection: string;
-    idAttribute: string;
-    timeAttributeDepartureOrArrival: 'arrival' | 'departure';
-    timeFormat: string;
-    timeAttribute: string;
-    withGeometries: boolean;
-    detailed: boolean;
-    cpuCount: number;
-    csvFile: { location: 'upload'; filename: string } | { location: 'server'; fromJob: number };
-};
-
-export type TransitBatchRoutingDemandFromCsvAttributes = TransitBatchDemandFromCsvAttributes & {
-    originXAttribute: string;
-    originYAttribute: string;
-    destinationXAttribute: string;
-    destinationYAttribute: string;
-    saveToDb: false | { type: 'new'; dataSourceName: string } | { type: 'overwrite'; dataSourceId: string };
-};
-
-export type TransitBatchRoutingDemandAttributes = {
-    type: 'csv';
-    configuration: TransitBatchRoutingDemandFromCsvAttributes;
-};
-
-export type TransitBatchAccessibilityMapAttributes = TransitBatchDemandFromCsvAttributes & {
-    xAttribute: string;
-    yAttribute: string;
-};
-
-export interface TransitBatchCalculationResult {
-    calculationName: string;
-    detailed: boolean;
-    completed: boolean;
-    warnings: ErrorMessage[];
-    errors: ErrorMessage[];
-}
-
 export interface TransitRouteQueryOptions {
     /**
      * An array containing the origin and destination points.

--- a/packages/chaire-lib-common/src/api/TrRouting/index.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/index.ts
@@ -53,7 +53,7 @@ export class TrRoutingConstants {
     static readonly BATCH_ROUTE_REPLAY = 'service.trRouting.batchRouteReplay';
     /**
      * Socket route name to call a batch accessibility map calculation. It takes
-     * a parameter of type {@link TransitBatchAccessibilityMapAttributes}. It
+     * a parameter of type {@link TransitDemandFromCsvAccessMapAttributes}. It
      * returns a {@link Status}, with a {@link TransitBatchCalculationResult} on
      * success.
      *

--- a/packages/chaire-lib-common/src/api/TrRouting/index.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/index.ts
@@ -45,6 +45,8 @@ export class TrRoutingConstants {
      * of type {@link TransitOdDemandFromCsvAttributes} and a 'csvFields' field
      * containing the string headers of the fields of the csv file on success
      *
+     * TODO Move batch route related services and constants to transition-backend
+     *
      * @static
      * @memberof TrRoutingConstants
      */

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -21,7 +21,7 @@ import { transitionRouteOptions, transitionMatchOptions } from 'chaire-lib-commo
 import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import {
     TransitBatchRoutingDemandAttributes,
-    TransitBatchAccessibilityMapAttributes
+    TransitDemandFromCsvAccessMapAttributes
 } from 'transition-common/lib/services/transitDemand/types';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
@@ -285,7 +285,7 @@ export default function (socket: EventEmitter, userId?: number) {
         socket.on(
             TrRoutingConstants.BATCH_ACCESS_MAP,
             async (
-                parameters: TransitBatchAccessibilityMapAttributes,
+                parameters: TransitDemandFromCsvAccessMapAttributes,
                 accessMapAttributes: AccessibilityMapAttributes,
                 callback
             ) => {

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -16,10 +16,13 @@ import trRoutingService from 'chaire-lib-backend/lib/utils/trRouting/TrRoutingSe
 import osrmProcessManager from 'chaire-lib-backend/lib/utils/processManagers/OSRMProcessManager';
 import osrmService from 'chaire-lib-backend/lib/utils/osrm/OSRMService';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import { TransitBatchRoutingDemandAttributes, TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
+import { TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
 import { transitionRouteOptions, transitionMatchOptions } from 'chaire-lib-common/lib/api/OSRMRouting';
 import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
-import { TransitBatchAccessibilityMapAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import {
+    TransitBatchRoutingDemandAttributes,
+    TransitBatchAccessibilityMapAttributes
+} from 'transition-common/lib/services/transitDemand/types';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import TrError from 'chaire-lib-common/lib/utils/TrError';

--- a/packages/transition-backend/src/services/transitRouting/BatchAccessibilityMapJob.ts
+++ b/packages/transition-backend/src/services/transitRouting/BatchAccessibilityMapJob.ts
@@ -4,10 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import {
-    TransitBatchAccessibilityMapAttributes,
-    TransitBatchCalculationResult
-} from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 
 export type BatchAccessMapJobType = {

--- a/packages/transition-backend/src/services/transitRouting/BatchAccessibilityMapJob.ts
+++ b/packages/transition-backend/src/services/transitRouting/BatchAccessibilityMapJob.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 
@@ -12,7 +12,7 @@ export type BatchAccessMapJobType = {
     name: 'batchAccessMap';
     data: {
         parameters: {
-            batchAccessMapAttributes: TransitBatchAccessibilityMapAttributes;
+            batchAccessMapAttributes: TransitDemandFromCsvAccessMapAttributes;
             accessMapAttributes: AccessibilityMapAttributes;
         };
         results?: TransitBatchCalculationResult;

--- a/packages/transition-backend/src/services/transitRouting/BatchRoutingJob.ts
+++ b/packages/transition-backend/src/services/transitRouting/BatchRoutingJob.ts
@@ -4,10 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import {
-    TransitBatchCalculationResult,
-    TransitBatchRoutingDemandAttributes
-} from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 
 export type BatchRouteJobType = {

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
@@ -17,10 +17,8 @@ import { parseLocationsFromCsv } from '../accessMapLocation/AccessMapLocationPro
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
 import nodeDbQueries from '../../models/db/transitNodes.db.queries';
 import scenariosDbQueries from '../../models/db/transitScenarios.db.queries';
-import {
-    TransitBatchAccessibilityMapAttributes,
-    TransitBatchCalculationResult
-} from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { createAccessMapFileResultProcessor } from './TrAccessibilityMapBatchResult';
 import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
 import { AccessibilityMapLocation } from 'transition-common/lib/services/accessibilityMap/AccessibiltyMapLocation';

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
@@ -17,7 +17,7 @@ import { parseLocationsFromCsv } from '../accessMapLocation/AccessMapLocationPro
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
 import nodeDbQueries from '../../models/db/transitNodes.db.queries';
 import scenariosDbQueries from '../../models/db/transitScenarios.db.queries';
-import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { createAccessMapFileResultProcessor } from './TrAccessibilityMapBatchResult';
 import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
@@ -36,7 +36,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
  * @returns
  */
 export const batchAccessibilityMap = async (
-    parameters: TransitBatchAccessibilityMapAttributes,
+    parameters: TransitDemandFromCsvAccessMapAttributes,
     accessMapAttributes: AccessibilityMapAttributes,
     absoluteBaseDirectory: string,
     progressEmitter: EventEmitter,

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatchResult.ts
@@ -9,7 +9,7 @@ import _omit from 'lodash.omit';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
-import { TransitBatchAccessibilityMapAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 import { AccessibilityMapLocation } from 'transition-common/lib/services/accessibilityMap/AccessibiltyMapLocation';
 import { unparse } from 'papaparse';

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatchResult.ts
@@ -9,7 +9,7 @@ import _omit from 'lodash.omit';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
-import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 import { AccessibilityMapLocation } from 'transition-common/lib/services/accessibilityMap/AccessibiltyMapLocation';
 import { unparse } from 'papaparse';
@@ -43,7 +43,7 @@ export interface BatchAccessibilityMapResultProcessor {
  */
 export const createAccessMapFileResultProcessor = (
     absoluteDirectory: string,
-    parameters: TransitBatchAccessibilityMapAttributes,
+    parameters: TransitDemandFromCsvAccessMapAttributes,
     accessMapAttributes: AccessibilityMapAttributes
 ): BatchAccessibilityMapResultProcessor => {
     return new BatchAccessibilityMapResultProcessorFile(absoluteDirectory, parameters, accessMapAttributes);
@@ -67,7 +67,7 @@ class BatchAccessibilityMapResultProcessorFile implements BatchAccessibilityMapR
      */
     constructor(
         private absoluteDirectory: string,
-        private parameters: TransitBatchAccessibilityMapAttributes,
+        private parameters: TransitDemandFromCsvAccessMapAttributes,
         private accessMapAttributes: AccessibilityMapAttributes
     ) {
         this.initResultFiles();

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -208,7 +208,7 @@ class TrRoutingBatch {
 
             const routingResult = {
                 calculationName: parameters.calculationName,
-                detailed: parameters.detailed,
+                detailed: this.transitRoutingAttributes.detailed,
                 completed: true,
                 errors: [],
                 warnings: this.errors,
@@ -274,8 +274,8 @@ class TrRoutingBatch {
                     routing.attributes.routingModes,
                     {
                         exportCsv: true,
-                        exportDetailed: this.demandParameters.detailed === true,
-                        withGeometries: this.demandParameters.withGeometries === true,
+                        exportDetailed: this.transitRoutingAttributes.detailed === true,
+                        withGeometries: this.transitRoutingAttributes.withGeometries === true,
                         pathCollection
                     }
                 );
@@ -299,12 +299,12 @@ class TrRoutingBatch {
         const resultHandler = createRoutingFileResultProcessor(
             this.options.absoluteBaseDirectory,
             this.demandParameters,
-            routing,
+            this.transitRoutingAttributes,
             this.options.inputFileName
         );
 
         let pathCollection: PathCollection | undefined = undefined;
-        if (this.demandParameters.withGeometries) {
+        if (this.transitRoutingAttributes.withGeometries) {
             pathCollection = new PathCollection([], {});
             if (routing.attributes.scenarioId) {
                 const pathGeojson = await pathDbQueries.geojsonCollection({
@@ -339,7 +339,7 @@ class TrRoutingBatch {
         // Divide odTripCount by 3 for the minimum number of calculation, to avoid creating too many processes if trip count is small
         const trRoutingInstancesCount = Math.max(
             1,
-            Math.min(Math.ceil(odTripsCount / 3), this.demandParameters.cpuCount)
+            Math.min(Math.ceil(odTripsCount / 3), this.transitRoutingAttributes.cpuCount || 1)
         );
 
         try {

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -16,10 +16,10 @@ import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import { parseOdTripsFromCsv } from '../odTrip/odTripProvider';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
 import {
-    TransitBatchCalculationResult,
     TransitBatchRoutingDemandAttributes,
     TransitBatchRoutingDemandFromCsvAttributes
-} from 'chaire-lib-common/lib/api/TrRouting';
+} from 'transition-common/lib/services/transitDemand/types';
+import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import odPairsDbQueries from '../../models/db/odPairs.db.queries';
 import pathDbQueries from '../../models/db/transitPaths.db.queries';
 import resultsDbQueries from '../../models/db/batchRouteResults.db.queries';

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -17,7 +17,7 @@ import { parseOdTripsFromCsv } from '../odTrip/odTripProvider';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
 import {
     TransitBatchRoutingDemandAttributes,
-    TransitBatchRoutingDemandFromCsvAttributes
+    TransitDemandFromCsvRoutingAttributes
 } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import odPairsDbQueries from '../../models/db/odPairs.db.queries';
@@ -75,7 +75,7 @@ class TrRoutingBatch {
     private pathCollection: PathCollection | undefined = undefined;
 
     constructor(
-        private demandParameters: TransitBatchRoutingDemandFromCsvAttributes,
+        private demandParameters: TransitDemandFromCsvRoutingAttributes,
         private transitRoutingAttributes: BatchCalculationParameters,
         private options: {
             jobId: number;

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import _omit from 'lodash.omit';
 import _cloneDeep from 'lodash.clonedeep';
 
-import { TransitBatchRoutingDemandFromCsvAttributes, TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
+import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
 import TransitRouting from 'transition-common/lib/services/transitRouting/TransitRouting';
 import { getDefaultCsvAttributes, getDefaultStepsAttributes } from './ResultAttributes';
 import { OdTripRouteOutput, OdTripRouteResult } from './types';
@@ -21,6 +21,7 @@ import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { Route } from 'chaire-lib-common/lib/services/routing/RoutingService';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { TransitBatchRoutingDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/types';
 
 const CSV_FILE_NAME = 'batchRoutingResults.csv';
 const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
@@ -21,7 +21,7 @@ import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { Route } from 'chaire-lib-common/lib/services/routing/RoutingService';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
-import { TransitBatchRoutingDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvRoutingAttributes } from 'transition-common/lib/services/transitDemand/types';
 
 const CSV_FILE_NAME = 'batchRoutingResults.csv';
 const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';
@@ -41,7 +41,7 @@ export interface BatchRoutingResultProcessor {
  */
 export const createRoutingFileResultProcessor = (
     absoluteDirectory: string,
-    parameters: TransitBatchRoutingDemandFromCsvAttributes,
+    parameters: TransitDemandFromCsvRoutingAttributes,
     routing: TransitRouting,
     inputFileName: string
 ): BatchRoutingResultProcessor => {
@@ -60,7 +60,7 @@ class BatchRoutingResultProcessorFile implements BatchRoutingResultProcessor {
 
     constructor(
         private absoluteDirectory: string,
-        private parameters: TransitBatchRoutingDemandFromCsvAttributes,
+        private parameters: TransitDemandFromCsvRoutingAttributes,
         private routing: TransitRouting,
         private inputFileName: string
     ) {

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -123,10 +123,13 @@ const defaultParameters = {
     timeAttributeDepartureOrArrival: 'departure' as const,
     timeFormat: 'HMM',
     timeAttribute: 'timeattrib',
+    saveToDb: false as false
+}
+const defaultBatchParameters = {
+    routingModes: ['walking' as const ],
     withGeometries: false,
     detailed: false,
-    cpuCount: 2,
-    saveToDb: false as false
+    cpuCount: 2
 }
 const jobId = 4;
 
@@ -140,13 +143,13 @@ beforeEach(() => {
 })
 
 test('Batch route to csv', async () => {
-    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
+    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' }) };
+    const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
         calculationName: parameters.configuration.calculationName,
-        detailed: parameters.configuration.detailed,
+        detailed: defaultBatchParameters.detailed,
         completed: true,
         errors: [],
         warnings: [],
@@ -176,13 +179,13 @@ test('Batch route with many pages of results', async () => {
     mockResultCollection.mockResolvedValueOnce({ totalCount: 260, tripResults: resultsInDb });
     mockResultCollection.mockResolvedValueOnce({ totalCount: 260, tripResults: resultsInDb });
 
-    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
+    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' }) };
+    const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
         calculationName: parameters.configuration.calculationName,
-        detailed: parameters.configuration.detailed,
+        detailed: defaultBatchParameters.detailed,
         completed: true,
         errors: [],
         warnings: [],
@@ -212,13 +215,13 @@ test('Batch route with many pages of results', async () => {
 test('Batch route with some errors', async () => {
     const errors = [ 'error1', 'error2' ];
     mockParseOdTripsFromCsv.mockResolvedValueOnce({ odTrips, errors });
-    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
+    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' }) };
+    const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
         calculationName: parameters.configuration.calculationName,
-        detailed: parameters.configuration.detailed,
+        detailed: defaultBatchParameters.detailed,
         completed: true,
         errors: [],
         warnings: errors,
@@ -246,8 +249,8 @@ test('Batch route with some errors', async () => {
 test('Batch route with too many errors', async () => {
     const errors = [ 'error1', 'error2' ];
     mockParseOdTripsFromCsv.mockRejectedValueOnce(errors);
-    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
+    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' }) };
+    const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(0);
     expect(mockCreateStream).toHaveBeenCalledTimes(0);
     expect(result).toEqual({
@@ -269,13 +272,13 @@ test('Batch route and save to db', async () => {
     (odPairsDbQueries.createMultiple as any).mockClear();
     (odPairsDbQueries.deleteForDataSourceId as any).mockClear();
 
-    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { saveToDb: {type: 'new', dataSourceName: 'name'}, calculationName: 'test', detailed: false }) };
-    const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
+    const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { saveToDb: {type: 'new', dataSourceName: 'name'}, calculationName: 'test' }) };
+    const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock });
     expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
     expect(mockCreateStream).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
         calculationName: parameters.configuration.calculationName,
-        detailed: parameters.configuration.detailed,
+        detailed: defaultBatchParameters.detailed,
         completed: true,
         errors: [],
         warnings: [],
@@ -307,13 +310,13 @@ describe('Batch route from checkpoint', () => {
 
     test('Checkpoint is 0', async () => {
         const currentCheckpoint = 0;
-        const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false })};
-        const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
+        const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' })};
+        const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length - currentCheckpoint);
         expect(mockCreateStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             calculationName: parameters.configuration.calculationName,
-            detailed: parameters.configuration.detailed,
+            detailed: defaultBatchParameters.detailed,
             completed: true,
             errors: [],
             warnings: [],
@@ -330,13 +333,13 @@ describe('Batch route from checkpoint', () => {
 
     test('Checkpoint of 1', async () => {
         const currentCheckpoint = 1;
-        const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false })};
-        const result = await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
+        const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' })};
+        const result = await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length - currentCheckpoint);
         expect(mockCreateStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
             calculationName: parameters.configuration.calculationName,
-            detailed: parameters.configuration.detailed,
+            detailed: defaultBatchParameters.detailed,
             completed: true,
             errors: [],
             warnings: [],
@@ -358,7 +361,7 @@ describe('Batch route from checkpoint', () => {
         mockParseOdTripsFromCsv.mockResolvedValueOnce({ odTrips: largeOdTripsArray, errors: [] });
         const currentCheckpoint = 0;
         const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false })};
-        await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
+        await batchRoute(parameters, defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
         expect(checkpointListenerMock).toHaveBeenCalledWith(250);
         expect(checkpointListenerMock).toHaveBeenCalledWith(500);
         expect(checkpointListenerMock).toHaveBeenCalledWith(750);
@@ -372,8 +375,8 @@ describe('Batch route from checkpoint', () => {
         const largeOdTripsArray = Array(756).fill(odTrips[0]);
         mockParseOdTripsFromCsv.mockResolvedValueOnce({ odTrips: largeOdTripsArray, errors: [] });
         const currentCheckpoint = 500;
-        const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test', detailed: false })};
-        await batchRoute(parameters, { routingModes: ['walking' ] }, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
+        const parameters = { type: 'csv' as const, configuration: Object.assign({}, defaultParameters, { calculationName: 'test' })};
+        await batchRoute(parameters,defaultBatchParameters, { jobId, absoluteBaseDirectory: absoluteDir, inputFileName, progressEmitter: socketMock, isCancelled: isCancelledMock, currentCheckpoint });
         expect(checkpointListenerMock).toHaveBeenCalledWith(750);
         expect(checkpointListenerMock).toHaveBeenCalledWith(756);
     });

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
@@ -111,7 +111,7 @@ describe('File generator: Only CSV results', () => {
 
     beforeAll(() => {
         resetFileStreams();
-        resultProcessor = createRoutingFileResultProcessor(absoluteDir, Object.assign({}, defaultParameters, { detailed: false, withGeometry: false }), new TransitRouting({ routingModes: testRoutingModes }), inputFileName);
+        resultProcessor = createRoutingFileResultProcessor(absoluteDir, defaultParameters, { routingModes: testRoutingModes, detailed: false, withGeometries: false }, inputFileName);
     })
 
     test('File initialization', () => {
@@ -162,7 +162,7 @@ describe('File generator: CSV and detailed results', () => {
     let resultProcessor;
     beforeAll(() => {
         resetFileStreams();
-        resultProcessor = createRoutingFileResultProcessor(absoluteDir, Object.assign({}, defaultParameters, { detailed: true, withGeometry: false }), new TransitRouting({ routingModes: testRoutingModes }), inputFileName);
+        resultProcessor = createRoutingFileResultProcessor(absoluteDir, defaultParameters, { routingModes: testRoutingModes, detailed: true, withGeometries: false }, inputFileName);
     })
 
     test('File initialization', () => {
@@ -228,7 +228,7 @@ describe('File generator: CSV and geojson results', () => {
     let resultProcessor;
     beforeAll(() => {
         resetFileStreams();
-        resultProcessor = createRoutingFileResultProcessor(absoluteDir, Object.assign({}, defaultParameters, { detailed: false, withGeometries: true }), new TransitRouting({ routingModes: testRoutingModes }), inputFileName);
+        resultProcessor = createRoutingFileResultProcessor(absoluteDir, defaultParameters, { routingModes: testRoutingModes, detailed: false, withGeometries: true }, inputFileName);
     })
 
     test('File initialization', () => {

--- a/packages/transition-common/src/services/accessibilityMap/TransitBatchAccessibilityMap.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitBatchAccessibilityMap.ts
@@ -6,9 +6,9 @@
  */
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import AccessibilityMapRouting from './TransitAccessibilityMapRouting';
-import { TransitDemandFromCsv, TransitDemandFromCsvAttributes } from '../transitDemand/TransitDemandFromCsv';
+import { TransitDemandFromCsv, DemandCsvAttributes } from '../transitDemand/TransitDemandFromCsv';
 
-export interface TransitBatchAccessibilityMapAttributes extends TransitDemandFromCsvAttributes {
+export interface TransitDemandFromCsvAccessMapAttributes extends DemandCsvAttributes {
     projection?: string;
     xAttribute?: string;
     yAttribute?: string;
@@ -16,11 +16,11 @@ export interface TransitBatchAccessibilityMapAttributes extends TransitDemandFro
 
 export const accessibilityMapPreferencesPath = 'accessibilityMap.batch';
 
-export class TransitBatchAccessibilityMap extends TransitDemandFromCsv<TransitBatchAccessibilityMapAttributes> {
+export class TransitBatchAccessibilityMap extends TransitDemandFromCsv<TransitDemandFromCsvAccessMapAttributes> {
     private _routing: AccessibilityMapRouting;
 
     constructor(
-        attributes: Partial<TransitBatchAccessibilityMapAttributes>,
+        attributes: Partial<TransitDemandFromCsvAccessMapAttributes>,
         isNew = false,
         routing: AccessibilityMapRouting
     ) {

--- a/packages/transition-common/src/services/accessibilityMap/TransitBatchAccessibilityMap.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitBatchAccessibilityMap.ts
@@ -12,6 +12,11 @@ export interface TransitDemandFromCsvAccessMapAttributes extends DemandCsvAttrib
     projection?: string;
     xAttribute?: string;
     yAttribute?: string;
+    // TODO Move to a BatchAccessMap type, similar to BatchCalculationParameters
+    detailed?: boolean;
+    withGeometries?: boolean;
+    cpuCount?: number;
+    maxCpuCount?: number;
 }
 
 export const accessibilityMapPreferencesPath = 'accessibilityMap.batch';
@@ -47,6 +52,19 @@ export class TransitBatchAccessibilityMap extends TransitDemandFromCsv<TransitDe
                 this._isValid = false;
                 this.errors.push('transit:transitRouting:errors:YAttributeIsMissing');
             }
+        }
+        if (typeof attributes.cpuCount !== 'number' && typeof attributes.maxCpuCount === 'number') {
+            attributes.cpuCount = attributes.maxCpuCount as number;
+        } else if (
+            typeof attributes.cpuCount === 'number' &&
+            typeof attributes.maxCpuCount === 'number' &&
+            attributes.cpuCount > attributes.maxCpuCount
+        ) {
+            // Automatically set the number of CPU to the max count
+            attributes.cpuCount = attributes.maxCpuCount;
+        } else if (typeof attributes.cpuCount === 'number' && attributes.cpuCount <= 0) {
+            // Minimum number of CPU is 1
+            attributes.cpuCount = 1;
         }
         return this._isValid;
     }

--- a/packages/transition-common/src/services/batchCalculation/__tests__/types.test.ts
+++ b/packages/transition-common/src/services/batchCalculation/__tests__/types.test.ts
@@ -6,16 +6,18 @@
  */
 import { BatchCalculationParameters, isBatchParametersValid } from '../types';
 
-describe('Test is valid', () => {
+describe('Test isBatchParametersValid', () => {
     test('Test valid, without transit', () => {
-        const parameters = { routingModes: ['walking' as const]};
+        const parameters = { routingModes: ['walking' as const], withGeometries: true, detailed: true };
         expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
     });
 
     test('Test valid, with transit, minimal', () => {
         const parameters: BatchCalculationParameters = { 
             routingModes: ['walking' as const, 'transit' as const],
-            scenarioId: 'arbitrary'
+            scenarioId: 'arbitrary',
+            withGeometries: true,
+            detailed: true
         };
         expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
     });
@@ -32,21 +34,82 @@ describe('Test is valid', () => {
             maxFirstWaitingTimeSeconds: 600,
             maxTotalTravelTimeSeconds: 3600,
             walkingSpeedMps: 5,
-            walkingSpeedFactor: 1
+            walkingSpeedFactor: 1,
+            withGeometries: false,
+            detailed: false
         };
         expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
     });
 
     test('Test invalid, missing routing modes', () => {
-        const parameters = { routingModes: []};
+        const parameters = { routingModes: [], withGeometries: true, detailed: true};
         expect(isBatchParametersValid(parameters)).toEqual({ valid: false, errors: ['transit:transitRouting:errors:RoutingModesIsEmpty']});
     });
 
     test('Test invalid, with transit missing scenario id', () => {
         const parameters: BatchCalculationParameters = { 
-            routingModes: ['walking' as const, 'transit' as const]
+            routingModes: ['walking' as const, 'transit' as const], withGeometries: true, detailed: true
         };
         expect(isBatchParametersValid(parameters)).toEqual({ valid: false, errors: ['transit:transitRouting:errors:ScenarioIsMissing']});
     });
 
+    test('Validate number of CPUs', () => {
+        const parameters: BatchCalculationParameters = { 
+            routingModes: ['walking' as const, 'transit' as const],
+            scenarioId: 'arbitrary',
+            withGeometries: true,
+            detailed: true
+        };
+        
+        // all cpu count has not been set, they should remain unset
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toBeUndefined();
+        expect(parameters.maxCpuCount).toBeUndefined();
+    
+        // Set a max count, the count should be the max count
+        const maxCpu = 4;
+        parameters.maxCpuCount = maxCpu;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(maxCpu);
+        expect(parameters.maxCpuCount).toEqual(maxCpu);
+    
+        // Set a valid count, should be unchanged
+        let cpuCount = 2;
+        parameters.cpuCount = cpuCount;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(cpuCount);
+        expect(parameters.maxCpuCount).toEqual(maxCpu);
+    
+        // Set a CPU count too high, should be back to max count
+        cpuCount = maxCpu + 2;
+        parameters.cpuCount = cpuCount;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(maxCpu);
+        expect(parameters.maxCpuCount).toEqual(maxCpu);
+    
+        // Set a CPU count below 0, should be set to 1
+        cpuCount = -1;
+        parameters.cpuCount = cpuCount;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(1);
+        expect(parameters.maxCpuCount).toEqual(maxCpu);
+    
+        // Set max to undefined, then set cpu count below to 0 or negative, should be 1
+        parameters.maxCpuCount = undefined;
+        parameters.cpuCount = 0;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(1);
+        expect(parameters.maxCpuCount).toBeUndefined();
+        parameters.cpuCount = -1;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(1);
+        expect(parameters.maxCpuCount).toBeUndefined();
+    
+        cpuCount = 10;
+        parameters.cpuCount = cpuCount;
+        expect(isBatchParametersValid(parameters)).toEqual({ valid: true, errors: []});
+        expect(parameters.cpuCount).toEqual(cpuCount);
+        expect(parameters.maxCpuCount).toBeUndefined();
+    });
 });
+

--- a/packages/transition-common/src/services/batchCalculation/types.ts
+++ b/packages/transition-common/src/services/batchCalculation/types.ts
@@ -1,4 +1,5 @@
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 import {
     TransitRoutingQueryAttributes,
     validateTrQueryAttributes
@@ -24,3 +25,11 @@ export const isBatchParametersValid = (parameters: BatchCalculationParameters) =
 export type BatchCalculationParameters = {
     routingModes: RoutingOrTransitMode[];
 } & TransitRoutingQueryAttributes;
+
+export interface TransitBatchCalculationResult {
+    calculationName: string;
+    detailed: boolean;
+    completed: boolean;
+    warnings: ErrorMessage[];
+    errors: ErrorMessage[];
+}

--- a/packages/transition-common/src/services/batchCalculation/types.ts
+++ b/packages/transition-common/src/services/batchCalculation/types.ts
@@ -4,26 +4,44 @@ import {
     TransitRoutingQueryAttributes,
     validateTrQueryAttributes
 } from '../transitRouting/TransitRoutingQueryAttributes';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 export const isBatchParametersValid = (parameters: BatchCalculationParameters) => {
     let parametersValid = true;
     const errors: string[] = [];
-    if (parameters.routingModes.length === 0) {
+    if (!Array.isArray(parameters.routingModes) || parameters.routingModes.length === 0) {
         parametersValid = false;
         errors.push('transit:transitRouting:errors:RoutingModesIsEmpty');
-    }
-    if (parameters.routingModes.includes('transit')) {
+    } else if (parameters.routingModes.includes('transit')) {
         const { valid: queryAttrValid, errors: queryAttrErrors } = validateTrQueryAttributes(parameters);
         if (!queryAttrValid) {
             parametersValid = false;
             errors.push(...queryAttrErrors);
         }
     }
+    if (typeof parameters.cpuCount !== 'number' && typeof parameters.maxCpuCount === 'number') {
+        parameters.cpuCount = parameters.maxCpuCount as number;
+    } else if (
+        typeof parameters.cpuCount === 'number' &&
+        typeof parameters.maxCpuCount === 'number' &&
+        parameters.cpuCount > parameters.maxCpuCount
+    ) {
+        // Automatically set the number of CPU to the max count
+        parameters.cpuCount = parameters.maxCpuCount;
+    } else if (typeof parameters.cpuCount === 'number' && parameters.cpuCount <= 0) {
+        // Minimum number of CPU is 1
+        parameters.cpuCount = 1;
+    }
     return { valid: parametersValid, errors };
 };
 
 export type BatchCalculationParameters = {
     routingModes: RoutingOrTransitMode[];
+    withGeometries: boolean;
+    detailed: boolean;
+    // TODO Remove these from this object once trRouting is parallel
+    cpuCount?: number;
+    maxCpuCount?: number;
 } & TransitRoutingQueryAttributes;
 
 export interface TransitBatchCalculationResult {

--- a/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
@@ -18,8 +18,7 @@ import { TransitDemandFromCsvAttributes } from './types';
  * Base attributes for any batch transit calculation, like routing or accessibility map
  */
 export interface DemandCsvAttributes extends GenericAttributes, Partial<TransitDemandFromCsvAttributes> {
-    // TODO Remove these from this object once trRouting is parallel
-    maxCpuCount?: number;
+    /* Nothing else to add */
 }
 
 export abstract class TransitDemandFromCsv<T extends DemandCsvAttributes> extends ObjectWithHistory<T> {
@@ -53,19 +52,7 @@ export abstract class TransitDemandFromCsv<T extends DemandCsvAttributes> extend
                 this.errors.push('transit:transitRouting:errors:TimeAttributeIsMissing');
             }
         }
-        if (_isBlank(attributes.cpuCount) && !_isBlank(attributes.maxCpuCount)) {
-            attributes.cpuCount = attributes.maxCpuCount;
-        } else if (
-            !_isBlank(attributes.cpuCount) &&
-            !_isBlank(attributes.maxCpuCount) &&
-            (attributes.cpuCount as number) > (attributes.maxCpuCount as number)
-        ) {
-            // Automatically set the number of CPU to the max count
-            attributes.cpuCount = attributes.maxCpuCount;
-        } else if (!_isBlank(attributes.cpuCount) && (attributes.cpuCount as number) <= 0) {
-            // Minimum number of CPU is 1
-            attributes.cpuCount = 1;
-        }
+
         return this._isValid;
 
         // TODO: add validations for all attributes fields

--- a/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
@@ -12,7 +12,7 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { parseCsvFile } from 'chaire-lib-common/lib/utils/files/CsvFile';
-import { TransitBatchDemandFromCsvAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchDemandFromCsvAttributes } from './types';
 
 /**
  * Base attributes for any batch transit calculation, like routing or accessibility map

--- a/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
@@ -12,19 +12,17 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { parseCsvFile } from 'chaire-lib-common/lib/utils/files/CsvFile';
-import { TransitBatchDemandFromCsvAttributes } from './types';
+import { TransitDemandFromCsvAttributes } from './types';
 
 /**
  * Base attributes for any batch transit calculation, like routing or accessibility map
  */
-export interface TransitDemandFromCsvAttributes
-    extends GenericAttributes,
-        Partial<TransitBatchDemandFromCsvAttributes> {
+export interface DemandCsvAttributes extends GenericAttributes, Partial<TransitDemandFromCsvAttributes> {
     // TODO Remove these from this object once trRouting is parallel
     maxCpuCount?: number;
 }
 
-export abstract class TransitDemandFromCsv<T extends TransitDemandFromCsvAttributes> extends ObjectWithHistory<T> {
+export abstract class TransitDemandFromCsv<T extends DemandCsvAttributes> extends ObjectWithHistory<T> {
     private _preferencesPath: string;
 
     constructor(attributes: Partial<T>, isNew = false, preferencesPath: string) {

--- a/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
@@ -10,7 +10,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import DataSourceCollection from '../dataSource/DataSourceCollection';
 import { TransitDemandFromCsv, TransitDemandFromCsvAttributes } from './TransitDemandFromCsv';
-import { TransitBatchRoutingDemandFromCsvAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchRoutingDemandFromCsvAttributes } from './types';
 
 export type TransitOdDemandFromCsvAttributes = TransitDemandFromCsvAttributes &
     Partial<TransitBatchRoutingDemandFromCsvAttributes>;

--- a/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
@@ -9,11 +9,10 @@ import _cloneDeep from 'lodash.clonedeep';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import DataSourceCollection from '../dataSource/DataSourceCollection';
-import { TransitDemandFromCsv, TransitDemandFromCsvAttributes } from './TransitDemandFromCsv';
-import { TransitBatchRoutingDemandFromCsvAttributes } from './types';
+import { TransitDemandFromCsv, DemandCsvAttributes } from './TransitDemandFromCsv';
+import { TransitDemandFromCsvRoutingAttributes } from './types';
 
-export type TransitOdDemandFromCsvAttributes = TransitDemandFromCsvAttributes &
-    Partial<TransitBatchRoutingDemandFromCsvAttributes>;
+export type TransitOdDemandFromCsvAttributes = DemandCsvAttributes & Partial<TransitDemandFromCsvRoutingAttributes>;
 
 /**
  * Describe a CSV file field mapping for a transition origin/destination pair file

--- a/packages/transition-common/src/services/transitDemand/__tests__/TransitOdDemandFromCsv.test.ts
+++ b/packages/transition-common/src/services/transitDemand/__tests__/TransitOdDemandFromCsv.test.ts
@@ -22,60 +22,6 @@ serviceLocator.addService('collectionManager', collectionManager);
 
 beforeEach(() => {
     parseCsvFileMock.mockClear();
-})
-
-test('Validate number of CPUs', () => {
-    const batchRouting = new TransitOdDemandFromCsv({}, false);
-    
-    // all cpu count has not been set, they should remain unset
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toBeUndefined();
-    expect(batchRouting.getAttributes().maxCpuCount).toBeUndefined();
-
-    // Set a max count, the count should be the max count
-    const maxCpu = 4;
-    batchRouting.getAttributes().maxCpuCount = maxCpu;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(maxCpu);
-    expect(batchRouting.getAttributes().maxCpuCount).toEqual(maxCpu);
-
-    // Set a valid count, should be unchanged
-    let cpuCount = 2;
-    batchRouting.getAttributes().cpuCount = cpuCount;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(cpuCount);
-    expect(batchRouting.getAttributes().maxCpuCount).toEqual(maxCpu);
-
-    // Set a CPU count too high, should be back to max count
-    cpuCount = maxCpu + 2;
-    batchRouting.getAttributes().cpuCount = cpuCount;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(maxCpu);
-    expect(batchRouting.getAttributes().maxCpuCount).toEqual(maxCpu);
-
-    // Set a CPU count below 0, should be set to 1
-    cpuCount = -1;
-    batchRouting.getAttributes().cpuCount = cpuCount;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(1);
-    expect(batchRouting.getAttributes().maxCpuCount).toEqual(maxCpu);
-
-    // Set max to undefined, then set cpu count below to 0 or negative, should be 1
-    batchRouting.getAttributes().maxCpuCount = undefined;
-    batchRouting.getAttributes().cpuCount = 0;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(1);
-    expect(batchRouting.getAttributes().maxCpuCount).toBeUndefined();
-    batchRouting.getAttributes().cpuCount = -1;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(1);
-    expect(batchRouting.getAttributes().maxCpuCount).toBeUndefined();
-
-    cpuCount = 10;
-    batchRouting.getAttributes().cpuCount = cpuCount;
-    batchRouting.validate();
-    expect(batchRouting.getAttributes().cpuCount).toEqual(cpuCount);
-    expect(batchRouting.getAttributes().maxCpuCount).toBeUndefined();
 });
 
 describe('validate saveToDb', () => {

--- a/packages/transition-common/src/services/transitDemand/types.ts
+++ b/packages/transition-common/src/services/transitDemand/types.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import TransitOdDemandFromCsv from './TransitOdDemandFromCsv';
-
 export type TransitDemandFromCsvAttributes = {
     calculationName: string;
     projection: string;
@@ -35,10 +33,4 @@ export type TransitBatchRoutingDemandAttributes = {
 export type TransitDemandFromCsvAccessMapAttributes = TransitDemandFromCsvAttributes & {
     xAttribute: string;
     yAttribute: string;
-};
-
-export type TransitDemandFromCsvFile = {
-    type: 'csv';
-    demand: TransitOdDemandFromCsv;
-    csvFields: string[];
 };

--- a/packages/transition-common/src/services/transitDemand/types.ts
+++ b/packages/transition-common/src/services/transitDemand/types.ts
@@ -6,7 +6,7 @@
  */
 import TransitOdDemandFromCsv from './TransitOdDemandFromCsv';
 
-export type TransitBatchDemandFromCsvAttributes = {
+export type TransitDemandFromCsvAttributes = {
     calculationName: string;
     projection: string;
     idAttribute: string;
@@ -19,7 +19,7 @@ export type TransitBatchDemandFromCsvAttributes = {
     csvFile: { location: 'upload'; filename: string } | { location: 'server'; fromJob: number };
 };
 
-export type TransitBatchRoutingDemandFromCsvAttributes = TransitBatchDemandFromCsvAttributes & {
+export type TransitDemandFromCsvRoutingAttributes = TransitDemandFromCsvAttributes & {
     originXAttribute: string;
     originYAttribute: string;
     destinationXAttribute: string;
@@ -29,10 +29,10 @@ export type TransitBatchRoutingDemandFromCsvAttributes = TransitBatchDemandFromC
 
 export type TransitBatchRoutingDemandAttributes = {
     type: 'csv';
-    configuration: TransitBatchRoutingDemandFromCsvAttributes;
+    configuration: TransitDemandFromCsvRoutingAttributes;
 };
 
-export type TransitBatchAccessibilityMapAttributes = TransitBatchDemandFromCsvAttributes & {
+export type TransitDemandFromCsvAccessMapAttributes = TransitDemandFromCsvAttributes & {
     xAttribute: string;
     yAttribute: string;
 };

--- a/packages/transition-common/src/services/transitDemand/types.ts
+++ b/packages/transition-common/src/services/transitDemand/types.ts
@@ -11,9 +11,6 @@ export type TransitDemandFromCsvAttributes = {
     timeAttributeDepartureOrArrival: 'arrival' | 'departure';
     timeFormat: string;
     timeAttribute: string;
-    withGeometries: boolean;
-    detailed: boolean;
-    cpuCount: number;
     csvFile: { location: 'upload'; filename: string } | { location: 'server'; fromJob: number };
 };
 
@@ -33,4 +30,10 @@ export type TransitBatchRoutingDemandAttributes = {
 export type TransitDemandFromCsvAccessMapAttributes = TransitDemandFromCsvAttributes & {
     xAttribute: string;
     yAttribute: string;
+    // TODO For batch routing, these parameters were moved to batch calculation. They should too for batch access map, when we refactor this calculation a similar way
+    withGeometries: boolean;
+    detailed: boolean;
+    // TODO Remove these from this object once trRouting is parallel
+    cpuCount: number;
+    maxCpuCount?: number;
 };

--- a/packages/transition-common/src/services/transitDemand/types.ts
+++ b/packages/transition-common/src/services/transitDemand/types.ts
@@ -4,8 +4,38 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-
 import TransitOdDemandFromCsv from './TransitOdDemandFromCsv';
+
+export type TransitBatchDemandFromCsvAttributes = {
+    calculationName: string;
+    projection: string;
+    idAttribute: string;
+    timeAttributeDepartureOrArrival: 'arrival' | 'departure';
+    timeFormat: string;
+    timeAttribute: string;
+    withGeometries: boolean;
+    detailed: boolean;
+    cpuCount: number;
+    csvFile: { location: 'upload'; filename: string } | { location: 'server'; fromJob: number };
+};
+
+export type TransitBatchRoutingDemandFromCsvAttributes = TransitBatchDemandFromCsvAttributes & {
+    originXAttribute: string;
+    originYAttribute: string;
+    destinationXAttribute: string;
+    destinationYAttribute: string;
+    saveToDb: false | { type: 'new'; dataSourceName: string } | { type: 'overwrite'; dataSourceId: string };
+};
+
+export type TransitBatchRoutingDemandAttributes = {
+    type: 'csv';
+    configuration: TransitBatchRoutingDemandFromCsvAttributes;
+};
+
+export type TransitBatchAccessibilityMapAttributes = TransitBatchDemandFromCsvAttributes & {
+    xAttribute: string;
+    yAttribute: string;
+};
 
 export type TransitDemandFromCsvFile = {
     type: 'csv';

--- a/packages/transition-common/src/services/transitRouting/TransitBatchRoutingCalculator.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitBatchRoutingCalculator.ts
@@ -11,8 +11,7 @@ import { TransitBatchRoutingDemandAttributes } from '../transitDemand/types';
 import { TransitBatchCalculationResult } from '../batchCalculation/types';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import TransitOdDemandFromCsv from '../transitDemand/TransitOdDemandFromCsv';
-import { validateTrQueryAttributes } from './TransitRoutingQueryAttributes';
-import { BatchCalculationParameters } from '../batchCalculation/types';
+import { BatchCalculationParameters, isBatchParametersValid } from '../batchCalculation/types';
 
 export class TransitBatchRoutingCalculator {
     private static async _calculate(
@@ -56,7 +55,7 @@ export class TransitBatchRoutingCalculator {
             console.error(trError.export());
             throw trError;
         }
-        if (!validateTrQueryAttributes(queryAttributes).valid) {
+        if (!isBatchParametersValid(queryAttributes).valid) {
             const trError = new TrError(
                 'cannot calculate transit batch route: the routing parameters are invalid',
                 'TRBROUTING0002',
@@ -72,7 +71,6 @@ export class TransitBatchRoutingCalculator {
             configuration: {
                 calculationName: attributes.calculationName as string,
                 projection: attributes.projection as string,
-                detailed: attributes.detailed || false,
                 idAttribute: attributes.idAttribute as string,
                 originXAttribute: attributes.originXAttribute as string,
                 originYAttribute: attributes.originYAttribute as string,
@@ -81,8 +79,6 @@ export class TransitBatchRoutingCalculator {
                 timeAttributeDepartureOrArrival: attributes.timeAttributeDepartureOrArrival || 'departure',
                 timeFormat: attributes.timeFormat as string,
                 timeAttribute: attributes.timeAttribute as string,
-                withGeometries: attributes.withGeometries || false,
-                cpuCount: attributes.cpuCount || 1,
                 saveToDb: attributes.saveToDb || false,
                 csvFile:
                     attributes.csvFile === undefined

--- a/packages/transition-common/src/services/transitRouting/TransitBatchRoutingCalculator.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitBatchRoutingCalculator.ts
@@ -6,11 +6,9 @@
  */
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import {
-    TrRoutingConstants,
-    TransitBatchRoutingDemandAttributes,
-    TransitBatchCalculationResult
-} from 'chaire-lib-common/lib/api/TrRouting';
+import { TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchRoutingDemandAttributes } from '../transitDemand/types';
+import { TransitBatchCalculationResult } from '../batchCalculation/types';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import TransitOdDemandFromCsv from '../transitDemand/TransitOdDemandFromCsv';
 import { validateTrQueryAttributes } from './TransitRoutingQueryAttributes';

--- a/packages/transition-common/src/services/transitRouting/__tests__/TransitBatchRoutingCalculator.test.ts
+++ b/packages/transition-common/src/services/transitRouting/__tests__/TransitBatchRoutingCalculator.test.ts
@@ -7,13 +7,8 @@
 import { EventEmitter } from 'events';
 import { TransitBatchRoutingCalculator } from '../TransitBatchRoutingCalculator';
 import { TransitOdDemandFromCsv } from '../../transitDemand/TransitOdDemandFromCsv';
-import { TransitRouting } from '../TransitRouting';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
-import { TransitRoutingQueryAttributes } from '../../transitRouting/TransitRoutingQueryAttributes';
-import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
-import DataSourceCollection from '../../dataSource/DataSourceCollection';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import DataSource from '../../dataSource/DataSource';
 import { TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
 
 const socketMock = new EventEmitter();
@@ -42,11 +37,6 @@ describe('Test Calculate', () => {
         timeAttributeDepartureOrArrival: 'arrival' as const,
         timeFormat: 'HH:MM',
         timeAttribute: 'time',
-        withGeometries: false,
-        detailed: false,
-        // TODO Remove these from this object once trRouting is parallel
-        cpuCount: 1,
-        maxCpuCount: 2,
         idAttribute: 'id',
         originXAttribute: 'xorig',
         originYAttribute: 'yorig',
@@ -58,14 +48,18 @@ describe('Test Calculate', () => {
     const defaultQueryParams = {
         routingModes: [ 'walking' as const ],
         minWaitingTimeSeconds: 180,
-        scenarioId: 'scenarioId'
+        scenarioId: 'scenarioId',
+        detailed:false,
+        withGeometries: false,
+        // TODO Remove these from this object once trRouting is parallel
+        cpuCount: 1,
+        maxCpuCount: 2,
     };
     const expectedDemand = {
         type: 'csv',
         configuration: {
             calculationName: defaultDemandAttributes.calculationName,
             projection: defaultDemandAttributes.projection,
-            detailed: defaultDemandAttributes.detailed,
             idAttribute: defaultDemandAttributes.idAttribute,
             originXAttribute: defaultDemandAttributes.originXAttribute,
             originYAttribute: defaultDemandAttributes.originYAttribute,
@@ -74,8 +68,6 @@ describe('Test Calculate', () => {
             timeAttributeDepartureOrArrival: defaultDemandAttributes.timeAttributeDepartureOrArrival,
             timeFormat: defaultDemandAttributes.timeFormat,
             timeAttribute: defaultDemandAttributes.timeAttribute,
-            withGeometries: defaultDemandAttributes.withGeometries,
-            cpuCount: defaultDemandAttributes.cpuCount,
             saveToDb: defaultDemandAttributes.saveToDb,
             csvFile: { location: 'upload', filename: 'input.csv' }
         }

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/widgets/BatchAttributesSelection.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/widgets/BatchAttributesSelection.tsx
@@ -7,16 +7,16 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import { TransitBatchAccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitBatchAccessibilityMap';
+import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitBatchAccessibilityMap';
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import * as BatchAttributeSelectionWidgets from '../../transitCalculation/widgets/AttributeSelectionWidget';
 
 export interface BatchAttributesSelectionComponentProps extends WithTranslation {
-    attributes: TransitBatchAccessibilityMapAttributes;
+    attributes: TransitDemandFromCsvAccessMapAttributes;
     csvAttributes: string[];
     onValueChange: (
-        path: keyof TransitBatchAccessibilityMapAttributes,
+        path: keyof TransitDemandFromCsvAccessMapAttributes,
         newValue: { value: any; valid?: boolean }
     ) => void;
 }

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -18,7 +18,7 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 import ConfirmCalculationForm from './stepForms/ConfirmCalculationForm';
 import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
-import { TransitBatchRoutingDemandAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
 import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
 
 export interface BatchCalculationFormProps {

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationForm.tsx
@@ -12,7 +12,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import ConfigureDemandFromCsvForm from './stepForms/ConfigureDemandFromCsvForm';
-import { TransitDemandFromCsvFile } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvFile } from '../../../services/transitDemand/frontendTypes';
 import ConfigureBatchCalculationForm from './stepForms/ConfigureBatchCalculationForm';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
@@ -14,7 +14,7 @@ import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
 import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
-import { TransitBatchRoutingDemandAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -12,8 +12,7 @@ import BatchCalculationList from './BatchCalculationList';
 import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import BatchCalculationForm from './BatchCalculationForm';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
-import { TransitOdDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
-import { TransitBatchRoutingDemandAttributes } from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
 
 export interface CalculationPanelPanelProps {
     availableRoutingModes?: string[];

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import _cloneDeep from 'lodash.clonedeep';
+import _toString from 'lodash.tostring';
 
 import { _toBool } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
@@ -20,6 +21,10 @@ import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
+import * as BatchAttributeSelectionWidgets from '../../transitCalculation/widgets/AttributeSelectionWidget';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
+import { _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 export interface ConfigureCalculationParametersFormProps {
     routingParameters: BatchCalculationParameters;
@@ -44,6 +49,10 @@ const ConfigureCalculationParametersForm: React.FunctionComponent<
         // validate the data on first load
         const { valid } = isBatchParametersValid(props.routingParameters);
         props.onUpdate(props.routingParameters, valid);
+        // Get the max cpu count
+        serviceLocator.socketEventManager.emit('service.parallelThreadCount', (response) => {
+            onValueChange('maxCpuCount', { value: response.count });
+        });
     }, []);
 
     const onValueChange = (path: keyof BatchCalculationParameters, newValue: { value: any; valid?: boolean }): void => {
@@ -118,6 +127,26 @@ const ConfigureCalculationParametersForm: React.FunctionComponent<
                             t={props.t}
                             isBoolean={true}
                             onValueChange={(e) => onValueChange('withAlternatives', { value: _toBool(e.target.value) })}
+                        />
+                    </InputWrapper>
+                    <BatchAttributeSelectionWidgets.BooleanAttributeSelectionWidget
+                        currentAttribute="detailed"
+                        onValueChange={onValueChange}
+                        attributes={props.routingParameters}
+                    />
+                    <BatchAttributeSelectionWidgets.BooleanAttributeSelectionWidget
+                        currentAttribute="withGeometries"
+                        onValueChange={onValueChange}
+                        attributes={props.routingParameters}
+                    />
+                    <InputWrapper smallInput={true} label={props.t('transit:transitRouting:CpuCount')}>
+                        <InputStringFormatted
+                            id={'formFieldTransitBatchRoutingCpuCount'}
+                            value={props.routingParameters.cpuCount}
+                            onValueUpdated={(value) => onValueChange('cpuCount', value)}
+                            stringToValue={_toInteger}
+                            valueToString={_toString}
+                            type={'number'}
                         />
                     </InputWrapper>
                 </React.Fragment>

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureDemandFromCsvForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureDemandFromCsvForm.tsx
@@ -19,7 +19,7 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import BatchAttributesSelection from '../../transitRouting/widgets/BatchAttributesSelection';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { TransitDemandFromCsvFile } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvFile } from '../../../../services/transitDemand/frontendTypes';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 
 interface ConfigureDemandFromCsvFormProps {

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
@@ -11,7 +11,7 @@ import ScenarioCollection from 'transition-common/lib/services/scenario/Scenario
 import { secondsToMinutes } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
-import { TransitDemandFromCsvFile } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvFile } from '../../../../services/transitDemand/frontendTypes';
 
 export interface ConfirmCalculationFormProps {
     currentDemand: TransitDemandFromCsvFile;

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfirmCalculationForm.tsx
@@ -49,14 +49,6 @@ const ConfirmCalculationForm: React.FunctionComponent<ConfirmCalculationFormProp
                         </td>
                     </tr>
                     <tr>
-                        <th>{props.t('transit:transitRouting:Detailed')}</th>
-                        <td>{props.t(`transit:transitRouting:${demandAttributes.detailed || false}`)}</td>
-                    </tr>
-                    <tr>
-                        <th>{props.t('transit:transitRouting:WithGeometries')}</th>
-                        <td>{props.t(`transit:transitRouting:${demandAttributes.withGeometries || false}`)}</td>
-                    </tr>
-                    <tr>
                         <th className="_header" colSpan={2}>
                             {props.t('transit:batchCalculation:AnalysisParameters')}
                         </th>
@@ -98,6 +90,18 @@ const ConfirmCalculationForm: React.FunctionComponent<ConfirmCalculationFormProp
                     <tr>
                         <th>{props.t('transit:transitRouting:WithAlternatives')}</th>
                         <td>{props.t(`transit:transitRouting:${props.routingParameters.withAlternatives}`)}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:Detailed')}</th>
+                        <td>{props.t(`transit:transitRouting:${props.routingParameters.detailed || false}`)}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:WithGeometries')}</th>
+                        <td>{props.t(`transit:transitRouting:${props.routingParameters.withGeometries || false}`)}</td>
+                    </tr>
+                    <tr>
+                        <th>{props.t('transit:transitRouting:CpuCount')}</th>
+                        <td>{`${props.routingParameters.cpuCount || 1}`}</td>
                     </tr>
                 </tbody>
             </table>

--- a/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
+++ b/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
@@ -8,18 +8,18 @@ import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import _toString from 'lodash.tostring';
 
-import { TransitDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/TransitDemandFromCsv';
+import { TransitDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/types';
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
 import { _toBool } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
-interface BatchAttributeSelectionComponentProps<T extends TransitDemandFromCsvAttributes> {
+interface BatchAttributeSelectionComponentProps<T extends Partial<TransitDemandFromCsvAttributes>> {
     currentAttribute: keyof T;
     attributes: T;
     onValueChange: (path: keyof T, newValue: { value: any; valid?: boolean }) => void;
 }
 
-interface BatchCsvAttributeSelectionComponentProps<T extends TransitDemandFromCsvAttributes>
+interface BatchCsvAttributeSelectionComponentProps<T extends Partial<TransitDemandFromCsvAttributes>>
     extends BatchAttributeSelectionComponentProps<T> {
     csvAttributes: string[];
 }
@@ -36,7 +36,7 @@ const getCsvAttributeChoice = (csvAttributes: string[]) => {
         : [];
 };
 
-function CsvAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttributes>(
+function CsvAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
     props: BatchCsvAttributeSelectionComponentProps<T> & WithTranslation
 ) {
     const csvAttributesChoices = getCsvAttributeChoice(props.csvAttributes);
@@ -57,12 +57,12 @@ function CsvAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttribute
 }
 
 export const CsvAttributeSelectionWidget = withTranslation(['transit', 'main'])(CsvAttributeSelectionWidgetBase) as <
-    T extends TransitDemandFromCsvAttributes
+    T extends Partial<TransitDemandFromCsvAttributes>
 >(
     props: BatchCsvAttributeSelectionComponentProps<T>
 ) => any;
 
-function BooleanAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttributes>(
+function BooleanAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
     props: BatchAttributeSelectionComponentProps<T> & WithTranslation
 ) {
     return (
@@ -94,9 +94,9 @@ function BooleanAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttri
 
 export const BooleanAttributeSelectionWidget = withTranslation(['transit', 'main'])(
     BooleanAttributeSelectionWidgetBase
-) as <T extends TransitDemandFromCsvAttributes>(props: BatchAttributeSelectionComponentProps<T>) => any;
+) as <T extends Partial<TransitDemandFromCsvAttributes>>(props: BatchAttributeSelectionComponentProps<T>) => any;
 
-function TimeAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttributes>(
+function TimeAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
     props: BatchCsvAttributeSelectionComponentProps<T> & WithTranslation
 ) {
     const csvAttributesChoices = getCsvAttributeChoice(props.csvAttributes);
@@ -140,7 +140,7 @@ function TimeAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttribut
 
 export const TimeAttributeSelectionWidget = withTranslation(['transit', 'main'])(TimeAttributeSelectionWidgetBase);
 
-function TimeFormatAttributeSelectionWidgetBase<T extends TransitDemandFromCsvAttributes>(
+function TimeFormatAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
     props: BatchAttributeSelectionComponentProps<T> & WithTranslation
 ) {
     const timeFormats = [

--- a/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
+++ b/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
@@ -6,21 +6,22 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _toString from 'lodash.tostring';
 
 import { TransitDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/types';
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
 import { _toBool } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
-interface BatchAttributeSelectionComponentProps<T extends Partial<TransitDemandFromCsvAttributes>> {
+// Can't use Record<string, unknown> instead of Object because our types are interfaces and/or include Partial and they can't be assigned. See https://github.com/microsoft/TypeScript/issues/15300
+// eslint-disable-next-line @typescript-eslint/ban-types
+interface BatchAttributeSelectionComponentProps<T extends Object> {
     currentAttribute: keyof T;
     attributes: T;
     onValueChange: (path: keyof T, newValue: { value: any; valid?: boolean }) => void;
 }
 
-interface BatchCsvAttributeSelectionComponentProps<T extends Partial<TransitDemandFromCsvAttributes>>
-    extends BatchAttributeSelectionComponentProps<T> {
+// eslint-disable-next-line @typescript-eslint/ban-types
+interface BatchCsvAttributeSelectionComponentProps<T extends Object> extends BatchAttributeSelectionComponentProps<T> {
     csvAttributes: string[];
 }
 
@@ -36,7 +37,8 @@ const getCsvAttributeChoice = (csvAttributes: string[]) => {
         : [];
 };
 
-function CsvAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
+// eslint-disable-next-line @typescript-eslint/ban-types
+function CsvAttributeSelectionWidgetBase<T extends Object>(
     props: BatchCsvAttributeSelectionComponentProps<T> & WithTranslation
 ) {
     const csvAttributesChoices = getCsvAttributeChoice(props.csvAttributes);
@@ -57,12 +59,14 @@ function CsvAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvA
 }
 
 export const CsvAttributeSelectionWidget = withTranslation(['transit', 'main'])(CsvAttributeSelectionWidgetBase) as <
-    T extends Partial<TransitDemandFromCsvAttributes>
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    T extends Object
 >(
     props: BatchCsvAttributeSelectionComponentProps<T>
 ) => any;
 
-function BooleanAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
+// eslint-disable-next-line @typescript-eslint/ban-types
+function BooleanAttributeSelectionWidgetBase<T extends Object>(
     props: BatchAttributeSelectionComponentProps<T> & WithTranslation
 ) {
     return (
@@ -94,7 +98,8 @@ function BooleanAttributeSelectionWidgetBase<T extends Partial<TransitDemandFrom
 
 export const BooleanAttributeSelectionWidget = withTranslation(['transit', 'main'])(
     BooleanAttributeSelectionWidgetBase
-) as <T extends Partial<TransitDemandFromCsvAttributes>>(props: BatchAttributeSelectionComponentProps<T>) => any;
+    // eslint-disable-next-line @typescript-eslint/ban-types
+) as <T extends Object>(props: BatchAttributeSelectionComponentProps<T>) => any;
 
 function TimeAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
     props: BatchCsvAttributeSelectionComponentProps<T> & WithTranslation

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -40,23 +40,6 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
         };
     }
 
-    // FIXME Keep the max parallel calculator code for now, until it is completely migrated in the new scenario analysis
-    private setMaxParallelCalculators(max: number) {
-        const batchRoutingEngine = this.state.object;
-        batchRoutingEngine.attributes.maxCpuCount = max;
-        batchRoutingEngine.attributes.cpuCount = Math.min(batchRoutingEngine.attributes.cpuCount || max, max);
-        batchRoutingEngine.validate();
-        this.setState({
-            object: batchRoutingEngine
-        });
-    }
-
-    componentDidMount() {
-        serviceLocator.socketEventManager.emit('service.parallelThreadCount', (response) => {
-            this.setMaxParallelCalculators(response.count);
-        });
-    }
-
     render() {
         // TODO This feature has moved in february 2023. Keep this message for a
         // few months, just so users get a warning if they are used to coming

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/BatchAttributesSelection.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/BatchAttributesSelection.tsx
@@ -80,16 +80,6 @@ const BatchAttributesSelectionComponent: React.FunctionComponent<BatchAttributes
                 onValueChange={props.onValueChange}
                 attributes={props.attributes}
             />
-            <BatchAttributeSelectionWidgets.BooleanAttributeSelectionWidget
-                currentAttribute="detailed"
-                onValueChange={props.onValueChange}
-                attributes={props.attributes}
-            />
-            <BatchAttributeSelectionWidgets.BooleanAttributeSelectionWidget
-                currentAttribute="withGeometries"
-                onValueChange={props.onValueChange}
-                attributes={props.attributes}
-            />
         </React.Fragment>
     );
 };

--- a/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
+++ b/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
@@ -7,7 +7,7 @@
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import TransitBatchAccessibilityMap from 'transition-common/lib/services/accessibilityMap/TransitBatchAccessibilityMap';
-import { TransitBatchAccessibilityMapAttributes as TransitBatchAccessibilityMapAttributesBase } from 'transition-common/lib/services/transitDemand/types';
+import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
 import AccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
@@ -29,7 +29,7 @@ export interface TransitMapCalculationOptions {
 
 export class BatchAccessibilityMapCalculator {
     private static async _calculate(
-        params: TransitBatchAccessibilityMapAttributesBase,
+        params: TransitDemandFromCsvAccessMapAttributes,
         routingEngine: AccessibilityMapRouting
     ): Promise<any> {
         return new Promise((resolve, reject) => {
@@ -75,7 +75,7 @@ export class BatchAccessibilityMapCalculator {
         }
 
         const attributes = accessMap.attributes;
-        const parameters: TransitBatchAccessibilityMapAttributesBase = {
+        const parameters: TransitDemandFromCsvAccessMapAttributes = {
             calculationName: attributes.calculationName as string,
             projection: attributes.projection as string,
             detailed: attributes.detailed || false,

--- a/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
+++ b/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
@@ -7,10 +7,8 @@
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import TransitBatchAccessibilityMap from 'transition-common/lib/services/accessibilityMap/TransitBatchAccessibilityMap';
-import {
-    TransitBatchAccessibilityMapAttributes as TransitBatchAccessibilityMapAttributesBase,
-    TransitBatchCalculationResult
-} from 'chaire-lib-common/lib/api/TrRouting';
+import { TransitBatchAccessibilityMapAttributes as TransitBatchAccessibilityMapAttributesBase } from 'transition-common/lib/services/transitDemand/types';
+import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
 import AccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import * as Status from 'chaire-lib-common/lib/utils/Status';

--- a/packages/transition-frontend/src/services/transitDemand/frontendTypes.ts
+++ b/packages/transition-frontend/src/services/transitDemand/frontendTypes.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
+
+export type TransitDemandFromCsvFile = {
+    type: 'csv';
+    demand: TransitOdDemandFromCsv;
+    csvFields: string[];
+};


### PR DESCRIPTION
* Types related to batch calculation are moved from chaire-lib to transition-common
* Rename types that relate to the demand to contain only the word "Demand" instead of Batch (which is for calculation)
* Move to transition-frontend some types that are used only for the forms in the frontend
* Move the detailed and withGeometries parameters to the BatchCalculationParameters instead of being part of the demand

This is a pre-requisite step to implement OD Trip (demand) import and management