### PR TITLE
Type the event manager and the `map.updateLayer` event

### DIFF
--- a/packages/chaire-lib-common/src/services/events/EventManager.ts
+++ b/packages/chaire-lib-common/src/services/events/EventManager.ts
@@ -10,7 +10,43 @@ import Event from './Event';
 
 const prefix = '';
 
+export type EventType = {
+    name: string;
+    arguments: { [key: string]: unknown };
+};
+
+export type EventNameKey = 'name';
+export type EventArgsKey = 'arguments';
+
 export interface EventManager {
+    /**
+     * Emit an event, with typing enabled. This is equivalent to calling
+     * emit(TEvent.name, TEvent.arguments) but allows compile-time validation of
+     * the parameters
+     * @param event The event descriptor
+     * @param args An object with the arguments of the same type as the
+     * EventType's
+     */
+    emitEvent<TEvent extends EventType>(
+        event: TEvent[EventNameKey],
+        args: {
+            [Property in keyof TEvent[EventArgsKey]]: TEvent[EventArgsKey][Property];
+        }
+    ): void;
+    /**
+     * Listen on event, with typing enabled. This is equivalent to calling
+     * on(TEvent.name, TEvent.arguments) but allows compile-time validation of
+     * the callback signature
+     * @param event The event descriptor
+     * @param callback The callback function to call, which receives in
+     * parameter an argument with the same type as the EventType's
+     */
+    onEvent<TEvent extends EventType>(
+        event: TEvent[EventNameKey],
+        callback: (args: {
+            [Property in keyof TEvent[EventArgsKey]]: TEvent[EventArgsKey][Property];
+        }) => void
+    ): void;
     emit(event: string | Event, ...args: any[]): void;
     emitProgress(progressName: string, completeRatio: number): void;
     once(event: string | Event, callback: (data: any) => void): void;
@@ -32,6 +68,15 @@ export class EventManagerImpl implements EventManager {
 
     constructor(wrappedEventManager = new events.EventEmitter()) {
         this._eventManager = wrappedEventManager; // must implement emit, on, once, and removeListener methods
+    }
+
+    emitEvent<TEvent extends EventType>(
+        event: TEvent[EventNameKey],
+        args: {
+            [Property in keyof TEvent[EventArgsKey]]: TEvent[EventArgsKey][Property];
+        }
+    ) {
+        this.emit(event, args);
     }
 
     emit(event: string | Event, ...args: any[]) {
@@ -57,6 +102,15 @@ export class EventManagerImpl implements EventManager {
             event = new Event(event);
         }
         this._eventManager.on(`${prefix}${event.eventName}`, callback);
+    }
+
+    onEvent<TEvent extends EventType>(
+        event: TEvent[EventNameKey],
+        callback: (args: {
+            [Property in keyof TEvent[EventArgsKey]]: TEvent[EventArgsKey][Property];
+        }) => void
+    ) {
+        this.on(event, callback);
     }
 
     addListener(event: string | Event, callback: (...data: any) => void) {

--- a/packages/chaire-lib-common/src/services/events/__tests__/EventManager.test.ts
+++ b/packages/chaire-lib-common/src/services/events/__tests__/EventManager.test.ts
@@ -109,4 +109,31 @@ describe('Events', function() {
 
   });
 
+  test('should emit an event, with typing', function(done) {
+    const eventName = 'test.event';
+    type TestEventType = {
+        name: 'test.event',
+        arguments: { 
+            arg1: number,
+            arg2: string
+        };
+    }
+    const arg1Val = 100;
+    const arg2Val = 'a string';
+
+    const callback = function(args: { 
+        arg1: number,
+        arg2: string
+    }) {
+      expect(args.arg1).toEqual(arg1Val);
+      expect(args.arg2).toEqual(arg2Val);
+      eventManager.off(eventName, callback);
+      done();
+    };
+
+    eventManager.onEvent<TestEventType>(eventName, callback);
+    eventManager.emitEvent<TestEventType>(eventName, { arg1: arg1Val, arg2: arg2Val });
+
+  });
+
 });

--- a/packages/chaire-lib-common/src/test/services/events/EventManagerMock.ts
+++ b/packages/chaire-lib-common/src/test/services/events/EventManagerMock.ts
@@ -4,8 +4,10 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { EventManager } from '../../../services/events/EventManager';
+import EventManagerImpl, { EventManager } from '../../../services/events/EventManager';
 import serviceLocator from '../../../utils/ServiceLocator';
+
+const eventMngr = new EventManagerImpl();
 
 const mockEmit: jest.MockedFunction<(event: string | Event, ...args: any[]) => void> = jest.fn();
 mockEmit.mockImplementation((_event, ...args) => {
@@ -18,12 +20,15 @@ mockEmit.mockImplementation((_event, ...args) => {
 });
 
 const mockEmitProgress: jest.MockedFunction<(progressName: string, completeRatio: number) => void> = jest.fn();
+const mockEmitEvent: jest.MockedFunction<typeof eventMngr.emitEvent> = jest.fn();
 
 const responses: any[] = [];
 
 const eventManagerMock = {
     emit: mockEmit,
     emitProgress: mockEmitProgress,
+    emitEvent: mockEmitEvent,
+    onEvent: jest.fn(),
     once: jest.fn(),
     on: jest.fn(),
     addListener: jest.fn(),

--- a/packages/chaire-lib-common/src/utils/objects/GenericMapObjectCollection.ts
+++ b/packages/chaire-lib-common/src/utils/objects/GenericMapObjectCollection.ts
@@ -79,7 +79,7 @@ export default abstract class GenericMapObjectCollection<
         return this._idByIntegerId.get(featureIntegerId);
     }
 
-    toGeojson() {
+    toGeojson(): GeoJSON.FeatureCollection<M> {
         return {
             type: 'FeatureCollection',
             features: this.features

--- a/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
+++ b/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
@@ -205,7 +205,10 @@ class MapboxLayerManager {
         this._map?.addLayer(this._layersByName[layerName].layer, this.getNextLayerName(layerName));
     }
 
-    updateLayer(layerName, geojson) {
+    updateLayer(
+        layerName: string,
+        geojson: GeoJSON.FeatureCollection | ((original: GeoJSON.FeatureCollection) => GeoJSON.FeatureCollection)
+    ) {
         const newGeojson =
             typeof geojson === 'function'
                 ? geojson(this._layersByName[layerName].source.data)

--- a/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
+++ b/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
@@ -13,6 +13,8 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { MapEventHandlerDescription } from '../IMapEventHandler';
 import { getLinesInView, offsetOverlappingLines } from 'chaire-lib-common/lib/services/geodata/ManageOverlappingLines';
 import { getNodesInView, manageRelocatingNodes } from 'chaire-lib-common/lib/services/geodata/RelocateNodes';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from './MapEventsCallbacks';
 
 // TODO: Make zoomLimit modifiable by user
 const zoomLimit = 14; //Zoom levels smaller than this will not apply line separation
@@ -118,7 +120,10 @@ const applyAestheticChanges = async (boundsGL: MapboxGL.LngLatBounds, zoom: numb
         return;
     }
 
-    serviceLocator.eventManager.emit('map.updateLayer', 'transitPaths', layer);
+    (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+        layerName: 'transitPaths',
+        data: layer
+    });
 
     serviceLocator.eventManager.emit('map.updateLayers', {
         transitNodes: transitNodes

--- a/packages/chaire-lib-frontend/src/services/map/events/MapEventsCallbacks.ts
+++ b/packages/chaire-lib-frontend/src/services/map/events/MapEventsCallbacks.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+export type MapUpdateLayerEventType = {
+    name: 'map.updateLayer';
+    arguments: {
+        layerName: string;
+        data: GeoJSON.FeatureCollection | ((original: GeoJSON.FeatureCollection) => GeoJSON.FeatureCollection);
+    };
+};

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -44,6 +44,8 @@ import AccessibilityMapStatsComponent from './AccessibilityMapStatsComponent';
 import TimeOfTripComponent from '../transitRouting/widgets/TimeOfTripComponent';
 import TransitRoutingBaseComponent from '../transitRouting/widgets/TransitRoutingBaseComponent';
 import AccessibilityMapBatchForm from './AccessibilityMapBatchForm';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 export interface AccessibilityMapFormProps extends WithTranslation {
     addEventListeners?: () => void;
@@ -89,11 +91,10 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         this.onScenarioCollectionUpdate = this.onScenarioCollectionUpdate.bind(this);
 
         if (routingEngine.hasLocation()) {
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'accessibilityMapPoints',
-                routingEngine.locationToGeojson()
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'accessibilityMapPoints',
+                data: routingEngine.locationToGeojson()
+            });
         }
     }
 
@@ -108,7 +109,10 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         routing.setLocation(coordinates);
         //}
 
-        serviceLocator.eventManager.emit('map.updateLayer', 'accessibilityMapPoints', routing.locationToGeojson());
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'accessibilityMapPoints',
+            data: routing.locationToGeojson()
+        });
 
         this.removePolygons();
     }
@@ -140,12 +144,14 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
     }
 
     removePolygons() {
-        serviceLocator.eventManager.emit('map.updateLayer', 'accessibilityMapPolygons', turfFeatureCollection([]));
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'accessibilityMapPolygonStrokes',
-            turfFeatureCollection([])
-        );
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'accessibilityMapPolygons',
+            data: turfFeatureCollection([])
+        });
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'accessibilityMapPolygonStrokes',
+            data: turfFeatureCollection([])
+        });
         this.setState({
             currentResult: undefined,
             loading: false
@@ -157,7 +163,10 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         if (routing.hasLocation()) {
             routing.setLocation(coordinates, false);
             // only update layer for better performance:
-            serviceLocator.eventManager.emit('map.updateLayer', 'accessibilityMapPoints', routing.locationToGeojson());
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'accessibilityMapPoints',
+                data: routing.locationToGeojson()
+            });
             this.removePolygons();
             //this.calculateRouting();
         }
