### PR TITLE
utils: Add an async function which fails after a timeout

### DIFF
--- a/packages/chaire-lib-common/src/utils/AsyncUtils.ts
+++ b/packages/chaire-lib-common/src/utils/AsyncUtils.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+const causeTimeout = 'PROMISE_TIMEOUT';
+export const isTimeout = (error: unknown) => error && (error as any).cause && (error as any).cause === causeTimeout;
+
+/**
+ * Call an async function with a maximum time limit (in milliseconds) for the timeout
+ * Taken from https://javascript.plainenglish.io/how-to-add-a-timeout-limit-to-asynchronous-javascript-functions-3676d89c186d
+ * @param {Promise<T>} asyncPromise An asynchronous promise to resolve
+ * @param {number} timeLimit Time limit to attempt function in milliseconds
+ * @returns {<T> | undefined} Resolved promise for async function call, or an error if time limit reached
+ */
+export const asyncCallWithTimeout = async <T>(asyncPromise: Promise<T>, timeLimit: number): Promise<T> => {
+    let timeoutHandle: NodeJS.Timeout;
+
+    const timeoutPromise = new Promise<T>((_resolve, reject) => {
+        timeoutHandle = setTimeout(() => {
+            reject(new Error('Async call timeout limit reached', { cause: causeTimeout }));
+        }, timeLimit);
+    });
+
+    return Promise.race([asyncPromise, timeoutPromise])
+        .then((result) => {
+            clearTimeout(timeoutHandle);
+            return result;
+        })
+        .catch((error) => {
+            if (!isTimeout(error)) {
+                // Error in promise, not because of timeout
+                clearTimeout(timeoutHandle);
+            }
+            throw error;
+        });
+};

--- a/packages/chaire-lib-common/src/utils/__tests__/AsyncUtils.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/AsyncUtils.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { asyncCallWithTimeout, isTimeout } from '../AsyncUtils';
+
+test('isTimeout', () => {
+    expect(isTimeout(undefined)).toBeFalsy();
+    expect(isTimeout(null)).toBeFalsy();
+    expect(isTimeout('PROMISE_TIMEOUT')).toBeFalsy();
+    expect(isTimeout({ someObj: 'test' })).toBeFalsy();
+    expect(isTimeout([1, 2, 3])).toBeFalsy();
+    expect(isTimeout(new Error('Async call timeout limit reached'))).toBeFalsy();
+    expect(isTimeout(new Error('Async call timeout limit reached', { cause: 'PROMISE_TIMEOUT' }))).toBeTruthy();
+})
+
+describe('asyncCallWithTimeout', () => {
+    test('Promise returns first', async () => {
+        const response = 'abc';
+        const promise = async () => response;
+        expect(await asyncCallWithTimeout(promise(), 3000)).toEqual(response);
+    });
+
+    test('Promise error', async () => {
+        const exceptionError = 'Exception in promise';
+        const promise = async () => {
+            throw exceptionError;
+        }
+
+        let exception: any = undefined;
+        try {
+            await asyncCallWithTimeout(promise(), 2000);
+        } catch(error) {
+            exception = error;
+        }
+
+        expect(exception).toBeDefined();
+        expect(isTimeout(exception)).toBeFalsy();
+        expect(exception).toEqual(exceptionError);
+    });
+
+    test('Promise timeout', async () => {
+        let exception: any = undefined;
+        const promise = async () => new Promise((_resolve, _reject) => {
+            // Never ending promise
+        });
+        try {
+            await asyncCallWithTimeout(promise(), 2000);
+        } catch(error) {
+            exception = error;
+        }
+        expect(exception).toBeDefined();
+        expect(isTimeout(exception)).toBeTruthy();
+    });
+});


### PR DESCRIPTION
The function receives a promise and a timeout as parameter and if the timeout is reached before the promise completes, the function throws an error.

Javascript taken from https://javascript.plainenglish.io/how-to-add-a-timeout-limit-to-asynchronous-javascript-functions-3676d89c186d