### PR TITLE
path: add tests and documentation for node/waypoint operations

### DIFF
--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -281,7 +281,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
         serviceLocator.eventManager.emit('selected.updateLayers.path');
     };
 
-    onUpdateWaypoint = (coordinates: [number, number], waypointType = null) => {
+    onUpdateWaypoint = (coordinates: [number, number], waypointType?: string) => {
         (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
             layerName: 'transitPathWaypointsSelected',
             data: turfFeatureCollection([])

--- a/packages/transition-frontend/src/services/map/events/PathSectionMapEvents.ts
+++ b/packages/transition-frontend/src/services/map/events/PathSectionMapEvents.ts
@@ -189,7 +189,7 @@ const onPathSectionMapClick = async (e: MapboxGL.MapMouseEvent) => {
                     e.lngLat.toArray() as [number, number],
                     waypointType,
                     lastNodeIndex,
-                    null
+                    undefined
                 );
             }
 


### PR DESCRIPTION
fixes #835

This adds exhaustive unit tests for the waypoints insert/update/delete and nodes insert/delete operations. It also adds some check of indexes before doing the operation.

After these addition, the coverage of the Path.ts file increased as follows:

% Stmts: 27.16    --> 58.6
% Branch: 34.75  --> 49.7
% Funcs: 33.77    --> 49.33
% Lines: 27.08     --> 58.94