### PR TITLE
Fix the is_admin flag of the create-user task

### DIFF
--- a/packages/chaire-lib-backend/src/config/auth/__tests__/localLogin.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/auth/__tests__/localLogin.config.test.ts
@@ -205,7 +205,8 @@ test('Local signup strategy, auto-signon username and email', async () => {
         is_valid: true,
         is_test: false,
         is_confirmed: true,
-        confirmation_token: null
+        confirmation_token: null,
+        preferences: null
     });
 });
 
@@ -272,7 +273,8 @@ test('Local signup strategy, with email confirmation by user', async () => {
         is_valid: true,
         is_test: false,
         is_confirmed: false,
-        confirmation_token: expect.anything()
+        confirmation_token: expect.anything(),
+        preferences: null
     });
     const insertedUser: any = mockCreate.mock.calls[0][0];
 
@@ -325,7 +327,8 @@ test('Local signup strategy, with email confirmation by admin', async () => {
         is_valid: true,
         is_test: false,
         is_confirmed: false,
-        confirmation_token: expect.anything()
+        confirmation_token: expect.anything(),
+        preferences: null
     });
     const insertedUser: any = mockCreate.mock.calls[0][0];
 
@@ -374,7 +377,8 @@ test('Local signup strategy, with email confirmation by admin, urls without endi
         is_valid: true,
         is_test: false,
         is_confirmed: false,
-        confirmation_token: expect.anything()
+        confirmation_token: expect.anything(),
+        preferences: null
     });
     const insertedUser: any = mockCreate.mock.calls[0][0];
 

--- a/packages/chaire-lib-backend/src/config/auth/__tests__/passwordless.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/auth/__tests__/passwordless.config.test.ts
@@ -97,7 +97,8 @@ test('Passwordless login, first entry, direct access', async () => {
         is_valid: true,
         is_test: false,
         is_confirmed: true,
-        confirmation_token: null
+        confirmation_token: null,
+        preferences: null
     });
 
     expect(logInFct).toHaveBeenCalledWith({ id: newUserId, username: newUserEmail, email: newUserEmail, firstName: '', lastName: '', preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());

--- a/packages/chaire-lib-backend/src/services/auth/__tests__/anonymousLoginStrategy.test.ts
+++ b/packages/chaire-lib-backend/src/services/auth/__tests__/anonymousLoginStrategy.test.ts
@@ -66,7 +66,8 @@ test('Anonymous strategy success', async () => {
         is_valid: true,
         is_test: false,
         is_confirmed: true,
-        confirmation_token: null
+        confirmation_token: null,
+        preferences: null
     });
     expect(logInFct).toHaveBeenCalledWith({ id: newUserId, username: expect.stringContaining('anonym_'), email: undefined, firstName: '', lastName: '', preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());
 });

