### PR TITLE
UI: Display split lines passing by a same segment

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -259,6 +259,8 @@
     "DefaultColor": "Default color",
     "DefaultWalkingSpeedKph": "Default walking speed (km/h)",
     "DefaultWalkingSpeedKphHelp": "Walking speed varies according to age and gender between 3 km/h (elderly people and young children) and 7 km/h (young and/or very active people). Men are on average a little faster than women and in general, walking speed decreases with age. The speed of a person in a manual wheelchair varies between 2 and 3 km/h depending on physical strength.",
+    "ExperimentalFeatures": "Experimental features",
+    "MapPrettyDisplay": "Display pretty lines and nodes on map",
     "transit": {
       "nodes": {
       }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -259,6 +259,8 @@
     "DefaultColor": "Couleur par défaut",
     "DefaultWalkingSpeedKph": "Vitesse de marche par défaut (km/h)",
     "DefaultWalkingSpeedKphHelp": "La vitesse de marche varie selon l'âge et le genre entre 3 km/h (personnes âges et jeunes enfants) et 7 km/h (personnes jeunes et/ou très actives). Les hommes sont en moyenne un peu plus rapides que les femmes et de manière générale, la vitesse de marche diminue avec l'âge. La vitesse d'une personne en chaise roulante manuelle varie entre 2 et 3 km/h selon la force physique.",
+    "ExperimentalFeatures": "Fonctionnalités expérimentales",
+    "MapPrettyDisplay": "Affichage esthétique des lignes et noeuds sur la carte",
     "transit": {
       "nodes": {
       }

--- a/packages/chaire-lib-common/src/services/geodata/ManageOverlappingLines.ts
+++ b/packages/chaire-lib-common/src/services/geodata/ManageOverlappingLines.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { lineOffset, lineOverlap, lineString, booleanPointInPolygon } from '@turf/turf';
+import { LineString, Feature, Polygon } from 'geojson';
+
+export const OFFSET_WIDTH = 3; // Offset of each line in meters
+
+interface OverlappingSegments {
+    /**
+     * GeoJSON data containing the overlapping coordinates
+     */
+    geoData: GeoJSON.Feature<LineString>;
+    /**
+     * Index of each line in conflict with the specified overlap
+     */
+    crossingLines: number[];
+    /**
+     * Directions of each line in conflict.
+     * True means the line has the overlap in the same coordinates order as geodata.
+     * False means the line has the overlap is in the opposite direction.
+     */
+    directions: boolean[];
+}
+
+/**
+ * Obtains the lines from a paths layer that have at least one coordinate inside the viewport.
+ * @param bounds - a bounding box Polygon that represents the viewport's coordinates
+ * @param layer - the paths layer that we want to get the visible lines from
+ * @return A collection of the lines that are in the viewport
+ */
+export const getLinesInView = (
+    bounds: Feature<Polygon>,
+    layer: GeoJSON.FeatureCollection<LineString>
+): GeoJSON.FeatureCollection<LineString> => {
+    const features = layer.features;
+    const linesInView: GeoJSON.FeatureCollection<LineString> = { type: 'FeatureCollection', features: [] };
+    for (let i = 0; i < features.length; i++) {
+        for (let j = 0; j < features[i].geometry.coordinates.length; j++) {
+            if (isInBounds(bounds, features[i].geometry.coordinates[j])) {
+                linesInView.features.push(features[i]);
+                break;
+            }
+        }
+    }
+    return linesInView;
+};
+
+const isInBounds = (bounds: Feature<Polygon>, coord: number[]): boolean => {
+    return booleanPointInPolygon(coord, bounds);
+};
+
+/**
+ * Offset overlapping lines when multiple lines use the same road or segment.
+ * This is to be able to visually follow where each line goes.
+ * @param layerData GeoJSON data containing the lines to offset (will be modified)
+ */
+export const offsetOverlappingLines = async (
+    layerData: GeoJSON.FeatureCollection<LineString>,
+    isCancelled: (() => boolean) | false = false
+): Promise<void> => {
+    try {
+        const overlapMap = await findOverlappingLines(layerData, isCancelled);
+        const overlapArray = manageOverlappingSegmentsData(overlapMap, layerData);
+        await applyOffset(overlapArray, layerData, isCancelled);
+        cleanLines(layerData);
+        return;
+    } catch (e) {
+        return Promise.reject(e);
+    }
+};
+
+const findOverlappingLines = async (
+    layerData: GeoJSON.FeatureCollection<LineString>,
+    isCancelled: (() => boolean) | false = false
+): Promise<Map<string, Set<number>>> => {
+    if (isCancelled && isCancelled()) {
+        return Promise.reject('Cancelled');
+    }
+
+    const features = layerData.features;
+    // The map contains the feature and a set of numbers
+    // The feature is the segment concerned by the overlap
+    // The set of numbers is a set that contains the IDs of every single line concerned by the overlap on that segment
+    let overlapMap: Map<string, Set<number>> = new Map();
+    for (let i = 0; i < features.length - 1; i++) {
+        if (i % 20 === 0) {
+            if (isCancelled && isCancelled()) {
+                return Promise.reject('Cancelled');
+            }
+        }
+        for (let j = i + 1; j < features.length; j++) {
+            const overlap = lineOverlap(
+                lineString(features[i].geometry.coordinates),
+                lineString(features[j].geometry.coordinates)
+            );
+            if (overlap.features.length === 0) continue;
+            if (j % 20 === 0) {
+                await new Promise<void>((resolve) =>
+                    setTimeout(() => {
+                        overlapMap = fillOverlapMap(overlap, overlapMap, i, j);
+                        resolve();
+                    }, 0)
+                );
+            } else {
+                overlapMap = fillOverlapMap(overlap, overlapMap, i, j);
+            }
+        }
+    }
+    return Promise.resolve(overlapMap);
+};
+
+const fillOverlapMap = (
+    overlap: GeoJSON.FeatureCollection<LineString>,
+    overlapMap: Map<string, Set<number>>,
+    indexI: number,
+    indexJ: number
+): Map<string, Set<number>> => {
+    for (const segment of overlap.features) {
+        const overlapStr = JSON.stringify(segment);
+        if (!overlapMap.has(overlapStr)) overlapMap.set(overlapStr, new Set());
+        overlapMap.get(overlapStr)?.add(indexI).add(indexJ);
+    }
+    return overlapMap;
+};
+
+const manageOverlappingSegmentsData = (
+    overlapMap: Map<string, Set<number>>,
+    layerData: GeoJSON.FeatureCollection<LineString>
+): OverlappingSegments[] => {
+    const overlapArray: OverlappingSegments[] = [];
+    overlapMap.forEach((value: Set<number>, key: string) => {
+        const segmentDirections: Array<boolean> = [];
+        const keyGeojson = JSON.parse(key);
+        // For each line, add the direction of the overlap segment
+        value.forEach((index: number) => {
+            const data = layerData.features[index];
+            const coordinates = keyGeojson.geometry.coordinates;
+            const firstPoint = coordinates[0];
+            const lastPoint = coordinates[coordinates.length - 1];
+            for (let i = 0; i < data.geometry.coordinates.length; i++) {
+                const actualPoint = data.geometry.coordinates[i];
+                if (actualPoint[0] === firstPoint[0] && actualPoint[1] === firstPoint[1]) {
+                    segmentDirections.push(true);
+                    break;
+                } else if (actualPoint[0] === lastPoint[0] && actualPoint[1] === lastPoint[1]) {
+                    segmentDirections.push(false);
+                    break;
+                }
+            }
+        });
+        const overlap: OverlappingSegments = {
+            geoData: keyGeojson,
+            crossingLines: Array.from(value),
+            directions: segmentDirections
+        };
+        overlapArray.push(overlap);
+    });
+    return overlapArray;
+};
+
+const applyOffset = async (
+    overlapArray: OverlappingSegments[],
+    layerData: GeoJSON.FeatureCollection<LineString>,
+    isCancelled: (() => boolean) | false = false
+): Promise<void> => {
+    for (let i = 0; i < overlapArray.length; i++) {
+        if (i % 20 === 0) {
+            if (isCancelled && isCancelled()) {
+                return Promise.reject('Cancelled');
+            }
+        }
+        await new Promise<void>((resolve) =>
+            setTimeout(() => {
+                const nbOverlapped = overlapArray[i].directions.length;
+                let oppositeDirectionOffset = 0;
+                let sameDirectionOffset = 0;
+                for (let j = 0; j < nbOverlapped; j++) {
+                    const segment = overlapArray[i].geoData;
+                    if (overlapArray[i].directions[j]) {
+                        const line = layerData.features[overlapArray[i].crossingLines[j]];
+                        replaceLineCoordinates(segment, sameDirectionOffset, line);
+                        sameDirectionOffset++;
+                    } else {
+                        // No deep copy made before the reverse as there was already one previously
+                        segment.geometry.coordinates.reverse();
+                        const line = layerData.features[overlapArray[i].crossingLines[j]];
+                        replaceLineCoordinates(segment, oppositeDirectionOffset, line);
+                        oppositeDirectionOffset++;
+                    }
+                }
+                resolve();
+            }, 0)
+        );
+    }
+    return;
+};
+
+/**
+ * Replace coordinates of a segment of line with the offsetted coordinates
+ * @param originalSegment The unmodified coordinates of the segment to offset
+ * @param offsetCount Units by which to offset the segment
+ * @param line The complete line on which to apply the offset segment (will be modified)
+ */
+const replaceLineCoordinates = (
+    originalSegment: GeoJSON.Feature<LineString>,
+    offsetCount: number,
+    line: GeoJSON.Feature<LineString>
+): void => {
+    const offsetSegment = lineOffset(originalSegment, OFFSET_WIDTH * offsetCount, { units: 'meters' });
+    // We go through the coordinates of every single LineString until we reach the starting point of the segment we want to replace
+    for (let i = 0; i < line.geometry.coordinates.length; i++) {
+        let match = true;
+        originalSegment.geometry.coordinates.forEach((oldCoord, index) => {
+            if (i + index >= line.geometry.coordinates.length) {
+                match = false;
+            } else {
+                const lineCoord = line.geometry.coordinates[i + index];
+                if (lineCoord[0] !== oldCoord[0] || lineCoord[1] !== oldCoord[1]) {
+                    match = false;
+                }
+            }
+        });
+
+        if (match) {
+            for (let j = 0; j < originalSegment.geometry.coordinates.length; j++) {
+                line.geometry.coordinates[i + j] = offsetSegment.geometry.coordinates[j];
+            }
+            break;
+        }
+    }
+};
+
+const cleanLines = (geojson: GeoJSON.FeatureCollection<LineString>): void => {
+    geojson.features.forEach((feature) => {
+        feature.geometry.coordinates = feature.geometry.coordinates.filter((value) => {
+            return !Number.isNaN(value[0]) && !Number.isNaN(value[1]);
+        });
+    });
+};

--- a/packages/chaire-lib-common/src/services/geodata/RelocateNodes.ts
+++ b/packages/chaire-lib-common/src/services/geodata/RelocateNodes.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { lineString, nearestPointOnLine, booleanPointInPolygon, Position, distance } from '@turf/turf';
+import { LineString, Point, Feature, Polygon } from 'geojson';
+
+const MAX_NODE_RELOCATION_DISTANCE = 50; // in meters
+
+export const getNodesInView = (
+    bounds: Feature<Polygon>,
+    layer: GeoJSON.FeatureCollection<Point>
+): GeoJSON.FeatureCollection<Point> => {
+    const features = layer.features;
+    const nodesInView: GeoJSON.FeatureCollection<Point> = { type: 'FeatureCollection', features: [] };
+    for (let i = 0; i < features.length; i++) {
+        if (isInBounds(bounds, features[i].geometry.coordinates)) {
+            nodesInView.features.push(features[i]);
+        }
+    }
+    return nodesInView;
+};
+
+const isInBounds = (bounds: Feature<Polygon>, coord: number[]): boolean => {
+    return booleanPointInPolygon(coord, bounds);
+};
+
+/**
+Relocates nodes to the middle point of their crossing paths, if they intersect more than one path.
+@param nodeFeatures - a FeatureCollection of nodes. (will be modified)
+@param nodeMap - a Map of node IDs to arrays of path IDs that intersect the node.
+@param pathFeatures - a FeatureCollection of paths.
+@param maxDistance - the maximum manhattan distance between the old and new node coordinates for the relocation to occur.
+*/
+const relocateNodes = async (
+    nodeFeatures: GeoJSON.FeatureCollection<Point>,
+    nodeMap: Map<string, number[]>,
+    pathFeatures: GeoJSON.FeatureCollection<LineString>,
+    isCancelled: (() => boolean) | false = false
+): Promise<void> => {
+    if (isCancelled && isCancelled()) {
+        Promise.reject('Cancelled');
+        return;
+    }
+
+    // Loop through each node feature in the input of the transit nodes array
+    //nodeFeatures.features.forEach((nodeFeature, i) => {
+    for (let i = 0; i < nodeFeatures.features.length; i++) {
+        if (i % 20 === 0) {
+            if (isCancelled && isCancelled()) {
+                Promise.reject('Cancelled');
+                return;
+            }
+        }
+
+        // Get the ID of the current node.
+        const nodeId = nodeFeatures.features[i].properties?.id;
+
+        // Get an array of the path IDs that intersect the current node.
+        const paths = nodeMap.get(nodeId);
+
+        // If the node intersects more than one path, find the middle point of the intersecting paths and relocate the node to that point.
+        if (paths && paths.length > 1) {
+            // Get an array of the coordinates of each path that intersects the node.
+            const pathCoords = paths.map((pathId) => {
+                const pathFeature = pathFeatures.features.find((feature) => feature.id === pathId);
+                return pathFeature?.geometry.coordinates;
+            });
+
+            // Get the coordinates of the current node.
+            const nodeCoords = nodeFeatures.features[i].geometry.coordinates;
+
+            // Find the closest point on each path to the current node.
+            const closestPoints = findClosestPoints(nodeCoords, pathCoords);
+
+            // Find the middle point of the closest point.
+            const middlePoint = findMiddlePoint(closestPoints);
+
+            // Offset node if not too far from the old coordinates.
+            if (distance(nodeCoords, middlePoint, { units: 'meters' }) <= MAX_NODE_RELOCATION_DISTANCE) {
+                nodeFeatures.features[i].geometry.coordinates = middlePoint;
+            }
+        }
+    }
+    return;
+};
+
+/**
+ * Finds the point on each path that is closest to the given node.
+ * @param nodeCoords - an array of two coordinates in the format [longitude, latitude] representing the coordinates of a node.
+ * @param pathCoords - an array of arrays, where each inner array represents the coordinates of a path in the format [[longitude1, latitude1], [longitude2, latitude2], ...].
+ * @returns an array of arrays, where each inner array represents the coordinates of the point on the corresponding path that is closest to the node.
+ */
+function findClosestPoints(nodeCoords, pathCoords): Position[] {
+    const closestPoints = pathCoords.map((path) => {
+        const line = lineString(path);
+        const nearestPoint = nearestPointOnLine(line, nodeCoords);
+        return nearestPoint.geometry.coordinates;
+    });
+    return closestPoints;
+}
+
+/**
+ * Finds the middle point of an array of points.
+ * @param points - an array of arrays, where each inner array represents a point in the format [longitude, latitude].
+ * @returns an array representing the coordinates of the middle point of the input points.
+ */
+function findMiddlePoint(points): Position {
+    const numPoints = points.length;
+    const xCoords = points.map((point) => point[0]);
+    const yCoords = points.map((point) => point[1]);
+    const xSum = xCoords.reduce((sum, coord) => sum + coord, 0);
+    const ySum = yCoords.reduce((sum, coord) => sum + coord, 0);
+    const xMiddle = xSum / numPoints;
+    const yMiddle = ySum / numPoints;
+    return [xMiddle, yMiddle];
+}
+
+/**
+ * Generates a Map object with the node IDs as keys and arrays of path IDs that intersect each node as values.
+ * @param featureCollection - a GeoJSON FeatureCollection representing the transit paths.
+ * @returns a Map object with the node IDs as keys and arrays of path IDs that intersect each node as values.
+ */
+function getCrossingPaths(featureCollection): Map<string, number[]> {
+    const nodeMap = new Map();
+
+    featureCollection.features.forEach((feature) => {
+        const nodes = feature.properties.nodes;
+        nodes.forEach((node) => {
+            if (!nodeMap.has(node)) {
+                nodeMap.set(node, [feature.id]);
+            } else {
+                const paths = nodeMap.get(node);
+                paths.push(feature.id);
+                nodeMap.set(node, paths);
+            }
+        });
+    });
+
+    return nodeMap;
+}
+
+/**
+ * Orchestrates the relocation of nodes by calling the relocateNodes function with the necessary parameters.
+ * @param transitNodes - a Points feature collection giving a reference to the correct nodes layer (will be modified)
+ * @param transitPath - a LineString feature collection giving a reference to the correct paths layer
+ */
+export const manageRelocatingNodes = async (
+    transitNodes: GeoJSON.FeatureCollection<Point>,
+    transitPaths: GeoJSON.FeatureCollection<LineString>,
+    isCancelled: (() => boolean) | false = false
+): Promise<void> => {
+    try {
+        const nodeMap = getCrossingPaths(transitPaths);
+        await relocateNodes(transitNodes, nodeMap, transitPaths, isCancelled);
+        return;
+    } catch (e) {
+        return Promise.reject(e);
+    }
+};

--- a/packages/chaire-lib-common/src/services/geodata/__tests__/ManageOverlappingLines.test.ts
+++ b/packages/chaire-lib-common/src/services/geodata/__tests__/ManageOverlappingLines.test.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { offsetOverlappingLines, OFFSET_WIDTH, getLinesInView } from '../ManageOverlappingLines';
+import { lineOffset, inside, circle, union, bboxPolygon } from '@turf/turf';
+import GeoJSON, { LineString } from 'geojson';
+import _cloneDeep from 'lodash.clonedeep';
+
+const featureSkeleton: GeoJSON.Feature = {
+    type: 'Feature',
+    geometry: {
+        type: 'LineString',
+        coordinates: []
+    },
+    id: 0,
+    properties: {
+        description: ''
+    }
+};
+
+const basicCollection : GeoJSON.FeatureCollection<LineString> = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,0], [0,1], [0,2], [0,3], [0,4], [0,5]]
+            },
+            id: 1,
+            properties: {
+                description: 'Vertical line'
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[1,0], [1,1], [1,2], [1,3], [1,4], [1,5]]
+            },
+            id: 2,
+            properties: {
+                description: 'Vertical line'
+            }
+        }]
+};
+
+
+test('Test offset with no overlaps', async () => {
+    const offsetCollection = _cloneDeep(basicCollection);
+    await offsetOverlappingLines(offsetCollection);
+    expect(offsetCollection).toEqual(basicCollection);
+});
+
+
+test('Test offset with basic opposite direction overlap', async () => {
+    const collection = _cloneDeep(basicCollection);
+    collection.features[1].geometry.coordinates =
+        collection.features[1].geometry.coordinates.map((_, index) => [0, index]).reverse();
+
+    const offsetCollection = _cloneDeep(collection);
+    await offsetOverlappingLines(offsetCollection);
+    expect(offsetCollection).toEqual(collection);
+});
+
+
+test('Test offset with multiple same length overlaps', async () => {
+    const collection : GeoJSON.FeatureCollection<LineString> = {
+        type: 'FeatureCollection',
+        features: []
+    };
+
+    // Populate the collection with identical lines
+    for(let i = 0; i < 4; i++) {
+        const feature = _cloneDeep(featureSkeleton) as GeoJSON.Feature<LineString>;
+        feature.id = i;
+        feature.properties!.description = 'Vertical line of same length';
+        for(let j = 0; j < 5; j++) {
+            feature.geometry.coordinates.push([0, j]);
+        }
+        collection.features.push(feature);
+    }
+
+    const offsetCollection = _cloneDeep(collection);
+    await offsetOverlappingLines(offsetCollection);
+
+    const expectedOffset: GeoJSON.Feature[] = [];
+    collection.features.forEach((feature, index) => {
+        expectedOffset.push(lineOffset(feature as GeoJSON.Feature<LineString>, OFFSET_WIDTH * index, { units: 'meters' }));
+    });
+
+    offsetCollection.features.forEach((feature, i) => {
+        expect(feature.geometry).toEqual(expectedOffset[i].geometry);
+    });
+});
+
+
+test('Test offset with multiple different lengths overlap', async () => {
+    const collection : GeoJSON.FeatureCollection<LineString> = {
+        type: 'FeatureCollection',
+        features: []
+    };
+
+    // The lines created have the same origin (0,0) and are all vertical (thus having overlaps).
+    // The only difference is their length. Every line created has 4 more coordinates at its end than the previous one.
+    for(let i = 0; i < 4; i++) {
+        const feature = _cloneDeep(featureSkeleton) as GeoJSON.Feature<LineString>;
+        feature.id = i;
+        feature.properties!.description = 'Vertical line of different length';
+        for(let j = 0; j < 4 * i + 3; j++) {
+            feature.geometry.coordinates.push([0, j]);
+        }
+        collection.features.push(feature);
+    }
+
+    const offsetCollection = _cloneDeep(collection);
+    await offsetOverlappingLines(offsetCollection);
+    // TODO: Add a more specific expect once the expected behaviour is specified
+    expect(offsetCollection).not.toEqual(collection);
+});
+
+
+test('Test overlaps between multiple segments of the same line with another line', async () => {
+    const collection: GeoJSON.FeatureCollection<LineString> = {
+        type: 'FeatureCollection',
+        features: [
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[0, 0], [1, 1], [2, 2], [3, 3]]
+                },
+                id: 1,
+                properties: {}
+            },
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[3, 3], [2, 2], [1, 1], [0, 0], [1, 1], [2, 2], [3, 3]]
+                },
+                id: 2,
+                properties: {}
+            }
+        ]
+    };
+
+    const offsetCollection = _cloneDeep(collection);
+    // Expect not to have an infinite loop in these calls
+    await offsetOverlappingLines(offsetCollection);
+    await offsetOverlappingLines(offsetCollection);
+
+    // Verify line lengths
+    collection.features.forEach((feature, i) => {
+        expect(offsetCollection.features[i].geometry.coordinates.length).toBe(feature.geometry.coordinates.length);
+    });
+
+    // Verify that offsetted coords are within the offset distance
+    let polygon = _cloneDeep(featureSkeleton) as GeoJSON.Feature<GeoJSON.Polygon | GeoJSON.MultiPolygon>;
+    polygon.geometry.type = 'Polygon';
+    collection.features[0].geometry.coordinates.forEach((coord) => {
+        polygon = union(polygon, (circle(coord, OFFSET_WIDTH + 1, { units: 'meters' })));
+    });
+    offsetCollection.features[1].geometry.coordinates.forEach((coord) => {
+        expect(inside(coord, polygon)).toBeTruthy();
+    });
+});
+
+
+test('Test overlaps with duplicate coordinates', async () => {
+    const collection: GeoJSON.FeatureCollection<LineString> = {
+        type: 'FeatureCollection',
+        features: [
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[0, 0], [0, 1], [0, 1], [0, 2]]
+                },
+                id: 1,
+                properties: {}
+            },
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[1, 1],[0, 1],[0, 0]]
+                },
+                id: 2,
+                properties: {}
+            }
+        ]
+    };
+
+    await offsetOverlappingLines(collection);
+    collection.features.forEach((feature) => {
+        feature.geometry.coordinates.forEach((coord) => {
+            expect(coord[0]).not.toBeNaN();
+            expect(coord[1]).not.toBeNaN();
+        });
+    });
+});
+
+test('Test getting lines within the view bounds', () => {
+    const collection: GeoJSON.FeatureCollection<LineString> = {
+        type: 'FeatureCollection',
+        features: [
+            // Line entirely contained in bounds
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[0, 0], [0, 1], [0, 1], [2, 2]]
+                },
+                id: 1,
+                properties: {}
+            },
+            // Line outside bounds
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[10, 10],[20, 20],[30, 30]]
+                },
+                id: 2,
+                properties: {}
+            },
+            // Line partially inside bounds
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[1, 1],[20, 20],[30, 30]]
+                },
+                id: 3,
+                properties: {}
+            }
+        ]
+    };
+    const bounds = bboxPolygon([0, 0, 5, 5]);
+
+    const linesInView = getLinesInView(bounds, collection);
+
+    expect(linesInView.features.length).toEqual(2);
+    expect(linesInView.features[0].id).toEqual(1);
+    expect(linesInView.features[1].id).toEqual(3);
+});