@@ -167,7 +176,10 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         const routing = this.state.object;
         // only both layer and routing engine object:
         routing.setLocation(coordinates);
-        serviceLocator.eventManager.emit('map.updateLayer', 'accessibilityMapPoints', routing.locationToGeojson());
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'accessibilityMapPoints',
+            data: routing.locationToGeojson()
+        });
         this.removePolygons();
         //this.calculateRouting();
     }
@@ -177,8 +189,14 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
 
         console.log('polygons calculated');
 
-        serviceLocator.eventManager.emit('map.updateLayer', 'accessibilityMapPolygons', polygons);
-        serviceLocator.eventManager.emit('map.updateLayer', 'accessibilityMapPolygonStrokes', strokes);
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'accessibilityMapPolygons',
+            data: polygons
+        });
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'accessibilityMapPolygonStrokes',
+            data: strokes
+        });
 
         this.setState({
             geojsonDownloadUrl: DownloadsUtils.generateJsonDownloadUrl(polygons),

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyButton.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyButton.tsx
@@ -17,6 +17,8 @@ import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
 import ButtonList from '../../parts/ButtonList';
 import TransitLineButton from '../line/TransitLineButton';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 interface AgencyButtonProps extends WithTranslation {
     agency: Agency;
@@ -62,11 +64,10 @@ const TransitAgencyButton: React.FunctionComponent<AgencyButtonProps> = (props: 
                 // reload paths
                 await serviceLocator.collectionManager.get('paths').loadFromServer(serviceLocator.socketEventManager);
                 serviceLocator.collectionManager.refresh('paths');
-                serviceLocator.eventManager.emit(
-                    'map.updateLayer',
-                    'transitPaths',
-                    serviceLocator.collectionManager.get('paths').toGeojson()
-                );
+                (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                    layerName: 'transitPaths',
+                    data: serviceLocator.collectionManager.get('paths').toGeojson()
+                });
                 await serviceLocator.collectionManager.get('lines').loadFromServer(serviceLocator.socketEventManager);
                 serviceLocator.collectionManager.refresh('lines');
             }
@@ -95,11 +96,10 @@ const TransitAgencyButton: React.FunctionComponent<AgencyButtonProps> = (props: 
         serviceLocator.collectionManager.refresh('paths');
         serviceLocator.collectionManager.refresh('lines');
         serviceLocator.collectionManager.refresh('agencies');
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'transitPaths',
-            serviceLocator.collectionManager.get('paths').toGeojson()
-        );
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPaths',
+            data: serviceLocator.collectionManager.get('paths').toGeojson()
+        });
         serviceLocator.eventManager.emit('progress', { name: 'SavingAgency', progress: 1.0 });
     };
 

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyEdit.tsx
@@ -23,6 +23,8 @@ import { SaveableObjectForm, SaveableObjectState } from 'chaire-lib-frontend/lib
 import SelectedObjectButtons from 'chaire-lib-frontend/lib/components/pageParts/SelectedObjectButtons';
 import CollectionDownloadButtons from 'chaire-lib-frontend/lib/components/pageParts/CollectionDownloadButtons';
 import Agency from 'transition-common/lib/services/agency/Agency';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 const timezoneZoneChoices: { label: string; value: string }[] = [];
 for (let i = 0, countI = timezones.length; i < countI; i++) {
@@ -77,11 +79,10 @@ class TransitAgencyEdit extends SaveableObjectForm<Agency, AgencyFormProps, Agen
             try {
                 await serviceLocator.collectionManager.get('paths').loadFromServer(serviceLocator.socketEventManager);
                 serviceLocator.collectionManager.refresh('paths');
-                serviceLocator.eventManager.emit(
-                    'map.updateLayer',
-                    'transitPaths',
-                    serviceLocator.collectionManager.get('paths').toGeojson()
-                );
+                (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                    layerName: 'transitPaths',
+                    data: serviceLocator.collectionManager.get('paths').toGeojson()
+                });
                 serviceLocator.collectionManager
                     .get('lines')
                     .loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager);

