### PR TITLE
routing: Take colors from the preferences instead of previous attributes

### DIFF
--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
@@ -96,6 +96,7 @@ const getAttributesOrDefault = (routing: TransitAccessibilityMapRouting) => {
         walkingSpeedFactor: attributes.walkingSpeedFactor,
         scenarioId: attributes.scenarioId,
         locationColor: attributes.locationColor,
+        color: attributes.color,
         placeName: attributes.placeName
     };
 };
@@ -319,6 +320,7 @@ export class TransitAccessibilityMapCalculator {
             maxAccessEgressTravelTimeSeconds: number;
             locationGeojson: Feature<Point>;
             locationColor?: string;
+            color?: string;
             [key: string]: any;
         },
         result: TransitAccessibilityMapResultByNode,
@@ -412,7 +414,7 @@ export class TransitAccessibilityMapCalculator {
                 areaSqM: area,
                 areaSqKm: area / 1000000,
                 areaSqMiles: area / 1000000 / 2.58999,
-                color: attributes.locationColor,
+                color: attributes.color,
                 accessiblePlacesCountByCategory,
                 accessiblePlacesCountByDetailedCategory,
                 ...attributes,

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
@@ -36,6 +36,11 @@ export type AccessibilityMapAttributes = AccessibilityMapCalculationAttributes &
 class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapAttributes> {
     constructor(attributes: Partial<AccessibilityMapAttributes>, isNew = false) {
         super(attributes, isNew);
+
+        // Initialize the colors to the preference.
+        // FIXME Allow to set the color from the UI as well
+        this.attributes.locationColor = Preferences.get('transit.routing.transitAccessibilityMap.locationColor');
+        this.attributes.color = Preferences.get('transit.routing.transitAccessibilityMap.polygonColor');
     }
 
     validate() {

--- a/packages/transition-common/src/services/transitRouting/TransitRouting.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRouting.ts
@@ -50,6 +50,11 @@ export type TransitRoutingAttributes = TransitRoutingSingleCalcAttributes & Tran
 const MAX_BATCH_ELEMENTS = 100;
 
 const prepareTransitAttributes = (attributes: Partial<TransitRoutingAttributes>): Partial<TransitRoutingAttributes> => {
+    // Initialize the colors to the preference.
+    // FIXME Allow to set the color from the UI as well
+    attributes.originLocationColor = Preferences.get('transit.routing.transit.originLocationColor');
+    attributes.destinationLocationColor = Preferences.get('transit.routing.transit.destinationLocationColor');
+
     if (!attributes.savedForBatch) {
         attributes.savedForBatch = [];
     }


### PR DESCRIPTION
Fixes #823

For both transit routing and accessibility map, always use the color from the user preferences instead of previous attributes. This allows to update the colors when the preferences are set. Eventually, we may want to be able to change those colors for each calculation from the interface.