--- a/packages/chaire-lib-common/src/services/geodata/__tests__/RelocateNodes.test.ts
+++ b/packages/chaire-lib-common/src/services/geodata/__tests__/RelocateNodes.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { manageRelocatingNodes } from '../RelocateNodes';
+import { LineString, Point } from '@turf/turf';
+import _cloneDeep from 'lodash.clonedeep';
+
+const transitPaths : GeoJSON.FeatureCollection<LineString> = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,0], [1,0], [2,0], [3,0], [4,0]]
+            },
+            id: 1,
+            properties: {
+                nodes: [0,1,2]
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,1], [1,1], [2,1], [3,1], [4,1]]
+            },
+            id: 2,
+            properties: {
+                nodes: [0,1,2]
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,2], [1,2], [2,2], [3,2], [4,2]]
+            },
+            id: 3,
+            properties: {
+                nodes: [0,1,2]
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,3], [1,3], [2,3], [3,3], [4,3]]
+            },
+            id: 4,
+            properties: {
+                nodes: [0,1]
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'LineString',
+                coordinates: [[0,4], [1,4], [2,4], [3,4], [4,4]]
+            },
+            id: 5,
+            properties: {
+                nodes: [0,1]
+            }
+        }]
+};
+
+const transitNodes : GeoJSON.FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                // distance within MAX_NODE_RELOCATION_DISTANCE from expected center
+                coordinates: [2,2.0004]
+            },
+            id: 0,
+            properties: {
+                color:'',
+                id: 0
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                // distance within MAX_NODE_RELOCATION_DISTANCE from expected center
+                coordinates: [1,2.0004]
+            },
+            id: 1,
+            properties: {
+                color:'',
+                id: 1
+            }
+        },
+        {
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                // distance within MAX_NODE_RELOCATION_DISTANCE from expected center
+                coordinates: [4,1.0004]
+            },
+            id: 2,
+            properties: {
+                color:'',
+                id: 2
+            }
+        }
+    ]
+};
+
+test('Check that the offset nodes are at the expected middle point', async () => {
+    const nodesTest = _cloneDeep(transitNodes);
+    await manageRelocatingNodes(nodesTest, _cloneDeep(transitPaths));
+
+    expect(nodesTest.features[0].geometry.coordinates).toEqual([2,2]);
+    expect(nodesTest.features[1].geometry.coordinates).toEqual([1,2]);
+    expect(nodesTest.features[2].geometry.coordinates).toEqual([4,1]);
+
+});