--- a/packages/transition-frontend/src/components/forms/line/TransitLineButton.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineButton.tsx
@@ -12,6 +12,8 @@ import Line from 'transition-common/lib/services/line/Line';
 import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
 import { duplicateLine } from 'transition-common/lib/services/line/LineDuplicator';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 interface LineButtonProps extends WithTranslation {
     line: Line;
@@ -51,11 +53,10 @@ const TransitLineButton: React.FunctionComponent<LineButtonProps> = (props: Line
                 // reload paths
                 await serviceLocator.collectionManager.get('paths').loadFromServer(serviceLocator.socketEventManager);
                 serviceLocator.collectionManager.refresh('paths');
-                serviceLocator.eventManager.emit(
-                    'map.updateLayer',
-                    'transitPaths',
-                    serviceLocator.collectionManager.get('paths').toGeojson()
-                );
+                (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                    layerName: 'transitPaths',
+                    data: serviceLocator.collectionManager.get('paths').toGeojson()
+                });
             }
         }
         serviceLocator.eventManager.emit('progress', { name: 'DeletingLine', progress: 1.0 });
@@ -79,11 +80,10 @@ const TransitLineButton: React.FunctionComponent<LineButtonProps> = (props: Line
         serviceLocator.collectionManager.refresh('paths');
         serviceLocator.collectionManager.refresh('lines');
         serviceLocator.collectionManager.refresh('services');
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'transitPaths',
-            serviceLocator.collectionManager.get('paths').toGeojson()
-        );
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPaths',
+            data: serviceLocator.collectionManager.get('paths').toGeojson()
+        });
         serviceLocator.eventManager.emit('progress', { name: 'SavingLine', progress: 1.0 });
     };
 

