### PR TITLE
batch jobs: Add a console.error when task is failed

### DIFF
--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -129,6 +129,9 @@ const wrapTaskExecution = async (id: number) => {
         }
         task.setCompleted();
     } catch (error) {
+        console.error(
+            `Setting job ${task.attributes.id} (${task.attributes.name}) as failed because of an error: ${error}`
+        );
         task.setFailed();
     }
     await task.save(taskListener);


### PR DESCRIPTION
The job execution themselves typically have console.error on failure, but if it fails at other points, like when verifying the user's disk quota, there should be message to explain the failure instead of silence.