### PR TITLE
preferences: Let the class have change listeners

### DIFF
--- a/packages/chaire-lib-common/src/config/Preferences.ts
+++ b/packages/chaire-lib-common/src/config/Preferences.ts
@@ -44,6 +44,7 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
         return this._attributes;
     }
 
+    // FIXME: Do the following functions need to be public?
     public getDefault() {
         return this._default;
     }
@@ -141,6 +142,11 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
         return this._isValid;
     }
 
+    /**
+     * FIXME: Used for preferences edit form
+     * @param path Dot-separated path to the preference to reset
+     * @returns The new preferences value
+     */
     public resetPathToDefault(path: string) {
         const projectDefaultOrDefaultValue = this.getFromProjectDefaultOrDefault(path);
         this.set(path, projectDefaultOrDefaultValue);
@@ -182,6 +188,17 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
         }
     }
 
+    /**
+     * Update preferences value and save to the server
+     * @param valuesByPath An object where the keys are the dot-separated path
+     * to the preferences to update and the value is the new value of the
+     * preference.
+     * @param socket Optional, an socket event emitter to use to save the data.
+     * If undefined, a post to the server will be done
+     * @param eventManager Optional, an event manager that will emit after the
+     * preferences update.
+     * @returns The complete preferences object
+     */
     public async update(
         valuesByPath: Partial<PreferencesModelWithIdAndData>,
         socket?: EventEmitter,
@@ -197,6 +214,10 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
         return this._attributes;
     }
 
+    /**
+     * Save the whole preferences object to the server
+     * FIXME: Used for preferences edit form
+     */
     public async save(socket?: EventEmitter, eventManager?: EventEmitter): Promise<PreferencesModel> {
         try {
             socket ? await this.updateFromSocket(socket, this.attributes) : await this.updateFromFetch(this.attributes);
@@ -260,6 +281,14 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
         }
     }
 
+    /**
+     * Load preferences from server
+     * @param socket Optional, an socket event emitter to use to load the data.
+     * If undefined, a get from the server will be done
+     * @param eventManager Optional, an event manager that will emit after the
+     * preferences are loaded.
+     * @returns The complete preferences object
+     */
     public async load(socket?: EventEmitter, eventManager?: EventEmitter): Promise<PreferencesModel> {
         try {
             const preferencesFromServer = socket ? await this.loadFromSocket(socket) : await this.loadFromFetch();

--- a/packages/chaire-lib-common/src/config/Preferences.ts
+++ b/packages/chaire-lib-common/src/config/Preferences.ts
@@ -198,20 +198,16 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
      * preference.
      * @param socket Optional, an socket event emitter to use to save the data.
      * If undefined, a post to the server will be done
-     * @param eventManager Optional, an event manager that will emit after the
-     * preferences update.
      * @returns The complete preferences object
      */
     public async update(
         valuesByPath: Partial<PreferencesModelWithIdAndData>,
-        socket?: EventEmitter,
-        eventManager?: EventEmitter
+        socket?: EventEmitter
     ): Promise<PreferencesModelWithIdAndData> {
         try {
             socket ? await this.updateFromSocket(socket, valuesByPath) : await this.updateFromFetch(valuesByPath);
             this._attributes = _cloneDeep(_merge({}, this._attributes, valuesByPath));
             this._eventEmitter.emit(prefChangeEvent, valuesByPath);
-            eventManager?.emit('preferences.updated');
         } catch (error) {
             console.error('Error loading preferences from server');
         }
@@ -289,18 +285,15 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
      * Load preferences from server
      * @param socket Optional, an socket event emitter to use to load the data.
      * If undefined, a get from the server will be done
-     * @param eventManager Optional, an event manager that will emit after the
-     * preferences are loaded.
      * @returns The complete preferences object
      */
-    public async load(socket?: EventEmitter, eventManager?: EventEmitter): Promise<PreferencesModel> {
+    public async load(socket?: EventEmitter): Promise<PreferencesModel> {
         try {
             const preferencesFromServer = socket ? await this.loadFromSocket(socket) : await this.loadFromFetch();
             this._attributes = _cloneDeep(
                 _merge({}, this._default, this._projectDefault, preferencesFromServer)
             ) as PreferencesModelWithIdAndData;
             this._eventEmitter.emit(prefChangeEvent, this._attributes);
-            eventManager?.emit('preferences.loaded');
         } catch (error) {
             console.error('Error loading preferences from server');
         }

--- a/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
+++ b/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
@@ -25,8 +25,6 @@ stubEmitter.on("preferences.update", mockStubUpdatePreferences);
 const mockStubReadPreferences = jest.fn();
 stubEmitter.on("preferences.read", mockStubReadPreferences);
 
-stubEmitter.on("preferences.updated", jest.fn());
-
 const originalPreferences = _cloneDeep(Preferences.attributes);
 
 beforeEach(() => {
@@ -76,7 +74,7 @@ describe('Updating preferences', () => {
     }
 
     test("Update from socket routes", async () => {
-        await Preferences.update(myNewPrefs, stubEmitter, stubEmitter);
+        await Preferences.update(myNewPrefs, stubEmitter);
 
         expect(mockStubUpdatePreferences).toHaveBeenLastCalledWith(myNewPrefs, expect.anything());
         expect(Preferences.get("sections.test.mySection")).toMatchObject(sectionData);
@@ -88,7 +86,7 @@ describe('Updating preferences', () => {
         mockStubUpdatePreferences.mockImplementationOnce((data, callback) => callback(Status.createError('Error from socket')));
         expect(mockStubUpdatePreferences).toHaveBeenLastCalledWith(myNewPrefs, expect.anything());
 
-        await Preferences.update(myNewPrefs, stubEmitter, stubEmitter);
+        await Preferences.update(myNewPrefs, stubEmitter);
         // No changes to preferences should happen
         expect(Preferences.get("sections.test.mySection")).toBeUndefined();
     });
@@ -150,7 +148,7 @@ describe('Load preferences', () => {
             callback(Status.createOk(testPreferences));
         })
 
-        await Preferences.load(stubEmitter, stubEmitter);
+        await Preferences.load(stubEmitter);
         expect(Preferences.attributes).toEqual(expect.objectContaining(testPreferences));
     });
 
@@ -160,7 +158,7 @@ describe('Load preferences', () => {
             callback(Status.createError('Error from socket'));
         })
 
-        await Preferences.load(stubEmitter, stubEmitter);
+        await Preferences.load(stubEmitter);
         // No changes to preferences should happen
         expect(Preferences.attributes).toEqual(currentPrefs);
     });

--- a/packages/chaire-lib-frontend/src/actions/Auth.tsx
+++ b/packages/chaire-lib-frontend/src/actions/Auth.tsx
@@ -344,7 +344,7 @@ export const resetUserProfile = (history: History) => {
             // reset localStorage
             window.localStorage.clear();
             // reload preferences from server
-            await Preferences.load(serviceLocator.socketEventManager, serviceLocator.eventManager);
+            await Preferences.load(serviceLocator.socketEventManager);
 
             if (response.status === 200) {
                 const defaultPath = appConfiguration.homePage;

--- a/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
+++ b/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
@@ -23,8 +23,7 @@ const onZoomEnd = (_e: MapboxGL.MapMouseEvent) => {
             {
                 'map.zoom': e.target.getZoom()
             },
-            serviceLocator.socketEventManager,
-            serviceLocator.eventManager
+            serviceLocator.socketEventManager
         );
     }, 1000);
 };
@@ -46,8 +45,7 @@ const onDragEnd = (e: MapboxGL.MapMouseEvent) => {
             {
                 'map.center': [centerLatLng.lng, centerLatLng.lat]
             },
-            serviceLocator.socketEventManager,
-            serviceLocator.eventManager
+            serviceLocator.socketEventManager
         );
     }, 1000)();
 };

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
@@ -210,8 +210,7 @@ class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapA
                 {
                     'transit.routing.transitAccessibilityMap': exportedAttributes
                 },
-                serviceLocator.socketEventManager,
-                serviceLocator.eventManager
+                serviceLocator.socketEventManager
             );
         }
     }