--- a/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
@@ -32,6 +32,8 @@ import SelectedObjectButtons from 'chaire-lib-frontend/lib/components/pageParts/
 import { SaveableObjectForm, SaveableObjectState } from 'chaire-lib-frontend/lib/components/forms/SaveableObjectForm';
 import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollection';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 interface LineFormProps extends WithTranslation {
     line: Line;
@@ -87,11 +89,10 @@ class TransitLineEdit extends SaveableObjectForm<Line, LineFormProps, LineFormSt
                 serviceLocator.selectedObjectsManager.deselect('line');
                 await serviceLocator.collectionManager.get('paths').loadFromServer(serviceLocator.socketEventManager);
                 serviceLocator.collectionManager.refresh('paths');
-                serviceLocator.eventManager.emit(
-                    'map.updateLayer',
-                    'transitPaths',
-                    serviceLocator.collectionManager.get('paths').toGeojson()
-                );
+                (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                    layerName: 'transitPaths',
+                    data: serviceLocator.collectionManager.get('paths').toGeojson()
+                });
                 serviceLocator.collectionManager.refresh('lines');
                 serviceLocator.eventManager.emit('progress', { name: 'DeletingLine', progress: 1.0 });
             } else {
@@ -140,11 +141,10 @@ class TransitLineEdit extends SaveableObjectForm<Line, LineFormProps, LineFormSt
             serviceLocator.collectionManager.refresh('lines');
             serviceLocator.collectionManager.refresh('agencies');
             serviceLocator.collectionManager.refresh('paths');
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'transitPaths',
-                serviceLocator.collectionManager.get('paths').toGeojson()
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'transitPaths',
+                data: serviceLocator.collectionManager.get('paths').toGeojson()
+            });
             serviceLocator.eventManager.emit('progress', { name: 'SavingLine', progress: 1.0 });
             serviceLocator.eventManager.emit('fullSizePanel.hide');
         } catch (error) {

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeEdit.tsx
@@ -32,6 +32,8 @@ import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/Input
 import SelectedObjectButtons from 'chaire-lib-frontend/lib/components/pageParts/SelectedObjectButtons';
 import NodeStatistics from './TransitNodeStatistics';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 interface NodeFormProps extends WithTranslation {
     node: Node;
@@ -174,9 +176,12 @@ class TransitNodeEdit extends SaveableObjectForm<Node, NodeFormProps, NodeFormSt
     }
 
     onDrag(coordinates) {
-        serviceLocator.eventManager.emit('map.updateLayer', 'transitNodesSelected', (oldGeojson) => {
-            oldGeojson.features[0].geometry.coordinates = coordinates;
-            return oldGeojson;
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitNodesSelected',
+            data: (oldGeojson: GeoJSON.FeatureCollection) => {
+                (oldGeojson.features[0].geometry as GeoJSON.Point).coordinates = coordinates;
+                return oldGeojson;
+            }
         });
     }
 

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
@@ -24,11 +24,10 @@ const NodesImportForm: React.FunctionComponent<NodeImportFormProps & WithTransla
             .get('nodes')
             .loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager);
         serviceLocator.collectionManager.refresh('nodes');
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'transitNodes',
-            serviceLocator.collectionManager.get('nodes').toGeojson()
-        );
+        serviceLocator.eventManager.emit('map.updateLayer', {
+            layerName: 'transitNodes',
+            data: serviceLocator.collectionManager.get('nodes').toGeojson()
+        });
         serviceLocator.eventManager.emit('transferableNodes.dirty');
         serviceLocator.eventManager.emit('progress', { name: 'Importing', progress: 1.0 });
         closeImporter();

