### PR TITLE
zones: Verify that the DB table does not already exist

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/migrations/20230725124200_createZonesTable.ts
+++ b/packages/chaire-lib-backend/src/models/db/migrations/20230725124200_createZonesTable.ts
@@ -10,6 +10,9 @@ import { onUpdateTrigger } from '../../../config/knexfile';
 const tableName = 'tr_zones';
 
 export async function up(knex: Knex): Promise<unknown> {
+    if (await knex.schema.hasTable(tableName)) {
+        return;
+    }
     await knex.schema.createTable(tableName, (table: Knex.TableBuilder) => {
         table.uuid('id').unique().notNullable().defaultTo(knex.raw('gen_random_uuid()')).primary();
         table.string('internal_id');


### PR DESCRIPTION
Some installations already have a tr_zones table from previous migrations, so we should verify it does not already exist.