### PR TITLE
schedules: get associated paths from trips

### DIFF
--- a/packages/transition-common/src/services/schedules/Schedule.ts
+++ b/packages/transition-common/src/services/schedules/Schedule.ts
@@ -155,22 +155,15 @@ class Schedule extends ObjectWithHistory<ScheduleAttributes> implements Saveable
     }
 
     getAssociatedPathIds() {
-        const associatedPathIds: string[] = [];
+        const associatedPathIds: { [pathId: string]: boolean } = {};
 
         const periods = this.getAttributes().periods;
         for (let i = 0, countI = periods.length; i < countI; i++) {
             const period = periods[i];
-            const outboundPathId = period.outbound_path_id;
-            if (outboundPathId) {
-                associatedPathIds.push(outboundPathId);
-            }
-            const inboundPathId = period.inbound_path_id;
-            if (inboundPathId) {
-                associatedPathIds.push(inboundPathId);
-            }
+            period.trips.forEach((trip) => (associatedPathIds[trip.path_id] = true));
         }
 
-        return associatedPathIds;
+        return Object.keys(associatedPathIds);
     }
 
     getPeriod(periodShortname: string) {

--- a/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
+++ b/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
@@ -91,3 +91,43 @@ test('Delete schedule', async () => {
     expect(eventManager.emit).toHaveBeenCalledWith('transitSchedule.delete', schedule.getId(), undefined, expect.anything());
     expect(schedule.isDeleted()).toBe(true);
 });
+
+describe('getAssociatedPathIds', () => {
+
+    test('No periods', () => {
+        const testAttributes = _cloneDeep(scheduleAttributes);
+        testAttributes.periods = [];
+        const schedule = new Schedule(testAttributes, true);
+        expect(schedule.getAssociatedPathIds()).toEqual([]);
+    });
+
+    test('Periods with no trips', () => {
+        const testAttributes = _cloneDeep(scheduleAttributes);
+        testAttributes.periods.forEach(period => {
+            period.trips = [];
+        })
+        const schedule = new Schedule(testAttributes, true);
+        expect(schedule.getAssociatedPathIds()).toEqual([]);
+    });
+
+    test('Multiple trips with single paths', () => {
+        const schedule = new Schedule(scheduleAttributes, true);
+        expect(schedule.getAssociatedPathIds()).toEqual([pathId]);
+    });
+
+    test('Multiple trips with multiple paths', () => {
+        const otherPathId = uuidV4();
+        const testAttributes = _cloneDeep(scheduleAttributes);
+        // Change the first trip of each period to the other path id
+        testAttributes.periods.forEach(period => {
+            if (period.trips.length > 0) {
+                period.trips[0].path_id = otherPathId;
+            }
+        })
+        const schedule = new Schedule(testAttributes, true);
+        const pathIds = schedule.getAssociatedPathIds()
+        expect(pathIds).toContain(otherPathId);
+        expect(pathIds).toContain(pathId);
+    });
+
+});


### PR DESCRIPTION
fixes #846

The period's inbound and outbound path ids are used by Transition to generate periodic schedules, but paths imported from GTFS do not have those fields. It is the trips which really contain the paths used by the schedule.