--- a/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitDemandFromCsv.ts
@@ -69,8 +69,7 @@ export abstract class TransitDemandFromCsv<T extends DemandCsvAttributes> extend
                 {
                     [this._preferencesPath]: exportedAttributes
                 },
-                serviceLocator.socketEventManager,
-                serviceLocator.eventManager
+                serviceLocator.socketEventManager
             );
         }
     }

--- a/packages/transition-common/src/services/transitRouting/TransitRouting.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRouting.ts
@@ -224,8 +224,7 @@ export class TransitRouting extends ObjectWithHistory<TransitRoutingAttributes> 
                 {
                     'transit.routing.transit': exportedAttributes
                 },
-                serviceLocator.socketEventManager,
-                serviceLocator.eventManager
+                serviceLocator.socketEventManager
             );
         }
     }

--- a/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
@@ -259,7 +259,7 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
             this.setState({ socketConnected: true });
         } else {
             // firsty load the preferences, then set socket state to connected, so the main map can get preferences on first load.
-            Preferences.load(serviceLocator.socketEventManager, serviceLocator.eventManager).then(() => {
+            Preferences.load(serviceLocator.socketEventManager).then(() => {
                 this.setState({
                     preferencesLoaded: true,
                     socketConnected: true,

--- a/packages/transition-frontend/src/services/map/PathMapLayerManager.ts
+++ b/packages/transition-frontend/src/services/map/PathMapLayerManager.ts
@@ -170,8 +170,7 @@ class PathMapLayerManager {
                 'map.layers.hiddenAgencyIds': hiddenAgencyIds,
                 'map.layers.hiddenLineIds': hiddenLineIds
             },
-            serviceLocator.socketEventManager,
-            serviceLocator.eventManager
+            serviceLocator.socketEventManager
         );
     }
 }


### PR DESCRIPTION
Some preferences methods, like load and update had an optional eventManager parameter which was used to notify of preferences changes. But interested classes need to know about this eventManager and all callers of preferences update/load needed to make sure to pass this specific eventManager. Now, they can register directly to the preferences class, which handles notifications.