--- a/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
+++ b/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
@@ -6,10 +6,18 @@
  */
 import MapboxGL from 'mapbox-gl';
 import _debounce from 'lodash.debounce';
+import { lineString, bboxPolygon, bbox, feature } from '@turf/turf';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { MapEventHandlerDescription } from '../IMapEventHandler';
+import { getLinesInView, offsetOverlappingLines } from 'chaire-lib-common/lib/services/geodata/ManageOverlappingLines';
+import { getNodesInView, manageRelocatingNodes } from 'chaire-lib-common/lib/services/geodata/RelocateNodes';
+
+// TODO: Make zoomLimit modifiable by user
+const zoomLimit = 14; //Zoom levels smaller than this will not apply line separation
+// eslint-disable-next-line @typescript-eslint/ban-types
+let applyAestheticChangesNonce: Object = new Object();
 
 /* This file encapsulates global map events, that do not require a specific context */
 
@@ -27,6 +35,8 @@ const onZoomEnd = (_e: MapboxGL.MapMouseEvent) => {
             serviceLocator.eventManager
         );
     }, 1000);
+    const boundsGL = _e.target.getBounds();
+    applyAestheticChanges(boundsGL, _e.target.getZoom());
 };
 
 const onDragEnd = (e: MapboxGL.MapMouseEvent) => {
@@ -50,6 +60,8 @@ const onDragEnd = (e: MapboxGL.MapMouseEvent) => {
             serviceLocator.eventManager
         );
     }, 1000)();
