### PR TITLE
Transit panel: add a button to delete all unused nodes

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -50,10 +50,12 @@
         },
         "MultipleDelete": "Delete nodes",
         "ConfirmMultipleDelete": "Do you confirm deletion of those stop nodes? Only the nodes through which no path passes will be deleted.",
+        "ConfirmAllDelete": "Do you confirm deletion of all unused stop nodes? Only the nodes through which no path passes will be deleted.",
         "deleteSelectedNodes": "Delete unused selected nodes",
-        "deleteSelectedPolygon":"Cancel selection",
-        "editSelectedNodes":"Edit selected nodes",
-        "editFrozenSelectedNodesWarning":"only unfrozen nodes will be saved"
+        "deleteSelectedPolygon": "Cancel selection",
+        "editSelectedNodes": "Edit selected nodes",
+        "editFrozenSelectedNodesWarning": "only unfrozen nodes will be saved",
+        "DeleteAllUnusedNodes": "Delete all unused nodes"
     },
     "transitAgency": {
         "List": "Agencies",
@@ -466,7 +468,6 @@
         "ShowPathEditHelp": "Show path edit help",
         "HidePathEditHelp": "Hide path edit help",
         "warningFromGtfs": "Warning! This transit path was imported from a GTFS. Recomputing its path could change the geography and timings.",
-
         "directions": {
             "loop": "Loop",
             "outbound": "Outbound",
@@ -656,7 +657,7 @@
             "DataSourceDoesNotExists": "The specified data source does not exists.",
             "DataSourceAlreadyExists": "A data source with that name already exists for OD calculations.",
             "InvalidOdTripsDataSource": "Invalid OD calculations data source.",
-            "ErrorCalculatingLocation":  "Error calculating location {{id}}",
+            "ErrorCalculatingLocation": "Error calculating location {{id}}",
             "UserDiskQuotaReached": "Maximum allowed disk space has been reached. Please delete old tasks to delete their files.",
             "RoutingParametersInvalidForBatch": "Routing parameters are invalid. Make sure the scenario is set and times have a valid value."
         },
@@ -722,9 +723,7 @@
         "HH_MM__HH_MM_SS": "HH:MM or HH:MM:SS",
         "HMM": "HMM",
         "SecondsSinceMidnight": "Seconds after midnight"
-
     },
-
     "gtfs": {
         "ButtonImport": "Import",
         "Import": "Import from a GTFS feed",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -50,10 +50,12 @@
         },
         "MultipleDelete": "Supprimer les noeuds d'arrêt",
         "ConfirmMultipleDelete": "Confirmez-vous que vous désirez bien supprimer ces noeuds d'arrêt? Seuls les noeuds ne desservant aucun trajet seront supprimés.",
+        "ConfirmAllDelete": "Confirmez-vous que vous désirez bien supprimer tous les noeuds d'arrêts inutilisés? Seuls les noeuds ne desservant aucun trajet seront supprimés.",
         "deleteSelectedNodes": "Supprimer les noeuds sélectionnés et inutilisés",
         "deleteSelectedPolygon": "Annuler la sélection",
         "editSelectedNodes": "Modifier les noeuds sélectionnés",
