### PR TITLE
transitPath: fix nodes list when path has no segments

### DIFF
--- a/packages/chaire-lib-frontend/src/components/pageParts/DistanceUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/DistanceUnitFormatter.tsx
@@ -21,8 +21,9 @@ export interface DistanceUnitFormatterProps extends WithTranslation {
 const DistanceUnitFormatter: React.FunctionComponent<DistanceUnitFormatterProps> = (
     props: DistanceUnitFormatterProps
 ) => {
-
-    const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(props.destinationUnit);
+    const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(
+        props.destinationUnit
+    );
     const valueInMeters = props.sourceUnit === 'm' ? props.value : props.value / 1000;
 
     useEffect(() => {

--- a/packages/chaire-lib-frontend/src/components/pageParts/DurationUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/DurationUnitFormatter.tsx
@@ -21,7 +21,9 @@ export interface DurationUnitFormatterProps extends WithTranslation {
 const DurationUnitFormatter: React.FunctionComponent<DurationUnitFormatterProps> = (
     props: DurationUnitFormatterProps
 ) => {
-    const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(props.destinationUnit);
+    const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(
+        props.destinationUnit
+    );
 
     const valueInSeconds =
         props.sourceUnit === 's'

--- a/packages/chaire-lib-frontend/src/components/pageParts/SpeedUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/SpeedUnitFormatter.tsx
@@ -18,10 +18,10 @@ export interface SpeedUnitFormatterProps extends WithTranslation {
     destinationUnit?: destinationUnitOptionsType;
 }
 
-const SpeedUnitFormatter: React.FunctionComponent<SpeedUnitFormatterProps> = (
-    props: SpeedUnitFormatterProps
-) => {
-    const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(props.destinationUnit);
+const SpeedUnitFormatter: React.FunctionComponent<SpeedUnitFormatterProps> = (props: SpeedUnitFormatterProps) => {
+    const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(
+        props.destinationUnit
+    );
 
     const valueInMetersPerSecond = props.sourceUnit === 'm/s' ? props.value : mpsToKph(props.value);
 
@@ -35,7 +35,7 @@ const SpeedUnitFormatter: React.FunctionComponent<SpeedUnitFormatterProps> = (
     const unitFormatters: Record<destinationUnitOptionsType, (value: number) => string> = {
         'm/s': (value) => `${roundToDecimals(value, 0)} ${props.t('main:mpsAbbr')}`,
         'km/h': (value) => `${roundToDecimals(mpsToKph(value), 1)} ${props.t('main:kphAbbr')}`,
-        'mph': (value) => `${roundToDecimals(mpsToMph(value), 1)} ${props.t('main:mphAbbr')}`,
+        mph: (value) => `${roundToDecimals(mpsToMph(value), 1)} ${props.t('main:mphAbbr')}`,
         'ft/s': (value) => `${roundToDecimals(mpsToFtps(value), 0)} ${props.t('main:ftpsAbbr')}`
     };
 

--- a/packages/transition-frontend/src/components/forms/path/TransitPathNodeButton.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathNodeButton.tsx
@@ -122,10 +122,22 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                 <li className={'_path-segment-list'} key={`segment${nodeIndex}`}>
                     <span className="_path-segment-label-container">
                         <span className="_path-segment-label">
-                            {segments[nodeIndex]?.travelTimeSeconds ? <DurationUnitFormatter value={segments[nodeIndex].travelTimeSeconds!} sourceUnit='s' destinationUnit='s' /> : '? s'}
+                            {segments[nodeIndex]?.travelTimeSeconds ? (
+                                <DurationUnitFormatter
+                                    value={segments[nodeIndex].travelTimeSeconds!}
+                                    sourceUnit="s"
+                                    destinationUnit="s"
+                                />
+                            ) : (
+                                '? s'
+                            )}
                         </span>
                         <span className="_path-segment-label">
-                            {segments[nodeIndex]?.distanceMeters ? <DistanceUnitFormatter value={segments[nodeIndex].distanceMeters!} sourceUnit='m' /> : '?'}
+                            {segments[nodeIndex]?.distanceMeters ? (
+                                <DistanceUnitFormatter value={segments[nodeIndex].distanceMeters!} sourceUnit="m" />
+                            ) : (
+                                '?'
+                            )}
                         </span>
                         {cumulativeTimeSecondsAfter && cumulativeDistanceMeters && <br />}
                         {cumulativeTimeSecondsAfter && cumulativeDistanceMeters && (
@@ -140,14 +152,13 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                         )}
                         {cumulativeTimeSecondsAfter && (
                             <span className="_path-segment-label" title={props.t('main:Cumulative')}>
-                                <DurationUnitFormatter value={cumulativeTimeSecondsAfter} sourceUnit='s' />
+                                <DurationUnitFormatter value={cumulativeTimeSecondsAfter} sourceUnit="s" />
                             </span>
                         )}
-                        &#8213;
-                        &nbsp;
+                        &#8213; &nbsp;
                         {cumulativeDistanceMeters && (
                             <span className="_path-segment-label" title={props.t('main:Cumulative')}>
-                                <DistanceUnitFormatter value={cumulativeDistanceMeters} sourceUnit='m' />
+                                <DistanceUnitFormatter value={cumulativeDistanceMeters} sourceUnit="m" />
                             </span>
                         )}
                     </span>

--- a/packages/transition-frontend/src/components/forms/path/TransitPathNodeButton.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathNodeButton.tsx
@@ -122,10 +122,10 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                 <li className={'_path-segment-list'} key={`segment${nodeIndex}`}>
                     <span className="_path-segment-label-container">
                         <span className="_path-segment-label">
-                            {segments[nodeIndex].travelTimeSeconds ? <DurationUnitFormatter value={segments[nodeIndex].travelTimeSeconds!} sourceUnit='s' destinationUnit='s' /> : '? s'}
+                            {segments[nodeIndex]?.travelTimeSeconds ? <DurationUnitFormatter value={segments[nodeIndex].travelTimeSeconds!} sourceUnit='s' destinationUnit='s' /> : '? s'}
                         </span>
                         <span className="_path-segment-label">
-                            {segments[nodeIndex].distanceMeters ? <DistanceUnitFormatter value={segments[nodeIndex].distanceMeters!} sourceUnit='m' /> : '?'}
+                            {segments[nodeIndex]?.distanceMeters ? <DistanceUnitFormatter value={segments[nodeIndex].distanceMeters!} sourceUnit='m' /> : '?'}
                         </span>
                         {cumulativeTimeSecondsAfter && cumulativeDistanceMeters && <br />}
                         {cumulativeTimeSecondsAfter && cumulativeDistanceMeters && (

--- a/packages/transition-frontend/src/components/forms/path/TransitPathStatistics.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathStatistics.tsx
@@ -26,12 +26,10 @@ interface StatsRowProps extends WithTranslation {
 const StatsRowBase: React.FunctionComponent<StatsRowProps> = (props: StatsRowProps) => {
     const value = props.value !== null && props.value !== undefined ? props.value : props.defaultValue || '?';
     const pathStatFormula = pathStatsFormula[props.variable];
-    const {
-        translatableString,
-        latexExpression,
-    } = typeof pathStatFormula === 'string'
-        ? { translatableString: `variable:${props.variable}`, latexExpression: props.variable }
-        : pathStatFormula;
+    const { translatableString, latexExpression } =
+        typeof pathStatFormula === 'string'
+            ? { translatableString: `variable:${props.variable}`, latexExpression: props.variable }
+            : pathStatFormula;
     return (
         <tr>
             <th>{props.t(translatableString)}</th>
@@ -81,46 +79,172 @@ const TransitPathStatistics: React.FunctionComponent<PathStatsProps> = (props: P
     return (
         <table className="_statistics">
             <tbody>
-                {variables && <StatsRow variable="d_p" value={!_isBlank(variables.d_p) ? <DistanceUnitFormatter value={variables.d_p as number} sourceUnit='m' destinationUnit='km'/> : '?'}/>}
+                {variables && (
+                    <StatsRow
+                        variable="d_p"
+                        value={
+                            !_isBlank(variables.d_p) ? (
+                                <DistanceUnitFormatter
+                                    value={variables.d_p as number}
+                                    sourceUnit="m"
+                                    destinationUnit="km"
+                                />
+                            ) : (
+                                '?'
+                            )
+                        }
+                    />
+                )}
                 {variables && <StatsRow variable="n_q_p" value={variables.n_q_p} />}
-                {variables && <StatsRow variable="d_l_min" value={!_isBlank(variables.d_l_min) ? <DistanceUnitFormatter value={variables.d_l_min as number} sourceUnit='m' destinationUnit='m'/> : '?'} />}
-                {variables && <StatsRow variable="d_l_max" value={!_isBlank(variables.d_l_max) ? <DistanceUnitFormatter value={variables.d_l_max as number} sourceUnit='m' destinationUnit='m'/> : '?'} />}
-                {variables && <StatsRow variable="d_l_avg" value={!_isBlank(variables.d_l_avg) ? <DistanceUnitFormatter value={variables.d_l_avg as number} sourceUnit='m' destinationUnit='m'/> : '?'} />}
-                {variables && <StatsRow variable="d_l_med" value={!_isBlank(variables.d_l_med) ? <DistanceUnitFormatter value={variables.d_l_med as number} sourceUnit='m' destinationUnit='m'/> : '?'} />}
+                {variables && (
+                    <StatsRow
+                        variable="d_l_min"
+                        value={
+                            !_isBlank(variables.d_l_min) ? (
+                                <DistanceUnitFormatter
+                                    value={variables.d_l_min as number}
+                                    sourceUnit="m"
+                                    destinationUnit="m"
+                                />
+                            ) : (
+                                '?'
+                            )
+                        }
+                    />
+                )}
+                {variables && (
+                    <StatsRow
+                        variable="d_l_max"
+                        value={
+                            !_isBlank(variables.d_l_max) ? (
+                                <DistanceUnitFormatter
+                                    value={variables.d_l_max as number}
+                                    sourceUnit="m"
+                                    destinationUnit="m"
+                                />
+                            ) : (
+                                '?'
+                            )
+                        }
+                    />
+                )}
+                {variables && (
+                    <StatsRow
+                        variable="d_l_avg"
+                        value={
+                            !_isBlank(variables.d_l_avg) ? (
+                                <DistanceUnitFormatter
+                                    value={variables.d_l_avg as number}
+                                    sourceUnit="m"
+                                    destinationUnit="m"
+                                />
+                            ) : (
+                                '?'
+                            )
+                        }
+                    />
+                )}
+                {variables && (
+                    <StatsRow
+                        variable="d_l_med"
+                        value={
+                            !_isBlank(variables.d_l_med) ? (
+                                <DistanceUnitFormatter
+                                    value={variables.d_l_med as number}
+                                    sourceUnit="m"
+                                    destinationUnit="m"
+                                />
+                            ) : (
+                                '?'
+                            )
+                        }
+                    />
+                )}
                 {variables && (
                     <StatsRow variable="q'_T" value={firstNode ? firstNode.properties.name : ''} defaultValue="" />
                 )}
                 {variables && (
                     <StatsRow variable="q''_T" value={lastNode ? lastNode.properties.name : ''} defaultValue="" />
                 )}
-                {variables && <StatsRow variable="T_o_p" value={!_isBlank(variables.T_o_p) ? <DurationUnitFormatter value={variables.T_o_p as number} sourceUnit='s' destinationUnit='m'/> : '0'} />}
+                {variables && (
+                    <StatsRow
+                        variable="T_o_p"
+                        value={
+                            !_isBlank(variables.T_o_p) ? (
+                                <DurationUnitFormatter
+                                    value={variables.T_o_p as number}
+                                    sourceUnit="s"
+                                    destinationUnit="m"
+                                />
+                            ) : (
+                                '0'
+                            )
+                        }
+                    />
+                )}
 
                 <SimpleRow header={props.t('transit:transitPath:TravelTimes')} isHeader={true} />
                 <SimpleRow
                     header={props.t('transit:transitPath:IncludingDwellTimes')}
-                    value={<DurationUnitFormatter value={pathData.operatingTimeWithoutLayoverTimeSeconds || 0} sourceUnit='s' destinationUnit='m'/>}
+                    value={
+                        <DurationUnitFormatter
+                            value={pathData.operatingTimeWithoutLayoverTimeSeconds || 0}
+                            sourceUnit="s"
+                            destinationUnit="m"
+                        />
+                    }
                 />
                 <SimpleRow
                     header={props.t('transit:transitPath:ExcludingDwellTimes')}
-                    value={<DurationUnitFormatter value={pathData.travelTimeWithoutDwellTimesSeconds || 0} sourceUnit='s' destinationUnit='m'/>}
+                    value={
+                        <DurationUnitFormatter
+                            value={pathData.travelTimeWithoutDwellTimesSeconds || 0}
+                            sourceUnit="s"
+                            destinationUnit="m"
+                        />
+                    }
                 />
                 <SimpleRow
                     header={props.t('transit:transitPath:IncludingDwellTimesAndLayover')}
-                    value={<DurationUnitFormatter value={pathData.operatingTimeWithLayoverTimeSeconds || 0} sourceUnit='s' destinationUnit='m'/>}
+                    value={
+                        <DurationUnitFormatter
+                            value={pathData.operatingTimeWithLayoverTimeSeconds || 0}
+                            sourceUnit="s"
+                            destinationUnit="m"
+                        />
+                    }
                 />
                 <SimpleRow
                     header={props.t('transit:transitPath:LayoverTime')}
-                    value={<DurationUnitFormatter value={pathData.layoverTimeSeconds as number || 0} sourceUnit='s' destinationUnit='m'/>}
+                    value={
+                        <DurationUnitFormatter
+                            value={(pathData.layoverTimeSeconds as number) || 0}
+                            sourceUnit="s"
+                            destinationUnit="m"
+                        />
+                    }
                 />
 
                 <SimpleRow header={props.t('transit:transitPath:Speeds')} isHeader={true} />
                 <SimpleRow
                     header={props.t('transit:transitPath:ExcludingDwellTimes')}
-                    value={<SpeedUnitFormatter value={pathData.averageSpeedWithoutDwellTimesMetersPerSecond || 0} sourceUnit='m/s' destinationUnit='km/h'/>}
+                    value={
+                        <SpeedUnitFormatter
+                            value={pathData.averageSpeedWithoutDwellTimesMetersPerSecond || 0}
+                            sourceUnit="m/s"
+                            destinationUnit="km/h"
+                        />
+                    }
                 />
                 <SimpleRow
                     header={props.t('transit:transitPath:OperatingSpeed')}
-                    value={<SpeedUnitFormatter value={pathData.operatingSpeedMetersPerSecond || 0} sourceUnit='m/s' destinationUnit='km/h'/>}
+                    value={
+                        <SpeedUnitFormatter
+                            value={pathData.operatingSpeedMetersPerSecond || 0}
+                            sourceUnit="m/s"
+                            destinationUnit="km/h"
+                        />
+                    }
                 />
 
                 {temporalTortuosity && (


### PR DESCRIPTION
The `segments` data attribute may be empty if the path was imported from gtfs. Undefined exceptions were thrown and the interface was blank when deleting nodes from the nodes list.

Also run `yarn format` on the code