### PR TITLE
mapObject: add a `hasChangedGeography` method

### DIFF
--- a/packages/chaire-lib-common/src/utils/objects/MapObject.ts
+++ b/packages/chaire-lib-common/src/utils/objects/MapObject.ts
@@ -36,6 +36,10 @@ export class MapObject<
             properties: _omit(this.attributes, 'data') as T
         };
     }
+
+    hasChangedGeography = (): boolean => {
+        return (this.isNew() && this._attributes.geography !== undefined) || this.hasChanged('geography');
+    };
 }
 
 export default MapObject;

--- a/packages/chaire-lib-common/src/utils/objects/__tests__/MapObject.test.ts
+++ b/packages/chaire-lib-common/src/utils/objects/__tests__/MapObject.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { GenericObject, GenericAttributes } from '../GenericObject';
+import { MapObject, MapObjectAttributes } from '../MapObject';
+
+const defaultAttributes = {
+    name: 'Transit stop',
+    color: 'red',
+    geography: {
+        type: 'Feature' as const,
+        geometry: {
+            type: 'Point' as const,
+            coordinates: [-73.6, 45.5]
+        },
+        properties: {
+            name: 'Transit stop'
+        }
+    }
+};
+
+class SomeMapObject extends MapObject<GeoJSON.Point, MapObjectAttributes<GeoJSON.Point>>
+{
+    public constructor(attributes = {}, isNew = true)
+    {
+        super(attributes, isNew, null);
+    }
+}
+
+describe('hasChangedGeography', () => {
+    
+    test('not changed for empty object', () => {
+        const object = new SomeMapObject({}, true);
+        expect(object.hasChangedGeography()).toEqual(false);
+    });
+
+    test('changed for new object with geography', () => {
+        const object = new SomeMapObject({
+            name: 'test',
+            geography: { coordinates: [-73, 45] }
+        }, true);
+        expect(object.hasChangedGeography()).toEqual(true);
+    });
+
+    test('not changed when geography not changed', () => {
+        const object = new SomeMapObject({
+            name: 'test',
+            geography: { coordinates: [-73, 45] }
+        }, false);
+        object.startEditing();
+        object.set('name', 'new name');
+        expect(object.hasChangedGeography()).toEqual(false);
+    });
+
+    test('changed when geography modified', () => {
+        const object = new SomeMapObject({
+            name: 'test',
+            geography: { coordinates: [-73, 45] }
+        }, false);
+        object.startEditing();
+        object.set('geography', { coordinates: [-74, 46] });
+        expect(object.hasChangedGeography()).toEqual(true);
+    });
+
+    test('not changed, even if geography changed in history', () => {
+        const object = new SomeMapObject({
+            name: 'test',
+            geography: { coordinates: [-73, 45] }
+        }, false);
+        object.startEditing();
+        // Set a geography and go back to original
+        object.set('geography', { coordinates: [-74, 46] });
+        object.set('geography', { coordinates: [-73, 45] });
+        expect(object.hasChangedGeography()).toEqual(false);
+    });
+})

--- a/packages/transition-common/src/services/nodes/__tests__/NodeCollection.test.ts
+++ b/packages/transition-common/src/services/nodes/__tests__/NodeCollection.test.ts
@@ -86,7 +86,7 @@ test('new node object', function() {
     
     const node1 = nodeCollection.newObject(node1Geojson, true);
     const node1Expected = new Node(nodeAttributes1, true);
-    expect(node1).toEqual(node1Expected);
+    expect(node1.attributes).toEqual(node1Expected.attributes);
 
 });
 

--- a/packages/transition-common/src/services/nodes/__tests__/NodeGeographyUtils.test.ts
+++ b/packages/transition-common/src/services/nodes/__tests__/NodeGeographyUtils.test.ts
@@ -84,7 +84,7 @@ test('nodesInWalkingTravelTimeRadiusSeconds with transferable nodes', async() =>
 
     let nodesInRoutedRadius = await NodeGeographyUtils.nodesInWalkingTravelTimeRadiusSeconds(node, nodeCollection, 300);
     // Make sure the object was not changed
-    expect(node).toEqual(nodeCollection.newObject(nodeOrig));
+    expect(node.attributes).toEqual(nodeCollection.newObject(nodeOrig).attributes);
     expect(nodesInRoutedRadius).toEqual({
         nodesIds: [ nodeClose1Geojson.properties.id, nodeClose2Geojson.properties.id, nodeClose3Geojson.properties.id ],
         walkingDistancesMeters: [ 0, 200, 400 ],
@@ -98,7 +98,7 @@ test('nodesInWalkingTravelTimeRadiusSeconds with transferable nodes', async() =>
     // Make a second call, but with a shorter travel time
     nodesInRoutedRadius = await NodeGeographyUtils.nodesInWalkingTravelTimeRadiusSeconds(node, nodeCollection, 150);
     // Make sure the object was not changed
-    expect(node).toEqual(nodeCollection.newObject(nodeOrig));
+    expect(node.attributes).toEqual(nodeCollection.newObject(nodeOrig).attributes);
     expect(nodesInRoutedRadius).toEqual({
         nodesIds: [ nodeClose1Geojson.properties.id, nodeClose2Geojson.properties.id ],
         walkingDistancesMeters: [ 0, 200 ],

--- a/packages/transition-common/src/services/odTrip/__tests__/BaseOdTripCollection.test.ts
+++ b/packages/transition-common/src/services/odTrip/__tests__/BaseOdTripCollection.test.ts
@@ -109,8 +109,8 @@ test('Load from server', async () => {
     expect(collection.getFeatures().length).toEqual(2);
     const odPair1 = collection.getFeatures()[0];
     const odPair2 = collection.getFeatures()[1];
-    expect(odPair1).toEqual(new BaseOdTrip(odTripAttributes1, false));
-    expect(odPair2).toEqual(new BaseOdTrip(odTripAttributes2, false));
+    expect(odPair1.attributes).toEqual(new BaseOdTrip(odTripAttributes1, false).attributes);
+    expect(odPair2.attributes).toEqual(new BaseOdTrip(odTripAttributes2, false).attributes);
 
 });
 
@@ -124,7 +124,7 @@ test('Load from server for data source', async () => {
     expect(eventManager.emit).toHaveBeenCalledWith('odPairs.collection', odTripAttributes1.dataSourceId, expect.anything());
     expect(collection.getFeatures().length).toEqual(1);
     const odPair1 = collection.getFeatures()[0];
-    expect(odPair1).toEqual(new BaseOdTrip(odTripAttributes1, false));
+    expect(odPair1.attributes).toEqual(new BaseOdTrip(odTripAttributes1, false).attributes);
 
 });
 

--- a/packages/transition-common/src/services/path/__tests__/PathCollection.test.ts
+++ b/packages/transition-common/src/services/path/__tests__/PathCollection.test.ts
@@ -103,7 +103,7 @@ test('new path object', function() {
     
     const path1 = pathCollection.newObject(path1Geojson, true);
     const path1Expected = new Path(pathAttributes1, true);
-    expect(path1).toEqual(path1Expected);
+    expect(path1.attributes).toEqual(path1Expected.attributes);
 
 });
 


### PR DESCRIPTION
This method returns true if the geography of the object has changed, otherwise false.

Also add unit tests for the new method and the MapObject class