--- a/packages/chaire-lib-backend/src/services/auth/__tests__/userAuthModel.test.ts
+++ b/packages/chaire-lib-backend/src/services/auth/__tests__/userAuthModel.test.ts
@@ -146,7 +146,8 @@ describe('User creation', () => {
             is_confirmed: true,
             confirmation_token: null,
             is_admin: false,
-            is_test: false
+            is_test: false,
+            preferences: null
         }],
         ['User with username/email/password', {
             username: 'foo',
@@ -165,9 +166,10 @@ describe('User creation', () => {
             is_confirmed: true,
             confirmation_token: null,
             is_admin: false,
-            is_test: false
+            is_test: false,
+            preferences: null
         }],
-        ['With validity and confirmation', {
+        ['With validity, confirmation and is_admin', {
             email: 'foo@example.org',
             confirmationToken: aUuid,
             isTest: true
@@ -184,7 +186,52 @@ describe('User creation', () => {
             is_confirmed: false,
             confirmation_token: aUuid,
             is_admin: false,
-            is_test: true
+            is_test: true,
+            preferences: null
+        }], 
+        ['With is_admin, user first and last names and preferences', {
+            email: 'foo@example.org',
+            is_admin: true,
+            firstName: 'Foo',
+            lastName: 'Bar',
+            preferences: { lang: 'en' }
+        }, {
+            username: null,
+            email: 'foo@example.org',
+            google_id: null,
+            facebook_id: null,
+            generated_password: null,
+            password: null,
+            first_name: 'Foo',
+            last_name: 'Bar',
+            is_valid: true,
+            is_confirmed: true,
+            confirmation_token: null,
+            is_admin: true,
+            is_test: false,
+            preferences: { lang: 'en' }
+        }],
+        ['With invalid values', {
+            email: 'foo@example.org',
+            is_admin: 'some value',
+            isTest: 'some value',
+            preferences: `{ lang: 'en' }`,
+            confirmationToken: null
+        }, {
+            username: null,
+            email: 'foo@example.org',
+            google_id: null,
+            facebook_id: null,
+            generated_password: null,
+            password: null,
+            first_name: '',
+            last_name: '',
+            is_valid: true,
+            is_confirmed: false,
+            confirmation_token: null,
+            is_admin: false,
+            is_test: false,
+            preferences: null
         }]
     ]).test('%s', async (_description, params: NewUserParams, expectedUser: UserAttributes) => {
         createFct.mockImplementationOnce(async (data) => ({ id: 100, uuid: uuidV4(), ...data }));

--- a/packages/chaire-lib-backend/src/services/auth/authModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/authModel.ts
@@ -31,12 +31,17 @@ export interface IUserModel {
 export type NewUserParams = {
     username?: string;
     email?: string;
+    /** Unencrypted generated password, the authentication model should take care to save it as expected */
     generatedPassword?: string;
     googleId?: string;
     facebookId?: string;
+    /** Unencrypted password, the authentication model should take care to save it as expected */
     password?: string;
     isTest?: boolean;
     confirmationToken?: string;
+    firstName?: string;
+    lastName?: string;
+    preferences?: { [key: string]: any };
 };
 
 export interface IAuthModel<U extends IUserModel> {

--- a/packages/chaire-lib-backend/src/services/auth/userAuthModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/userAuthModel.ts
@@ -47,7 +47,7 @@ class UserAuthModel extends AuthModelBase<UserModel> {
             is_confirmed: userData.confirmationToken !== undefined ? false : true,
             confirmation_token: userData.confirmationToken !== undefined ? userData.confirmationToken : null,
             is_admin: false,
-            is_test: userData.isTest
+            is_test: userData.isTest === true
         });
         const user = this.newUser(userAttribs);
 

--- a/packages/chaire-lib-backend/src/services/auth/userAuthModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/userAuthModel.ts
@@ -30,7 +30,7 @@ class UserAuthModel extends AuthModelBase<UserModel> {
         super(dbQueries);
     }
 
-    createAndSave = async (userData: NewUserParams): Promise<UserModel> => {
+    createAndSave = async (userData: NewUserParams & { is_admin?: boolean }): Promise<UserModel> => {
         const userAttribs = await dbQueries.create({
             username: userData.username || null,
             email: userData.email || null,
@@ -41,13 +41,14 @@ class UserAuthModel extends AuthModelBase<UserModel> {
                 userData.googleId || userData.facebookId || !userData.password
                     ? null
                     : this.encryptPassword(userData.password),
-            first_name: '',
-            last_name: '',
+            first_name: userData.firstName || '',
+            last_name: userData.lastName || '',
             is_valid: userData.isTest === true ? false : true,
             is_confirmed: userData.confirmationToken !== undefined ? false : true,
             confirmation_token: userData.confirmationToken !== undefined ? userData.confirmationToken : null,
-            is_admin: false,
-            is_test: userData.isTest === true
+            is_admin: userData.is_admin === true,
+            is_test: userData.isTest === true,
+            preferences: typeof userData.preferences === 'object' ? userData.preferences : null
         });
         const user = this.newUser(userAttribs);
 

--- a/packages/chaire-lib-backend/src/tasks/user/__tests__/createUser.test.ts
+++ b/packages/chaire-lib-backend/src/tasks/user/__tests__/createUser.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import each from 'jest-each';
+
+import { CreateUser } from '../createUser';
+import config from '../../../config/server.config';
+import { userAuthModel } from '../../../services/auth/userAuthModel';
+
+jest.mock('../../../services/auth/userAuthModel', () => ({
+    userAuthModel: {
+        createAndSave: jest.fn(),
+        fetchAll: jest.fn().mockResolvedValue([{ username: 'foo', email: 'foo@test.com' }, { username: 'bar', email: null }, { username: null, email: 'baz@test.com' }])
+    }
+}));
+const mockCreateAndSave = userAuthModel.createAndSave as jest.MockedFunction<typeof userAuthModel.createAndSave>;
+
+beforeEach(() => {
+    mockCreateAndSave.mockClear();
+});
+
+each([
+    ['Valid user with default extra params', {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        first_name: 'Bob',
+        last_name: 'Baker'
+    }, {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        firstName: 'Bob',
+        lastName: 'Baker',
+        is_admin: false,
+        confirmationToken: undefined,
+        preferences: {}
+    }],
+    ['Unconfirmed user, with preferences', {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        first_name: 'Bob',
+        last_name: 'Baker',
+        confirmed: false,
+        prefs: '{"lang": "en"}'
+    }, {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        firstName: 'Bob',
+        lastName: 'Baker',
+        is_admin: false,
+        confirmationToken: expect.anything(),
+        preferences: { lang: 'en' }
+    }],
+    ['Admin user', {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        admin: true
+    }, {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        firstName: '',
+        lastName: '',
+        is_admin: true,
+        confirmationToken: undefined,
+        preferences: {}
+    }],
+    ['Random data in fields', {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        admin: 'gg',
+        confirmed: 'some value'
+    }, {
+        username: 'test',
+        email: 'test@test.org',
+        password: '111111',
+        firstName: '',
+        lastName: '',
+        is_admin: false,
+        confirmationToken: undefined,
+        preferences: {}
+    }],
+    ['Duplicate username', {
+        username: 'foo',
+        email: 'test@test.org',
+        password: '111111'
+    }],
+    ['Duplicate email', {
+        email: 'baz@test.com',
+        password: '111111'
+    }],
+    ['Invalid email', {
+        email: 'notAnEmail',
+        password: '111111',
+    }],
+    ['Invalid username', {
+        username: 'foo foo',
+        email: 'test@test.org',
+        password: '111111'
+    }],
+]).test('Create user with parameters: %s', async (_description, parameters, expectedAttributes = undefined) => {
+    const createUser = new CreateUser();
+    await createUser.run(parameters);
+
+    if (expectedAttributes !== undefined) {
+        expect(mockCreateAndSave).toHaveBeenCalledTimes(1);
+        expect(mockCreateAndSave).toHaveBeenCalledWith(expectedAttributes);
+    } else {
+        expect(mockCreateAndSave).not.toHaveBeenCalled();
+    }
+});


### PR DESCRIPTION
Also support preferences, first and last names for the user creation (which probably once worked but were broken).

Add unit tests for the createUser task