### PR TITLE
auth: Validate email for passwordless login

### DIFF
--- a/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/RegisterForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/RegisterForm.tsx
@@ -14,6 +14,7 @@ import Button from '../../../input/Button';
 import FormErrors from '../../../pageParts/FormErrors';
 import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 import CaptchaComponent, { validateCaptcha } from './CaptchaComponent';
+import { _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 export interface RegisterFormProps {
     isAuthenticated?: boolean;
@@ -71,12 +72,7 @@ export class RegisterForm extends React.Component<RegisterFormProps & WithTransl
             this.setState({
                 error: { text: 'auth:passwordMustHaveAtLeastNCharacters', params: { n: '8' } }
             });
-        } else if (
-            this.state.email &&
-            !/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
-                this.state.email
-            )
-        ) {
+        } else if (this.state.email && !_isEmail(this.state.email)) {
             this.setState(() => ({
                 error: 'auth:invalidEmail'
             }));

--- a/packages/chaire-lib-frontend/src/components/forms/auth/passwordless/PwdLessLoginForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/passwordless/PwdLessLoginForm.tsx
@@ -12,7 +12,7 @@ import { History, Location } from 'history';
 import FormErrors from '../../../pageParts/FormErrors';
 import { startPwdLessLogin, LoginPwdlessData } from '../../../../actions/Auth';
 import Button from '../../../input/Button';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { _isBlank, _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 export interface LoginPageProps {
     isAuthenticated?: boolean;
@@ -51,6 +51,10 @@ export class LoginPage extends React.Component<LoginPageProps & WithTranslation,
     onButtonClick = () => {
         if (!this.state.email) {
             this.setState(() => ({ error: this.props.t('auth:missingUsernameOrEmail') }));
+        } else if (this.state.email && !_isEmail(this.state.email)) {
+            this.setState(() => ({
+                error: 'auth:invalidEmail'
+            }));
         } else {
             this.setState(() => ({ error: undefined }));
             this.props.startPwdLessLogin({


### PR DESCRIPTION
fixes #713

Validate that the email field is really an email, as otherwise it won't be possible to go back to an interview.

Also, use the LodashExtension's utility function for isEmail in RegisterForm.