### PR TITLE
auth: check is username exists and use part of a uuid as name

### DIFF
--- a/packages/chaire-lib-backend/src/services/auth/__tests__/anonymousLoginStrategy.test.ts
+++ b/packages/chaire-lib-backend/src/services/auth/__tests__/anonymousLoginStrategy.test.ts
@@ -26,13 +26,16 @@ jest.mock('../../../models/db/users.db.queries', () => ({
             uuid: 'arbitrary',
             ...attribs
         }
-    })
+    }),
+    find: jest.fn().mockResolvedValue(undefined)
 }));
 const mockCreate = usersDbQueries.create as jest.MockedFunction<typeof usersDbQueries.create>;
+const mockFind = usersDbQueries.find as jest.MockedFunction<typeof usersDbQueries.find>;
 
 beforeEach(() => {
     logInFct.mockClear();
     mockCreate.mockClear();
+    mockFind.mockClear();
 });
 
 const strategy = new AnonymousLoginStrategy(userAuthModel);
@@ -71,6 +74,64 @@ test('Anonymous strategy success', async () => {
     });
     expect(logInFct).toHaveBeenCalledWith({ id: newUserId, username: expect.stringContaining('anonym_'), email: undefined, firstName: '', lastName: '', preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());
 });
+
+test('Anonymous strategy success, but duplicate user name', async () => {
+    // Return users for the first 2 find requests
+    mockFind.mockResolvedValueOnce({ username: 'anonym_something', id: 1, uuid: 'someuuid' });
+    mockFind.mockResolvedValueOnce({ username: 'anonym_something', id: 2, uuid: 'someuuid2' });
+    const authPromise = new Promise((resolve, reject) => (
+        passport.authenticate('anonymous-login')({
+            logIn: logInFct
+        }, {end: jest.fn()}, (err, result) => {
+            resolve({ result, err });
+        })
+    ));
+    await authPromise;
+    expect(logInFct).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith({
+        username: expect.stringContaining('anonym_'),
+        email: null,
+        google_id: null,
+        facebook_id: null,
+        generated_password: null,
+        password: null,
+        first_name: '',
+        last_name: '',
+        is_admin: false,
+        is_valid: true,
+        is_test: false,
+        is_confirmed: true,
+        confirmation_token: null,
+        preferences: null
+    });
+    expect(logInFct).toHaveBeenCalledWith({ id: newUserId, username: expect.stringContaining('anonym_'), email: undefined, firstName: '', lastName: '', preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());
+});
+
+test('Anonymous strategy with too many duplicate trials, should fail', async () => {
+    // Return users for the first 10 find requests, it should fail
+    for (let i = 0; i < 10; i++) {
+        mockFind.mockResolvedValueOnce({ username: 'anonym_something', id: i, uuid: 'someuuid' });
+    }
+    const endFct = jest.fn();
+    const authPromise = new Promise((resolve, reject) => {
+        const res = { 
+            end: endFct.mockImplementation((message) => resolve({ result: null, err: message })),
+            json: jest.fn().mockImplementation((json) => resolve({ result: json, err: null })),
+            setHeader: jest.fn()
+        };
+        return passport.authenticate('anonymous-login')({
+            logIn: logInFct
+        }, res, (err, result) => {
+            resolve({ result, err });
+        })
+    });
+    await authPromise;
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(logInFct).not.toHaveBeenCalled();
+    expect(endFct).toHaveBeenCalledTimes(1);
+});
+
 
 test('Anonymous strategy failure', async () => {
     mockCreate.mockRejectedValueOnce('Error creating user');


### PR DESCRIPTION
fixes #711

Instead of 6 digits, we use the last 10 characters of a uuid (hex characters) for the "random" part of the username. It also checks if the username exists before assigning it, up to 10 tentatives, after which it fails with a message that a unique name cannot be found.

According to https://zelark.github.io/nano-id-cc/, with the hex alphabet and 10 characters, it should take 148K IDs to have a 1% probability of collision. With 10 checks, it should be enough for most applications using chaire-lib.