### PR TITLE
right panel: Re-compute contributions when routing modes change

### DIFF
--- a/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
@@ -27,10 +27,11 @@ interface RightPanelProps extends LayoutSectionProps {
 const RightPanel: React.FunctionComponent<RightPanelProps> = ({ contributions, ...props }: RightPanelProps) => {
     const contributionElements = React.useMemo(
         () =>
+
             contributions
                 .filter((contrib) => contrib.section === undefined || contrib.section === props.activeSection)
                 .map((contrib) => contrib.create({ ...props, key: `rightPanelEl${contrib.id}` })),
-        [props.activeSection]
+        [props.activeSection, props.availableRoutingModes]
     );
 
     return (


### PR DESCRIPTION
fixes #791

Available routing modes are fetched asynchronously on the server and sent as props to the panels and forms. The right panel needs to re-compute the contribution elements when that prop value changes so the contribution elements can have the latest value.