### PR TITLE
json2capnp: listen to ipv6 instead of ipv4

### DIFF
--- a/services/json2capnp/src/main.rs
+++ b/services/json2capnp/src/main.rs
@@ -156,5 +156,5 @@ fn main() {
         })
     };
 
-    rouille::start_server(format!("0.0.0.0:{}", port), handle_request);
+    rouille::start_server(format!(":::{}", port), handle_request);
 }


### PR DESCRIPTION
Modern linux will try to connect to localhost on IPv6 first.

Further fix will be to listen on both