### PR TITLE
batchRoute: Use stream to process results instead of paged queries

### DIFF
--- a/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
+++ b/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
@@ -130,6 +130,28 @@ const collection = async (
 };
 
 /**
+ * Get a stream of results
+ * FIXME Should this replace the collection call?
+ *
+ * @param jobId The ID of the job for which to get the results
+ * @returns
+ */
+const streamResults = (jobId: number) => {
+    try {
+        const resultsQuery = knex.select().from(tableName).where('job_id', jobId).orderBy('trip_index');
+
+        // TODO Try to pipe the attributeParser in the stream
+        return resultsQuery.stream();
+    } catch (error) {
+        throw new TrError(
+            `cannot fetch batch route results stream because of a database error (knex error: ${error})`,
+            'DBBRR0002',
+            'TransitTaskResultCouldNotBeStreamedBecauseDatabaseError'
+        );
+    }
+};
+
+/**
  * Delete the results for a specific job
  *
  * @param jobId The ID of the job for which to delete
@@ -156,7 +178,9 @@ const deleteForJob = async (jobId: number, tripIndex?: number): Promise<void> =>
 export default {
     create,
     collection,
+    streamResults,
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
-    deleteForJob
+    deleteForJob,
+    resultParser: attributesParser
 };

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatchResult.ts
@@ -149,7 +149,9 @@ class BatchAccessibilityMapResultProcessorFile implements BatchAccessibilityMapR
             polygonAttributes[`polygon${i}Duration`] = results.polygons.features[i].properties?.durationMinutes;
             polygonAttributes[`polygon${i}AreaSqKm`] = results.polygons.features[i].properties?.areaSqKm;
             if (this.parameters.withGeometries) {
-                polygonAttributes[`polygon${i}Geojson`] = JSON.stringify(_omit(results.polygons.features[i], 'properties'));
+                polygonAttributes[`polygon${i}Geojson`] = JSON.stringify(
+                    _omit(results.polygons.features[i], 'properties')
+                );
             }
         }
         if (this._csvStream) {


### PR DESCRIPTION
fixes #760

Add a database query to stream batch routing results. This allows to process results one at a time in a streamed way, instead of fixed paged size at once. This might prevent out of memory exceptions for large calculation batches.