### PR TITLE
Remove timeout for downloading OSM data from Overpass

### DIFF
--- a/packages/chaire-lib-common/src/config/osm/overpassQueries/networksPolyForOsrm.ts
+++ b/packages/chaire-lib-common/src/config/osm/overpassQueries/networksPolyForOsrm.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-export default `<osm-script output="OUTPUT" output-config="" timeout="200">
+export default `<osm-script output="OUTPUT" output-config="" timeout="1800">
     <union into="_">
         <query into="_" type="way">
             <has-kv k="highway" modv="" v=""/>


### PR DESCRIPTION
We might want to download large data set. Setting an arbitrary timeout prohibit this.