### PR TITLE
jest: Add enableAllMocks to transition-backend tests

### DIFF
--- a/packages/transition-backend/jestSetup.ts
+++ b/packages/transition-backend/jestSetup.ts
@@ -5,3 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 jest.mock('chaire-lib-backend/lib/config/shared/db.config');
+import { enableAllMocks } from 'chaire-lib-common/lib/test';
+
+enableAllMocks();

--- a/packages/transition-backend/src/services/capnpCache/__tests__/dbToCache.test.ts
+++ b/packages/transition-backend/src/services/capnpCache/__tests__/dbToCache.test.ts
@@ -12,8 +12,10 @@ import serviceLocator   from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { saveAndUpdateAllNodes } from '../../nodes/NodeCollectionUtils';
 
 import { recreateCache } from '../dbToCache';
+import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
+import { EventManagerMock } from 'chaire-lib-common/lib/test';
 
-serviceLocator.socketEventManager = new EventEmitter();
+//serviceLocator.socketEventManager = new EventEmitter();
 
 // Mock data sources
 const dataSourceAttributes = {
@@ -245,7 +247,7 @@ jest.mock('../../../models/db/places.db.queries', () => {
     }
 });
 jest.mock('../../nodes/NodeCollectionUtils');
-const mockedSaveAndUpdateAllNodes = saveAndUpdateAllNodes as jest.Mocked<typeof saveAndUpdateAllNodes>;
+const mockedSaveAndUpdateAllNodes = saveAndUpdateAllNodes as jest.MockedFunction<typeof saveAndUpdateAllNodes>;
 const mockedNodesToCache = jest.fn();
 jest.mock('../../../models/capnpCache/transitNodes.cache.queries', () => {
     return {
@@ -393,13 +395,13 @@ describe('Recreate cache', () => {
                 geometry: nodeGeography
             })]
         }), undefined);
-        expect(mockedSaveAndUpdateAllNodes).toHaveBeenCalledWith(expect.objectContaining({
+        expect(mockedSaveAndUpdateAllNodes).toHaveBeenLastCalledWith(expect.objectContaining({
             _features: [expect.objectContaining({
                 type: 'Feature' as const,
                 properties: nodeAttributes,
                 geometry: nodeGeography
             })]
-        }), expect.anything(), undefined, expect.anything(), undefined);
+        }), expect.anything(), EventManagerMock.eventManagerMock, expect.anything(), undefined);
     });
 
     test('no refresh nodes, refresh schedules', async () => {
@@ -444,7 +446,7 @@ describe('Recreate cache', () => {
                 properties: nodeAttributes,
                 geometry: nodeGeography
             })]
-        }), expect.anything(), undefined, expect.anything(), undefined);
+        }), expect.anything(), EventManagerMock.eventManagerMock, expect.anything(), undefined);
     });
 
     test('refresh nodes and schedules', async () => {
@@ -490,6 +492,6 @@ describe('Recreate cache', () => {
                 properties: nodeAttributes,
                 geometry: nodeGeography
             })]
-        }), expect.anything(), undefined, expect.anything(), undefined);
+        }), expect.anything(), EventManagerMock.eventManagerMock, expect.anything(), undefined);
     });
 });


### PR DESCRIPTION
This makes it easier to mock calls to osrm engine or tr routing in unit tests for example.

The dbToCache test had to be updated because now a event manager exists by default.