-        "editFrozenSelectedNodesWarning": "Seulement les noeuds non verrouillés seront sauvegardés"
+        "editFrozenSelectedNodesWarning": "Seulement les noeuds non verrouillés seront sauvegardés",
+        "DeleteAllUnusedNodes": "Supprimer tous les noeuds non utilisés"
     },
     "transitAgency": {
         "List": "Agences",

--- a/packages/transition-backend/src/api/transit.socketRoutes.ts
+++ b/packages/transition-backend/src/api/transit.socketRoutes.ts
@@ -14,6 +14,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import nodesDbQueries from '../models/db/transitNodes.db.queries';
 import schedulesDbQueries from '../models/db/transitSchedules.db.queries';
+import { TransitApi } from 'transition-common/lib/api/transit';
 
 /**
  * Add routes specific to the transit objects
@@ -82,7 +83,7 @@ export default function (socket: EventEmitter) {
     );
 
     socket.on(
-        'transitNodes.deleteUnused',
+        TransitApi.DELETE_UNUSED_NODES,
         async (nodeIds: string[] | undefined, callback: (status: Status.Status<string[]>) => void) => {
             try {
                 const deletedNodeIds = await nodesDbQueries.deleteMultipleUnused(

--- a/packages/transition-backend/src/api/transit.socketRoutes.ts
+++ b/packages/transition-backend/src/api/transit.socketRoutes.ts
@@ -80,4 +80,25 @@ export default function (socket: EventEmitter) {
             }
         }
     );
+
+    socket.on(
+        'transitNodes.deleteUnused',
+        async (nodeIds: string[] | undefined, callback: (status: Status.Status<string[]>) => void) => {
+            try {
+                const deletedNodeIds = await nodesDbQueries.deleteMultipleUnused(
+                    nodeIds === undefined || nodeIds === null ? 'all' : nodeIds
+                );
+                callback(Status.createOk(deletedNodeIds));
+            } catch (error) {
+                console.error(
+                    `An error occurred while deleting ${
+                        nodeIds === undefined || nodeIds === null ? 'all' : nodeIds.length
+                    } unused nodes: ${error}`
+                );
+                if (typeof callback === 'function') {
+                    callback(Status.createError('Error deleting unused nodes'));
+                }
+            }
+        }
+    );
 }

--- a/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
@@ -272,7 +272,22 @@ describe(`${objectName}`, () => {
 
         // Delete multiple nodes, some of which have paths associated, only the
         // one without path should be deleted
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id, newObjectAttributes3.id]);
+        const ids = await dbQueries.deleteMultipleUnused([newObjectAttributes.id, newObjectAttributes2.id, newObjectAttributes3.id]);
+        expect(ids).toEqual([newObjectAttributes3.id]);
+        expect(await dbQueries.exists(newObjectAttributes.id)).toBe(true);
+        expect(await dbQueries.exists(newObjectAttributes2.id)).toBe(true);
+        expect(await dbQueries.exists(newObjectAttributes3.id)).toBe(false);
+
+    });
+
+    test('should not delete all nodes nodes from database if paths exist', async () => {
+        // Add a new node, not associated with a path
+        const newObject = new ObjectClass(newObjectAttributes3, true);
+        await dbQueries.create(newObject.attributes);
+        expect(await dbQueries.exists(newObjectAttributes3.id)).toBe(true);
+
+        // Delete all unused nodes
+        const ids = await dbQueries.deleteMultipleUnused('all');
         expect(ids).toEqual([newObjectAttributes3.id]);
         expect(await dbQueries.exists(newObjectAttributes.id)).toBe(true);
         expect(await dbQueries.exists(newObjectAttributes2.id)).toBe(true);
@@ -288,7 +303,7 @@ describe(`${objectName}`, () => {
         expect(id).toBe(newObjectAttributes.id);
         expect(await dbQueries.exists(newObjectAttributes.id)).toBe(false);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        const ids = await dbQueries.deleteMultipleUnused([newObjectAttributes.id, newObjectAttributes2.id]);
         expect(ids).toEqual([newObjectAttributes2.id]);
 
     });

--- a/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
@@ -240,12 +240,14 @@ const deleteIfUnused = async (id: string): Promise<string | undefined> => {
     }
 };
 
-const deleteMultipleUnused = function (ids: string[]): Promise<string[]> {
+const deleteMultipleUnused = function (ids: string[] | 'all'): Promise<string[]> {
     return new Promise((resolve, reject) => {
         const notInQuery = knex.distinct(knex.raw('unnest(nodes)')).from(pathTableName);
-        return knex(tableName)
-            .whereIn('id', ids)
-            .whereNotIn('id', notInQuery)
+        const deleteQuery = knex(tableName).whereNotIn('id', notInQuery);
+        if (ids !== 'all') {
+            deleteQuery.whereIn('id', ids);
+        }
+        return deleteQuery
             .del()
             .returning('id')
             .then((ret) => {
@@ -281,7 +283,7 @@ export default {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
     },
     delete: deleteIfUnused,
-    deleteMultiple: deleteMultipleUnused,
+    deleteMultipleUnused,
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection,

--- a/packages/transition-common/src/api/transit.ts
+++ b/packages/transition-common/src/api/transit.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+export class TransitApi {
+    /**
+     * Socket route name to delete the unused transit nodes
+     *
+     * @static
+     * @memberof TransitApi
+     */
+    static readonly DELETE_UNUSED_NODES = 'transitNodes.deleteUnused';
+}

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -28,6 +28,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import { featureCollection as turfFeatureCollection } from '@turf/turf';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
 import { MapEventHandlerDescription } from 'chaire-lib-frontend/lib/services/map/IMapEventHandler';
+import { deleteUnusedNodes } from '../../services/transitNodes/transitNodesUtils';
 
 MapboxGL.accessToken = process.env.MAPBOX_ACCESS_TOKEN || '';
 