+    const boundsGL = e.target.getBounds();
+    applyAestheticChanges(boundsGL, e.target.getZoom());
 };
 
 const onDragStart = (e: MapboxGL.MapMouseEvent) => {
@@ -68,5 +80,51 @@ const globalEventDescriptors: MapEventHandlerDescription[] = [
     { type: 'map', eventName: 'dragstart', handler: onDragStart },
     { type: 'map', eventName: 'mousemove', handler: onMouseMove }
 ];
+
+const applyAestheticChanges = async (boundsGL: MapboxGL.LngLatBounds, zoom: number): Promise<void> => {
+    if (!Preferences.get('features.map.prettyDisplay', false)) {
+        return;
+    }
+
+    const localNonce = (applyAestheticChangesNonce = new Object());
+    const isCancelled = () => localNonce !== applyAestheticChangesNonce;
+
+    if (zoom <= zoomLimit) {
+        return;
+    }
+
+    if (isCancelled && isCancelled()) {
+        return;
+    }
+
+    const sw = boundsGL.getSouthWest().toArray();
+    const ne = boundsGL.getNorthEast().toArray();
+    const bounds = [sw, ne];
+    const boundsPolygon = bboxPolygon(bbox(lineString(bounds)));
+
+    const layer = serviceLocator.layerManager._layersByName['transitPaths'].source.data;
+    const linesInView = getLinesInView(boundsPolygon, layer);
+    await offsetOverlappingLines(linesInView, isCancelled).catch(() => {
+        return;
+    }); // isCancelled is handled after
+    if (isCancelled && isCancelled()) {
+        return;
+    }
+
+    const transitNodes = serviceLocator.layerManager._layersByName['transitNodes'].source.data;
+    const nodesInView = getNodesInView(boundsPolygon, transitNodes);
+    await manageRelocatingNodes(nodesInView, linesInView, isCancelled).catch(() => {
+        return;
+    });
+    if (isCancelled && isCancelled()) {
+        return;
+    }
+
+    serviceLocator.eventManager.emit('map.updateLayer', 'transitPaths', layer);
+
+    serviceLocator.eventManager.emit('map.updateLayers', {
+        transitNodes: transitNodes
+    });
+};
 
 export default globalEventDescriptors;

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
@@ -23,6 +23,7 @@ import PreferencesSectionTransitLines from './sections/PreferencesSectionTransit
 import PreferencesSectionTransitPaths from './sections/PreferencesSectionTransitPaths';
 import PreferencesSectionTransitServices from './sections/PreferencesSectionTransitServices';
 import PreferencesSectionTransitScenarios from './sections/PreferencesSectionTransitScenarios';
+import PreferencesSectionFeatures from './sections/PreferencesSectionFeatures';
 
 type PreferencesPanelProps = WithTranslation;
 
@@ -132,6 +133,13 @@ class PreferencesPanel extends SaveableObjectForm<PreferencesClass, PreferencesP
                 />
 
                 <PreferencesSectionTransitScenarios
+                    preferences={this.state.object}
+                    onValueChange={this.onValueChange}
+                    resetChangesCount={this.resetChangesCount}
+                    resetPrefToDefault={this.resetPrefToDefault}
+                />
+
+                <PreferencesSectionFeatures
                     preferences={this.state.object}
                     onValueChange={this.onValueChange}
                     resetChangesCount={this.resetChangesCount}

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import Collapsible from 'react-collapsible';
+import { withTranslation } from 'react-i18next';
+import _toString from 'lodash.tostring';
+import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
+import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
+import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
+import PreferencesSectionProps from '../PreferencesSectionProps';
+
+const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProps> = (
+    props: PreferencesSectionProps
+) => {
+    const prefs = props.preferences.getAttributes();
+
+    return (
+        <Collapsible trigger={props.t('main:preferences:ExperimentalFeatures')} open={true} transitionTime={100}>
+            <div className="tr__form-section">
+                <InputWrapper twoColumns={true} label={props.t('main:preferences:MapPrettyDisplay')}>
+                    <InputCheckboxBoolean
+                        id={'formFieldPreferencesFeatureMapPrettyDisplay'}
+                        isChecked={props.preferences.get('features.map.prettyDisplay')}
+                        defaultChecked={false}
+                        label={props.t('main:Yes')}
+                        onValueChange={(e) =>
+                            props.onValueChange('features.map.prettyDisplay', { value: e.target.value })
+                        }
+                    />
+                    <PreferencesResetToDefaultButton
+                        resetPrefToDefault={props.resetPrefToDefault}
+                        path="features.map.prettyDisplay"
+                        preferences={props.preferences}
+                    />
+                </InputWrapper>
+            </div>
+        </Collapsible>
+    );
+};
+
+export default withTranslation(['main', 'transit'])(PreferencesSectionFeatures);

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -464,7 +464,6 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
     };
 
     updateLayer = (layerName: string, geojson: GeoJSON.FeatureCollection) => {
-        //console.log('updating map layer', layerName, geojson);
         this.layerManager.updateLayer(layerName, geojson);
     };
 