--- a/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
@@ -13,6 +13,8 @@ import Path, { PathAttributesData } from 'transition-common/lib/services/path/Pa
 import Line from 'transition-common/lib/services/line/Line';
 import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 interface PathButtonProps extends WithTranslation {
     line: Line;
@@ -49,11 +51,10 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
         if (!props.path.isNew()) {
             serviceLocator.eventManager.emit('progress', { name: 'DeletingPath', progress: 0.0 });
             await props.path.delete(serviceLocator.socketEventManager);
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'transitPaths',
-                serviceLocator.collectionManager.get('paths').toGeojson()
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'transitPaths',
+                data: serviceLocator.collectionManager.get('paths').toGeojson()
+            });
             serviceLocator.eventManager.emit('progress', { name: 'DeletingPath', progress: 1.0 });
         }
 
@@ -133,10 +134,12 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                     await reversedPath.save(serviceLocator.socketEventManager);
                     serviceLocator.collectionManager.refresh('paths');
                     props.line.refreshPaths();
-                    serviceLocator.eventManager.emit(
+                    (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>(
                         'map.updateLayer',
-                        'transitPaths',
-                        serviceLocator.collectionManager.get('paths').toGeojson()
+                        {
+                            layerName: 'transitPaths',
+                            data: serviceLocator.collectionManager.get('paths').toGeojson()
+                        }
                     );
                     serviceLocator.selectedObjectsManager.update('line', props.line);
                     serviceLocator.collectionManager.refresh('lines');
@@ -161,11 +164,10 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                 await duplicatePath.save(serviceLocator.socketEventManager);
                 serviceLocator.collectionManager.refresh('paths');
                 props.line.refreshPaths();
-                serviceLocator.eventManager.emit(
-                    'map.updateLayer',
-                    'transitPaths',
-                    serviceLocator.collectionManager.get('paths').toGeojson()
-                );
+                (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                    layerName: 'transitPaths',
+                    data: serviceLocator.collectionManager.get('paths').toGeojson()
+                });
                 serviceLocator.selectedObjectsManager.update('line', props.line);
                 serviceLocator.collectionManager.refresh('lines');
             } catch (error) {

--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -38,6 +38,8 @@ import { parseIntOrNull, parseFloatOrNull } from 'chaire-lib-common/lib/utils/Ma
 import Path, { pathDirectionArray } from 'transition-common/lib/services/path/Path';
 import Line from 'transition-common/lib/services/line/Line';
 import { NodeAttributes } from 'transition-common/lib/services/nodes/Node';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 const lineModesConfigByMode = {};
 for (let i = 0, countI = lineModesConfig.length; i < countI; i++) {
@@ -223,18 +225,16 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
     // TODO Once the map is in typescript, we can probably get the type of the properties here instead of any
     onStartDragWaypoint = (waypointGeojson: GeoJSON.Feature<GeoJSON.Point, any>) => {
         if (this.props.path.isFrozen()) {
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'transitPathWaypointsSelected',
-                turfFeatureCollection([])
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'transitPathWaypointsSelected',
+                data: turfFeatureCollection([])
+            });
             return true;
         }
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'transitPathWaypointsSelected',
-            turfFeatureCollection([waypointGeojson])
-        );
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPathWaypointsSelected',
+            data: turfFeatureCollection([waypointGeojson])
+        });
         this.setState((oldState) => {
             return {
                 waypointDraggingAfterNodeIndex: waypointGeojson.properties.afterNodeIndex,
@@ -245,28 +245,25 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
 
     onDragWaypoint = (coordinates: [number, number]) => {
         if (this.props.path.isFrozen()) {
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'transitPathWaypointsSelected',
-                turfFeatureCollection([])
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'transitPathWaypointsSelected',
+                data: turfFeatureCollection([])
+            });
             return true;
         }
         const waypointGeojson = turfPoint(coordinates);
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'transitPathWaypointsSelected',
-            turfFeatureCollection([waypointGeojson])
-        );
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPathWaypointsSelected',
+            data: turfFeatureCollection([waypointGeojson])
+        });
     };
 
     onReplaceWaypointByNodeId = async (nodeId: string, waypointType = 'engine') => {
         if (this.props.path.isFrozen()) {
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'transitPathWaypointsSelected',
-                turfFeatureCollection([])
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'transitPathWaypointsSelected',
+                data: turfFeatureCollection([])
+            });
             return true;
         }
         await this.props.path.replaceWaypointByNodeId(
@@ -277,12 +274,18 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
         );
         this.props.path.validate();
         serviceLocator.selectedObjectsManager.update('path', this.props.path);
