### PR TITLE
Upgrade webpack-glsl-loader.

### DIFF
--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -117,6 +117,6 @@
     "webpack": "^4.43.0",
     "webpack-cdn-plugin": "^3.3.1",
     "webpack-cli": "^3.3.12",
-    "@davcri/webpack-glsl-loader": "^1.0.2"
+    "ts-shader-loader": "^2.0.2"
   }
 }

--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -117,6 +117,6 @@
     "webpack": "^4.43.0",
     "webpack-cdn-plugin": "^3.3.1",
     "webpack-cli": "^3.3.12",
-    "webpack-glsl-loader": "^1.0.1"
+    "@davcri/webpack-glsl-loader": "^1.0.2"
   }
 }

--- a/packages/transition-frontend/webpack.config.js
+++ b/packages/transition-frontend/webpack.config.js
@@ -86,7 +86,7 @@ module.exports = (env) => {
         },
         {
           test: /\.glsl$/,
-          loader: 'webpack-glsl-loader'
+          loader: '@davcri/webpack-glsl-loader'
         },
         {
           test: /\.s?css$/,

--- a/packages/transition-frontend/webpack.config.js
+++ b/packages/transition-frontend/webpack.config.js
@@ -86,7 +86,7 @@ module.exports = (env) => {
         },
         {
           test: /\.glsl$/,
-          loader: '@davcri/webpack-glsl-loader'
+          loader: 'ts-shader-loader'
         },
         {
           test: /\.s?css$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,11 +697,6 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@davcri/webpack-glsl-loader@^1.0.2":
-  version "1.0.2"
-  resolved "http://localhost:4873/@davcri/webpack-glsl-loader/-/webpack-glsl-loader-1.0.2.tgz#657b0919bc3f9ceb6bc4cfaee2ef7db8c18bcb61"
-  integrity sha512-6E2C2qHEchwQb1SswWG2Lapsl1WvNZ+EDz5d7F+v4ZBmymZFr/kPMHG/9sBhURpAunn9Gs/KMIJWUPHDdZvcxg==
-
 "@emotion/babel-plugin@^11.10.5":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
@@ -9683,6 +9678,11 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+loader-utils@^3.2.0:
+  version "3.2.1"
+  resolved "http://localhost:4873/loader-utils/-/loader-utils-3.2.1.tgz#4fb104b599daafd82ef3e1a41fb9265f87e1f576"
+  integrity sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -14310,6 +14310,13 @@ ts-loader@^7.0.5:
     loader-utils "^1.0.2"
     micromatch "^4.0.0"
     semver "^6.0.0"
+
+ts-shader-loader@^2.0.2:
+  version "2.0.2"
+  resolved "http://localhost:4873/ts-shader-loader/-/ts-shader-loader-2.0.2.tgz#8d8d96491a9dcb026f2855da21fbd7a7d0dde744"
+  integrity sha512-PMdxdDQoS9D3O+UZ4y8Ul4AwXjTdvBiZHOLRnjkUbgNJyA1p0c4U2YXggqIGw7apCyoBP80QJz2Y+YcZMFHoVg==
+  dependencies:
+    loader-utils "^3.2.0"
 
 tslib@^1.7.1:
   version "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,6 +697,11 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@davcri/webpack-glsl-loader@^1.0.2":
+  version "1.0.2"
+  resolved "http://localhost:4873/@davcri/webpack-glsl-loader/-/webpack-glsl-loader-1.0.2.tgz#657b0919bc3f9ceb6bc4cfaee2ef7db8c18bcb61"
+  integrity sha512-6E2C2qHEchwQb1SswWG2Lapsl1WvNZ+EDz5d7F+v4ZBmymZFr/kPMHG/9sBhURpAunn9Gs/KMIJWUPHDdZvcxg==
+
 "@emotion/babel-plugin@^11.10.5":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.5.tgz#65fa6e1790ddc9e23cc22658a4c5dea423c55c3c"
@@ -7434,11 +7439,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.2.tgz#e1f244ef3933c1b2a64bd4799136060d0f5914f8"
-  integrity sha512-YAiVokMCrSIFZiroB1oz51hPiPRVcUtSa4x2U5RYXyhS9VAPdiFigKbPTnOSq7XY8wd3FIVPYmXpo5lMzFmxgg==
-
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -11363,11 +11363,6 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-path@^0.11.14:
-  version "0.11.14"
-  resolved "https://registry.yarnpkg.com/path/-/path-0.11.14.tgz#cbc7569355cb3c83afeb4ace43ecff95231e5a7d"
-  integrity sha512-CzEXTDgcEfa0yqMe+DJCSbEB5YCv4JZoic5xulBNFF2ifIMjNrTWbNSPNhgKfSo0MjneGIx9RLy4pCFuZPaMSQ==
-
 pause@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
@@ -14880,14 +14875,6 @@ webpack-cli@^3.3.12:
     supports-color "^6.1.0"
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
-
-webpack-glsl-loader@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/webpack-glsl-loader/-/webpack-glsl-loader-1.0.1.tgz#72a0e30192bd57947d60d6d505c915be680d0acc"
-  integrity sha512-bFtjj+sOGECMKQ+o8V4Y0TdrIxiua6ykVAncj5ccws8ezZBhhz+9wdrQqSgawm2IS3SPjoVaF7yxSAS8naNirg==
-  dependencies:
-    fs "0.0.2"
-    path "^0.11.14"
 
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9680,7 +9680,7 @@ loader-utils@^2.0.0:
 
 loader-utils@^3.2.0:
   version "3.2.1"
-  resolved "http://localhost:4873/loader-utils/-/loader-utils-3.2.1.tgz#4fb104b599daafd82ef3e1a41fb9265f87e1f576"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.1.tgz#4fb104b599daafd82ef3e1a41fb9265f87e1f576"
   integrity sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==
 
 locate-path@^3.0.0:
@@ -14313,7 +14313,7 @@ ts-loader@^7.0.5:
 
 ts-shader-loader@^2.0.2:
   version "2.0.2"
-  resolved "http://localhost:4873/ts-shader-loader/-/ts-shader-loader-2.0.2.tgz#8d8d96491a9dcb026f2855da21fbd7a7d0dde744"
+  resolved "https://registry.yarnpkg.com/ts-shader-loader/-/ts-shader-loader-2.0.2.tgz#8d8d96491a9dcb026f2855da21fbd7a7d0dde744"
   integrity sha512-PMdxdDQoS9D3O+UZ4y8Ul4AwXjTdvBiZHOLRnjkUbgNJyA1p0c4U2YXggqIGw7apCyoBP80QJz2Y+YcZMFHoVg==
   dependencies:
     loader-utils "^3.2.0"


### PR DESCRIPTION
This was a very old dependency (not sure how it's actually used) but it was pulling in <https://www.npmjs.com/package/path> and <https://www.npmjs.com/package/fs> (which are actually node core modules).

On the road to a webpack 5 upgrade.