@@ -418,23 +419,26 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
     };
 
     onDeleteSelectedNodes = () => {
-        serviceLocator.eventManager.emit('progress', { name: 'DeletingNode', progress: 0.0 });
+        serviceLocator.eventManager.emit('progress', { name: 'DeletingNodes', progress: 0.0 });
         const selectedNodes = serviceLocator.selectedObjectsManager.get('selectedNodes');
 
-        Promise.all(
-            selectedNodes.map((node: Node) => {
-                return node.delete(serviceLocator.socketEventManager);
+        deleteUnusedNodes(selectedNodes.map((n) => n.getId()))
+            .then((response) => {
+                serviceLocator.selectedObjectsManager.deselect('node');
+                serviceLocator.collectionManager.refresh('nodes');
+                serviceLocator.eventManager.emit('map.updateLayers', {
+                    transitNodes: serviceLocator.collectionManager.get('nodes').toGeojson(),
+                    transitNodesSelected: turfFeatureCollection([])
+                });
             })
-        ).then((response) => {
-            serviceLocator.selectedObjectsManager.deselect('node');
-            serviceLocator.collectionManager.refresh('nodes');
-            serviceLocator.eventManager.emit('map.updateLayers', {
-                transitNodes: serviceLocator.collectionManager.get('nodes').toGeojson(),
-                transitNodesSelected: turfFeatureCollection([])
+            .catch((error) => {
+                // TODO Log errors
+                console.log('Error deleting unused nodes', error);
+            })
+            .finally(() => {
+                this.deleteSelectedPolygon();
+                serviceLocator.eventManager.emit('progress', { name: 'DeletingNodes', progress: 1.0 });
             });
-        });
-        this.deleteSelectedPolygon();
-        serviceLocator.eventManager.emit('progress', { name: 'DeletingNode', progress: 1.0 });
     };
 
     handleDrawControl = (section: string) => {

--- a/packages/transition-frontend/src/services/transitNodes/__tests__/transitNodesUtils.test.ts
+++ b/packages/transition-frontend/src/services/transitNodes/__tests__/transitNodesUtils.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import { TransitApi } from 'transition-common/lib/api/transit';
+import { deleteUnusedNodes } from '../transitNodesUtils';
+
+const socketMock = new EventEmitter();
+let responseStatus: Status.Status<string[]> | undefined = undefined;
+const deleteUnusedSocketMock = jest.fn().mockImplementation((nodeIds, callback) => callback(responseStatus));
+
+socketMock.on(TransitApi.DELETE_UNUSED_NODES, deleteUnusedSocketMock);
+serviceLocator.addService('socketEventManager', socketMock);
+serviceLocator.addService('collectionManager', {
+    get: () => ({
+        loadFromServer: jest.fn()
+    })
+})
+
+describe('deleteUnusedNodes', () => {
+    const nodeId1 = 'arbitrary uuid';
+
+    beforeEach(() => {
+        deleteUnusedSocketMock.mockClear();
+    })
+
+    test('Delete some unused', async () => {
+        responseStatus = Status.createOk([nodeId1]);
+        const nodeIds = await deleteUnusedNodes([nodeId1]);
+        expect(nodeIds).toEqual([nodeId1]);
+        expect(deleteUnusedSocketMock).toHaveBeenCalledWith([nodeId1], expect.anything());
+    });
+
+    test('Delete all unused', async () => {
+        responseStatus = Status.createOk([nodeId1]);
+        const nodeIds = await deleteUnusedNodes([nodeId1]);
+        expect(nodeIds).toEqual([nodeId1]);
+        expect(deleteUnusedSocketMock).toHaveBeenCalledWith([nodeId1], expect.anything());
+    });
+
+    test('Delete some unused, with error', async () => {
+        responseStatus = Status.createError('error on socket');
+        let err: any = undefined;
+        try {
+            await deleteUnusedNodes([nodeId1])
+        } catch(error) {
+            err = error;
+        }
+        expect(err).toEqual('Error deleting unused nodes');
+        expect(deleteUnusedSocketMock).toHaveBeenCalledWith([nodeId1], expect.anything());
+    });
+});
+

--- a/packages/transition-frontend/src/services/transitNodes/transitNodesUtils.ts
+++ b/packages/transition-frontend/src/services/transitNodes/transitNodesUtils.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import { TransitApi } from 'transition-common/lib/api/transit';
+
+export const deleteUnusedNodes = async (nodeIds?: string[] | null): Promise<string[]> => {
+    return new Promise((resolve, reject) => {
+        serviceLocator.socketEventManager.emit(
+            TransitApi.DELETE_UNUSED_NODES,
+            nodeIds,
+            async (responseStatus: Status.Status<string[]>) => {
+                if (Status.isStatusOk(responseStatus)) {
+                    await serviceLocator.collectionManager
+                        .get('nodes')
+                        .loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager);
+                    resolve(Status.unwrap(responseStatus));
+                } else {
+                    reject('Error deleting unused nodes');
+                }
+            }
+        );
+    });
+};


### PR DESCRIPTION
fixes #808 

* Add a socket route to delete unused routes, either all or with node ids
* Add a button on the transit node panel to delete all unused nodes, with a confirmation dialog
* Update the current deletion on selection code to use the same function as the delete all nodes.