-        serviceLocator.eventManager.emit('map.updateLayer', 'transitPathWaypointsSelected', turfFeatureCollection([]));
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPathWaypointsSelected',
+            data: turfFeatureCollection([])
+        });
         serviceLocator.eventManager.emit('selected.updateLayers.path');
     };
 
     onUpdateWaypoint = (coordinates: [number, number], waypointType = null) => {
-        serviceLocator.eventManager.emit('map.updateLayer', 'transitPathWaypointsSelected', turfFeatureCollection([]));
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPathWaypointsSelected',
+            data: turfFeatureCollection([])
+        });
         if (!this.props.path.isFrozen()) {
             this.props.path
                 .updateWaypoint(

--- a/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
@@ -9,6 +9,8 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import FileImportForm from '../../parts/FileImportForm';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 interface PathImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
@@ -32,11 +34,10 @@ const PathsImportForm: React.FunctionComponent<PathImportFormProps & WithTransla
         serviceLocator.collectionManager.refresh('paths');
         serviceLocator.collectionManager.refresh('lines');
         serviceLocator.collectionManager.refresh('agencies');
-        serviceLocator.eventManager.emit(
-            'map.updateLayer',
-            'transitPaths',
-            serviceLocator.collectionManager.get('paths').toGeojson()
-        );
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPaths',
+            data: serviceLocator.collectionManager.get('paths').toGeojson()
+        });
         serviceLocator.eventManager.emit('progress', { name: 'Importing', progress: 1.0 });
         closeImporter();
     };

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -20,6 +20,8 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import { TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 export interface RoutingResultStatus {
     routingResult: UnimodalRouteCalculationResult | TransitRoutingResult;
     alternativeIndex: number;
@@ -33,7 +35,10 @@ export interface TransitRoutingResultsProps extends WithTranslation {
 
 const showCurrentAlternative = async (result, alternativeIndex) => {
     const pathGeojson = await result.getPathGeojson(alternativeIndex, {});
-    serviceLocator.eventManager.emit('map.updateLayer', 'routingPoints', result.originDestinationToGeojson());
+    (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+        layerName: 'routingPoints',
+        data: result.originDestinationToGeojson()
+    });
     serviceLocator.eventManager.emit('map.updateLayers', {
         routingPaths: pathGeojson,
         routingPathsStrokes: pathGeojson

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -38,6 +38,8 @@ import TransitRoutingBaseComponent from './widgets/TransitRoutingBaseComponent';
 import ODCoordinatesComponent from './widgets/ODCoordinatesComponent';
 import TimeOfTripComponent from './widgets/TimeOfTripComponent';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 export interface TransitRoutingFormProps extends WithTranslation {
     // TODO tahini batch routing
@@ -90,11 +92,10 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
         this.resetBatchSelection = this.resetBatchSelection.bind(this);
 
         if (this.state.object.hasOrigin()) {
-            serviceLocator.eventManager.emit(
-                'map.updateLayer',
-                'routingPoints',
-                this.state.object.originDestinationToGeojson()
-            );
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'routingPoints',
+                data: this.state.object.originDestinationToGeojson()
+            });
         }
     }
 
@@ -174,7 +175,10 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
             if (isCancelled()) {
                 return;
             }
-            serviceLocator.eventManager.emit('map.updateLayer', 'routingPoints', routing.originDestinationToGeojson());
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'routingPoints',
+                data: routing.originDestinationToGeojson()
+            });
 
             this.setState({
                 currentResult: results,
@@ -202,7 +206,10 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
         const routing = this.state.object;
         routing.setOrigin(originCoordinates, true);
         routing.setDestination(destinationCoordinates, true);
-        serviceLocator.eventManager.emit('map.updateLayer', 'routingPoints', routing.originDestinationToGeojson());
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'routingPoints',
+            data: routing.originDestinationToGeojson()
+        });
         if (routing.hasOrigin() && routing.hasDestination() && shouldCalculate) {
             this.calculateRouting(true);
         }

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/ODCoordinatesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/ODCoordinatesComponent.tsx
@@ -13,6 +13,8 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 export interface ODCoordinatesComponentProps extends WithTranslation {
     originGeojson?: GeoJSON.Feature<GeoJSON.Point>;
@@ -160,7 +162,10 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
                 externalUpdate: this.state.externalUpdate + 1
             });
             this.updateOrigin(coordinates[0], coordinates[1]);
