### PR TITLE
Fix 691: unzip files using a stream to reduce RAM load

### DIFF
--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -49,6 +49,7 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "morgan": "^1.10.0",
+        "node-stream-zip": "^1.15.0",
         "p-queue": "^6.6.2",
         "papaparse": "^5.3.1",
         "pbf": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10631,6 +10631,11 @@ node-releases@^2.0.1:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
+node-stream-zip@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.15.0.tgz#158adb88ed8004c6c49a396b50a6a5de3bca33ea"
+  integrity sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==
+
 nodemailer-mock@^1.5.8:
   version "1.5.8"
   resolved "https://registry.yarnpkg.com/nodemailer-mock/-/nodemailer-mock-1.5.8.tgz#22e3d54db735f426fc590a0f975ded3a8cbd6b12"


### PR DESCRIPTION
In Transition, we zip and unzip files for GTFS exporting and importing. 
I could not find a package that allowed unzipping using a stream but also allow zipping files. This PR uses https://github.com/antelle/node-stream-zip, which only allows unzipping. We must therefore keep our current dependency on JSZip.

The options are as follows:
1. Accept this PR which unzips using a stream, but adds an extra package dependency
2. Spend time writing our own zip/unzip code (or find an existing library to extend/improve)
3. Drop both packages (JSZip and node-stream-zip) and instead ask users to install the unix `zip` utility on their workstations (it is preinstalled on macOS and probably most linux distros anyway)