### PR TITLE
dep: Drop support of node 16 and require node 18

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -14,33 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
-    env:
-      PROJECT_CONFIG: ${{ github.workspace }}/examples/config.js
-    steps:
-    - uses: actions/checkout@v3
-    - name: copy env file
-      run: cp .env.example .env
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install
-      run: yarn
-    - name: Compile
-      run: yarn compile
-    - name: Build Client bundle
-      run: yarn build:prod
-    - name: Unit Test
-      run: yarn test
-    - name: UI Test
-      run: yarn test:ui
-
-  # Because of https://github.com/chairemobilite/transition/issues/531, version 18 needs an additional environment variable. When fixed, we can use a version matrix instead
-  build-and-test-18:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
         node-version: [18.x]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/examples/config.js
@@ -57,7 +30,7 @@ jobs:
     - name: Compile
       run: yarn compile
     - name: Build Client bundle
-      run: yarn cross-env NODE_OPTIONS=--openssl-legacy-provider yarn build:prod
+      run: yarn build:prod
     - name: Unit Test
       run: yarn test
     - name: UI Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cargo build
 
 
 # Build Node app
-FROM node:16-bookworm
+FROM node:18-bookworm
 WORKDIR /app
 # Install all the json package dependencies in an intermediary image. To do so, we copy each package.json files
 # and run yarn install which will download all the listed packages in the image.

--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "name": "chaire-lib-backend",
     "version": "0.2.2",

--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "chaire-lib-common",
   "version": "0.2.2",

--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "chaire-lib-frontend",
   "version": "0.2.2",

--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "name": "transition-backend",
     "version": "0.2.0-2",

--- a/packages/transition-common/package.json
+++ b/packages/transition-common/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "transition-common",
   "version": "0.2.0-2",

--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "name": "transition-frontend",
   "version": "0.2.0-2",
@@ -8,9 +8,9 @@
   "repository": "github.com/chairemobilite/transition",
   "license": "MIT",
   "scripts": {
-    "build:dev": "webpack --watch --progress --colors --env development --mode development",
-    "build:prod": "webpack -p --progress --colors --env production --mode production",
-    "build:test": "cross-env NODE_ENV=test webpack -p --env test --mode development --watch --progress --colors",
+    "build:dev": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096 --openssl-legacy-provider\" webpack --watch --progress --colors --env development --mode development",
+    "build:prod": "cross-env NODE_OPTIONS=\"--max_old_space_size=4096 --openssl-legacy-provider\" webpack -p --progress --colors --env production --mode production",
+    "build:test": "cross-env NODE_ENV=\"test --openssl-legacy-provider\" webpack -p --env test --mode development --watch --progress --colors",
     "compile": "tsc && yarn copy-files",
     "compile:dev": "yarn copy-files && tsc -w",
     "clean": "rimraf lib/",


### PR DESCRIPTION
Add the --openssl-legacy-provider flag to webpack commands