### PR DESCRIPTION
Offset transit paths on the map to better see where each goes. Offset
stop nodes to be in the middle of crossing paths to see which paths have
a stop there.
    
It is inspired by this article for by the transit app developers:
https://blog.transitapp.com/how-we-built-the-worlds-prettiest-auto-generated-transit-maps-12d0c6fa502f/
    
But instead of image processing, the geojson data is processed directly
and modified before display.
    
This feature is experimental and needs the `features.map.prettyDisplay`
preference to be set.
    
Also, the transit nodes by which paths pass are placed such that they
are in the middle of the lines.
    
The overlapping segments take time to calculate, it is done
asynchronously. After zooming or panning, it may take a few seconds
before the map shows the pretty path
    
Future work:
    
* Improve performance of the overlapping lines
* Cache the overlapping segments to avoid having to recalculate on every
  map refresh
* Find a better sorting algorithm to decide the order of he ofsetted
  lines
* Add a use configurable minimum zoom level for which the algorithm is
  applied (now hardcoded zoom limit of 14)
* There are still a few bugs in the display
* Add more tests
* Make clearer which lines stop at nodes or not (for example a segment with
  express and non-express routes)

Limits:
    
* The current offset is applied on a perfect match between the overlapped segment coordinates and the line coordinates. This can be adjusted in turf.lineOverlap function.
    