### PR TITLE
batchRoute: Remove the walkOnlyPath from results in DB

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
@@ -70,6 +70,10 @@ const routeOdTrip = async function (odTrip: BaseOdTrip, parameters: RouteOdTripP
             false
         );
 
+        if (results.transit) {
+            delete results.transit.getParams().walkOnlyPath;
+        }
+
         return {
             uuid,
             internalId,


### PR DESCRIPTION
fixes #724

The walkOnlyPath is the same as the first walking route, which is already part of the result. This should save some space in the database for the results.