### PR TITLE
osrm: Use the host even for local servers

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
@@ -81,7 +81,8 @@ const configureAllOsrmServers = async function (startServers = true): Promise<vo
             // Only configure mode that are enabled
             if (modeConfig.enabled === true) {
                 const port = modeConfig.port;
-                let host = '';
+                // Use the host in the config even for local server starts as it allows to fine-tune the url to contact (for example ipv4 vs ipv6 names)
+                const host = modeConfig.host !== null ? modeConfig.host : '';
 
                 if (port === null || port === undefined || port <= 0) {
                     errorConfiguringMode(routingMode, 'Invalid port number');
@@ -103,7 +104,6 @@ const configureAllOsrmServers = async function (startServers = true): Promise<vo
                     }
                 } else {
                     console.log('Using external OSRM for mode ' + routingMode);
-                    host = modeConfig.host !== null ? modeConfig.host : '';
                 }
 
                 // Register OSRMMode object


### PR DESCRIPTION
fixes #821

This uses the value set in the mode config's host field even for local servers. This allows to specify a specific URL on which to join the server, for example an ipv4 url where 'localhost' would have resolved to an ipv6 url, or simply a named URL for the local server.