### PR TITLE
db: Add index on the tr_transit_nodes' geography field

### DIFF
--- a/packages/transition-backend/src/models/db/migrations/20231206121400_addNodeGeographyIndex.ts
+++ b/packages/transition-backend/src/models/db/migrations/20231206121400_addNodeGeographyIndex.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const tableName = 'tr_transit_nodes';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.index('geography', 'tr_transit_nodes_geography', 'gist');
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.dropIndex('tr_transit_nodes_geography');
+    });
+}


### PR DESCRIPTION
A gist index allows faster queries on the geography field, like returning nodes within a certain distance.