### PR TITLE
auth: Deserialize users with all attributes

### DIFF
--- a/packages/chaire-lib-backend/src/config/auth/index.ts
+++ b/packages/chaire-lib-backend/src/config/auth/index.ts
@@ -135,7 +135,7 @@ export default <U extends IUserModel>(authModel: IAuthModel<U>): PassportStatic 
         try {
             const model = await authModel.getById(id as number);
             if (model !== undefined) {
-                done(null, model.sanitize());
+                done(null, model.attributes);
                 return null;
             }
             done('User does not exist');

--- a/packages/chaire-lib-backend/src/services/auth/authModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/authModel.ts
@@ -18,6 +18,11 @@ export interface IUserModel {
     passwordResetExpireAt?: Moment | null;
     confirmationToken: string | null;
     isConfirmed: boolean;
+    /** Get the user attributes for this user, used in backend applications.
+     * Implementations can add data to these attributes */
+    attributes: UserAttributesBase;
+    /** Function that returns a base user with no confidential information. This
+     * user may be seen by the client */
     sanitize: () => BaseUser;
     verifyPassword: (password: string) => Promise<boolean>;
     updateAndSave(newAttribs: unknown): Promise<void>;


### PR DESCRIPTION
User deserialization is for backend only, so all users attributes can be returned instead of just a sanitized version. That was the previous implementation, before supporting multiple authentication models. It was changed, but the admin users now cannot have proper authorization in evolution, so attributes are returned again.