-            serviceLocator.eventManager.emit('map.updateLayer', 'routingPoints', this.originDestinationToGeojson());
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'routingPoints',
+                data: this.originDestinationToGeojson()
+            });
         } else {
             this.setState({
                 destinationLat: coordinates[1],
@@ -168,7 +173,10 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
                 externalUpdate: this.state.externalUpdate + 1
             });
             this.updateDestination(coordinates[0], coordinates[1]);
-            serviceLocator.eventManager.emit('map.updateLayer', 'routingPoints', this.originDestinationToGeojson());
+            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+                layerName: 'routingPoints',
+                data: this.originDestinationToGeojson()
+            });
         }
     };
 

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -29,6 +29,8 @@ import { featureCollection as turfFeatureCollection } from '@turf/turf';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
 import { MapEventHandlerDescription } from 'chaire-lib-frontend/lib/services/map/IMapEventHandler';
 import { deleteUnusedNodes } from '../../services/transitNodes/transitNodesUtils';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
 
 MapboxGL.accessToken = process.env.MAPBOX_ACCESS_TOKEN || '';
 
@@ -231,7 +233,10 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
         mapCustomEvents.addEvents(serviceLocator.eventManager);
         elementResizedEvent(this.mapContainer, this.onResizeContainer);
         serviceLocator.eventManager.on('map.updateEnabledLayers', this.updateEnabledLayers);
-        serviceLocator.eventManager.on('map.updateLayer', this.updateLayer);
+        (serviceLocator.eventManager as EventManager).onEvent<MapUpdateLayerEventType>(
+            'map.updateLayer',
+            this.updateLayer
+        );
         serviceLocator.eventManager.on('map.updateLayers', this.updateLayers);
         serviceLocator.eventManager.on('map.addPopup', this.addPopup);
         serviceLocator.eventManager.on('map.removePopup', this.removePopup);
@@ -481,8 +486,11 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
         this.popupManager.removeAllPopups();
     };
 
-    updateLayer = (layerName: string, geojson: GeoJSON.FeatureCollection) => {
-        this.layerManager.updateLayer(layerName, geojson);
+    updateLayer = (args: {
+        layerName: string;
+        data: GeoJSON.FeatureCollection | ((original: GeoJSON.FeatureCollection) => GeoJSON.FeatureCollection);
+    }) => {
+        this.layerManager.updateLayer(args.layerName, args.data);
     };
 
     updateLayers = (geojsonByLayerName) => {

--- a/packages/transition-frontend/src/services/dashboard/LayersAndCollectionsService.ts
+++ b/packages/transition-frontend/src/services/dashboard/LayersAndCollectionsService.ts
@@ -13,6 +13,8 @@ import PlaceCollection from 'transition-common/lib/services/places/PlaceCollecti
 import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
 import SimulationCollection from 'transition-common/lib/services/simulation/SimulationCollection';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 // TODO: Bring back the missing data types
 type LoadLayersOptions = {
@@ -56,11 +58,17 @@ export const loadLayersAndCollections = async ({
         serviceLocator.collectionManager.add('simulations', simulationCollection);
 
         await nodeCollection.loadFromServer(serviceLocator.socketEventManager);
-        serviceLocator.eventManager.emit('map.updateLayer', 'transitNodes', nodeCollection.toGeojson());
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitNodes',
+            data: nodeCollection.toGeojson()
+        });
         serviceLocator.collectionManager.add('nodes', nodeCollection);
 
         await pathCollection.loadFromServer(serviceLocator.socketEventManager);
-        serviceLocator.eventManager.emit('map.updateLayer', 'transitPaths', pathCollection.toGeojson());
+        (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
+            layerName: 'transitPaths',
+            data: pathCollection.toGeojson()
+        });
         serviceLocator.collectionManager.add('paths', pathCollection);
 
         await lineCollection.loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager);


### PR DESCRIPTION
* eventManager: Add methods to listen and emit typed events

This allows to use a type for the events, with a `name` and `args` fields for the name of the event and types of arguments in the callback.
    
The methods are generic, with the generic type being the type of the event. The listening method is `onEvent`, the emitting one is `emitEvent`. It can be called in the code with
    
`eventManager.emitEvent<MyEventType>('event.myevent', myArgs)`
`eventManager.onEvent<MyEventType>('event.myevent', (myArgs) => void)`

* map: type the `map.updateLayer` event

Use the new `onEvent` and `emitEvent` methods of the EventManager to type the calls to `map.updateLayer`. It receives an argument with 2 fields: `layerName` and `data`, which are respectively the layer to update and the geojson feature collection for the layer (or function to retrieve it).