### PR TITLE
schedules: Add unit tests for schedule generation

### DIFF
--- a/packages/transition-common/src/services/path/__tests__/PathData.test.ts
+++ b/packages/transition-common/src/services/path/__tests__/PathData.test.ts
@@ -112,8 +112,8 @@ const pathAttributesFromTransition = {
     is_enabled: true,
     data: {
         segments:[
-            { distanceMeters:510, travelTimeSeconds:119 },
-            { distanceMeters:515, travelTimeSeconds:89 },
+            { distanceMeters: 510, travelTimeSeconds: 120 },
+            { distanceMeters: 515, travelTimeSeconds: 90 },
             { distanceMeters: 444, travelTimeSeconds: 85 }
         ],
         from_gtfs: false,
@@ -226,6 +226,8 @@ export const getPathObject = ({
         getPathAttributesWithData(true, { lineId }) :
         pathType === 'gtfs' ? _cloneDeep(pathAttributesFromGtfs) : _cloneDeep(pathAttributesFromTransition);
     attributes.line_id = lineId;
+    // Make sure to generate paths with different IDs each time
+    attributes.id = uuidV4();
     const path = new Path(attributes, true);
     pathCollection.add(path);
     return path;

--- a/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
+++ b/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
@@ -10,14 +10,14 @@ import _omit from 'lodash/omit';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import EventManagerMock from 'chaire-lib-common/lib/test/services/events/EventManagerMock';
-import Schedule from '../Schedule';
+import Schedule, { SchedulePeriod } from '../Schedule';
 import { getScheduleAttributes } from './ScheduleData.test';
 import { getPathObject } from '../../path/__tests__/PathData.test';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
 import LineCollection from '../../line/LineCollection';
 import PathCollection from '../../path/PathCollection';
 import Line from '../../line/Line';
-import { timeStrToSecondsSinceMidnight } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import { minutesToSeconds, timeStrToSecondsSinceMidnight } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 
 const eventManager = EventManagerMock.eventManagerMock;
 
@@ -185,12 +185,12 @@ describe('updateForAllPeriods', () => {
         }
     });
 
-    test('Periods with individual trips, no outbound/inboud/frequencies/units', () => {
+    test('Periods with individual trips, no outbound/inbound/frequencies/units', () => {
         // Reset paths, intervals and units
         const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
         testAttributes.periods.forEach(period => {
             (period as any).outbound_path_id = null;
-            period.inbound_path_id = null;
+            (period as any).inbound_path_id = null;
             period.interval_seconds = undefined;
             period.number_of_units = undefined;
         });
@@ -224,4 +224,284 @@ describe('updateForAllPeriods', () => {
             expect(period.trips.length).toEqual(Math.ceil((periodEnd - periodStart)/ interval));
         }
     });
+});
+
+describe('generateForPeriod', () => {
+    // Prepare collection manager and path objects
+    const collectionManager = new CollectionManager(null);
+    const pathCollection = new PathCollection([], {});
+    // Use same path for outbound and inbound, geography is not important for schedules
+    const path = getPathObject({ lineId, pathCollection }, 'smallReal');
+    const returnPath = getPathObject({ lineId, pathCollection }, 'smallReal');
+    returnPath.attributes.direction = 'inbound';
+
+    const lineCollection = new LineCollection([new Line({ id: lineId, path_ids: [path.getId(), returnPath.getId()] }, false)], {});
+    collectionManager.add('lines', lineCollection);
+    collectionManager.add('paths', pathCollection);
+    const scheduleAttributesForUpdate = getScheduleAttributes({ lineId, serviceId, pathId: path.getId() });
+    // Use 2 small periods by default for those tests
+    const smallPeriodsForUpdate: SchedulePeriod[] = [{
+        // Period with start and end hours and multiple trips
+        id: uuidV4(),
+        schedule_id: scheduleAttributesForUpdate.id,
+        inbound_path_id: undefined,
+        outbound_path_id: path.getId(),       
+        period_shortname: "period1",
+        start_at_hour: 10,
+        end_at_hour: 12,
+        data:{},
+        trips: []
+    }, {
+        id: uuidV4(),
+        schedule_id: scheduleAttributesForUpdate.id,
+        inbound_path_id: undefined,
+        outbound_path_id: path.getId(),
+        period_shortname: "period2",
+        start_at_hour: 12,
+        end_at_hour: 14,
+        data: {},
+        trips: []
+    }]
+    
+    test('Update frequency based period, one direction', () => {
+        // Use a 15-minute frequency
+        const testFrequencyMinutes = 15;
+        const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+        const testPeriods = _cloneDeep(smallPeriodsForUpdate);
+        testPeriods[0].interval_seconds = minutesToSeconds(testFrequencyMinutes) as number;
+        testAttributes.periods = testPeriods;
+        const schedule = new Schedule(testAttributes, true, collectionManager);
+        const { trips } = schedule.generateForPeriod(testPeriods[0].period_shortname as string);
+
+        // Expected values
+        const expectedTripCnt = 8;
+        const expectedFirstDeparture = timeStrToSecondsSinceMidnight('10:00') as number;
+        const dwellTimes = path.getAttributes().data.dwellTimeSeconds as number[];
+        const expectedPathDuration = (path.attributes.data.segments as any[]).reduce((total, current) => total + current.travelTimeSeconds, 0) + dwellTimes.reduce((total, current) => total + current, 0) - dwellTimes[dwellTimes.length - 1];
+
+        // Validate return value, and 0.6 vehicle
+        const scheduledTrips = schedule.attributes.periods[0].trips;
+        expect(scheduledTrips).toEqual(trips);
+        expect(schedule.attributes.periods[0].calculated_number_of_units).toEqual(0.6);
+
+        // Validate actual trip content
+        expect(scheduledTrips.length).toEqual(expectedTripCnt);
+        for (let i = 0; i < expectedTripCnt; i++) {
+            const currentTrip = scheduledTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(expectedFirstDeparture + i * (minutesToSeconds(testFrequencyMinutes) as number))
+            expect(currentTrip.path_id).toEqual(path.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(expectedPathDuration + expectedFirstDeparture + i * (minutesToSeconds(testFrequencyMinutes) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+    });
+
+    test('Update frequency based period, 2 directions', () => {
+        // Use a 15-minute frequency
+        const testFrequencyMinutes = 15;
+        const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+        const testPeriods = _cloneDeep(smallPeriodsForUpdate);
+        testPeriods[0].interval_seconds = minutesToSeconds(testFrequencyMinutes) as number;
+        testPeriods[0].inbound_path_id = returnPath.getId();
+        testAttributes.periods = testPeriods;
+        const schedule = new Schedule(testAttributes, true, collectionManager);
+        const { trips } = schedule.generateForPeriod(testPeriods[0].period_shortname as string);
+
+        // Expected values
+        const expectedTripCntPerDirection = 8;
+        const expectedFirstDeparture = timeStrToSecondsSinceMidnight('10:00') as number;
+        const dwellTimes = path.getAttributes().data.dwellTimeSeconds as number[];
+        const expectedPathDuration = (path.attributes.data.segments as any[]).reduce((total, current) => total + current.travelTimeSeconds, 0) + dwellTimes.reduce((total, current) => total + current, 0) - dwellTimes[dwellTimes.length - 1];
+
+        // Validate return value and 1.2 vehicles
+        const scheduledTrips = schedule.attributes.periods[0].trips;
+        expect(scheduledTrips).toEqual(trips);
+        expect(schedule.attributes.periods[0].calculated_number_of_units).toEqual(1.2);
+
+        // Validate outbound trips
+        const outboundTrips = scheduledTrips.filter(trip => trip.path_id === path.getId());
+        // Validate actual trip content
+        expect(outboundTrips.length).toEqual(expectedTripCntPerDirection);
+        for (let i = 0; i < expectedTripCntPerDirection; i++) {
+            const currentTrip = outboundTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(expectedFirstDeparture + i * (minutesToSeconds(testFrequencyMinutes) as number))
+            expect(currentTrip.path_id).toEqual(path.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(expectedPathDuration + expectedFirstDeparture + i * (minutesToSeconds(testFrequencyMinutes) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+
+        // Validate inbound trips, there's one more trip, starting at start time for the second unit
+        const inboundTrips = scheduledTrips.filter(trip => trip.path_id === returnPath.getId());
+        expect(inboundTrips.length).toEqual(expectedTripCntPerDirection + 1);
+        const returnTripOffset = path.attributes.data.operatingTimeWithLayoverTimeSeconds as number;
+        // FIXME Because of issue #854, we can't use this loop for the first trip
+        for (let i = 1; i < expectedTripCntPerDirection; i++) {
+            const currentTrip = inboundTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(returnTripOffset + expectedFirstDeparture + (i - 1) * (minutesToSeconds(testFrequencyMinutes) as number))
+            expect(currentTrip.path_id).toEqual(returnPath.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(returnTripOffset + expectedPathDuration + expectedFirstDeparture + (i - 1) * (minutesToSeconds(testFrequencyMinutes) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+            // FIXME Issue #854 frequency is too high for first trips, but the next line should be uncommented
+            // expect(currentTrip.departure_time_seconds - inboundTrips[i - 1].departure_time_seconds).toEqual(minutesToSeconds(testFrequencyMinutes));
+        }
+    });
+
+    test('Update unexisting period', () => {
+        // Use a 15-minute frequency
+        const testFrequencyMinutes = 15;
+        const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+        const testPeriods = _cloneDeep(smallPeriodsForUpdate);
+        testPeriods[0].interval_seconds = minutesToSeconds(testFrequencyMinutes) as number;
+        testAttributes.periods = testPeriods;
+        const schedule = new Schedule(testAttributes, true, collectionManager);
+        const { trips } = schedule.generateForPeriod('not a period');
+        expect(trips).toEqual([]);
+    });
+
+    test('Update unit based period, 2 directions', () => {
+        // Use 2 units. Paths are perfectly symetric so travel time with layover is the frequency
+        const testNumberOfUnits = 2;
+        const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+        const testPeriods = _cloneDeep(smallPeriodsForUpdate);
+        testPeriods[0].number_of_units = testNumberOfUnits;
+        testPeriods[0].inbound_path_id = returnPath.getId();
+        testAttributes.periods = testPeriods;
+        const schedule = new Schedule(testAttributes, true, collectionManager);
+        const { trips } = schedule.generateForPeriod(testPeriods[0].period_shortname as string);
+
+        // Expected values
+        const expectedFirstDeparture = timeStrToSecondsSinceMidnight('10:00') as number;
+        const dwellTimes = path.getAttributes().data.dwellTimeSeconds as number[];
+        const expectedPathDuration = (path.attributes.data.segments as any[]).reduce((total, current) => total + current.travelTimeSeconds, 0) + dwellTimes.reduce((total, current) => total + current, 0) - dwellTimes[dwellTimes.length - 1];
+        const expectedFrequency = path.attributes.data.operatingTimeWithLayoverTimeSeconds as number;
+        const expectedTripCntPerDirection = Math.ceil(2 * 3600 / expectedFrequency);
+
+        // Validate return value
+        const scheduledTrips = schedule.attributes.periods[0].trips;
+        expect(scheduledTrips).toEqual(trips);
+        expect(schedule.attributes.periods[0].calculated_interval_seconds).toEqual(expectedFrequency);
+
+        // Validate outbound trips
+        const outboundTrips = scheduledTrips.filter(trip => trip.path_id === path.getId());
+        // Validate actual trip content
+        expect(outboundTrips.length).toEqual(expectedTripCntPerDirection);
+        for (let i = 0; i < expectedTripCntPerDirection; i++) {
+            const currentTrip = outboundTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(expectedFirstDeparture + i * expectedFrequency)
+            expect(currentTrip.path_id).toEqual(path.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(expectedPathDuration + expectedFirstDeparture + i * expectedFrequency)
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+
+        // Validate inbound trips
+        const inboundTrips = scheduledTrips.filter(trip => trip.path_id === returnPath.getId());
+        expect(inboundTrips.length).toEqual(expectedTripCntPerDirection);
+        for (let i = 0; i < expectedTripCntPerDirection; i++) {
+            const currentTrip = inboundTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(expectedFirstDeparture + i * expectedFrequency)
+            expect(currentTrip.path_id).toEqual(returnPath.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(expectedPathDuration + expectedFirstDeparture + i * expectedFrequency)
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+    });
+
+    test('Update frequency based, 2 directions, 2 periods', () => {
+        // Use a 15-minute frequency
+        const testFrequencyMinutesPeriod1 = 14;
+        const testFrequencyMinutesPeriod2 = 20;
+        const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+        const testPeriods = _cloneDeep(smallPeriodsForUpdate);
+        testPeriods[0].interval_seconds = minutesToSeconds(testFrequencyMinutesPeriod1) as number;
+        testPeriods[0].inbound_path_id = returnPath.getId();
+        testPeriods[1].interval_seconds = minutesToSeconds(testFrequencyMinutesPeriod2) as number;
+        testPeriods[1].inbound_path_id = returnPath.getId();
+        testAttributes.periods = testPeriods;
+        const schedule = new Schedule(testAttributes, true, collectionManager);
+
+        //********** Test for first period */
+        const { trips } = schedule.generateForPeriod(testPeriods[0].period_shortname as string);
+
+        // Expected values
+        const expectedTripCntPerDirection = 9;
+        const expectedFirstDeparture = timeStrToSecondsSinceMidnight('10:00') as number;
+        const dwellTimes = path.getAttributes().data.dwellTimeSeconds as number[];
+        const expectedPathDuration = (path.attributes.data.segments as any[]).reduce((total, current) => total + current.travelTimeSeconds, 0) + dwellTimes.reduce((total, current) => total + current, 0) - dwellTimes[dwellTimes.length - 1];
+
+        // Validate return value and 1.2 vehicles
+        const scheduledTrips = schedule.attributes.periods[0].trips;
+        expect(scheduledTrips).toEqual(trips);
+        expect(schedule.attributes.periods[0].calculated_number_of_units).toEqual(((path.attributes.data.operatingTimeWithLayoverTimeSeconds as number) + (returnPath.attributes.data.operatingTimeWithLayoverTimeSeconds as number)) / (testFrequencyMinutesPeriod1 * 60));
+
+        // Validate outbound trips
+        const outboundTrips = scheduledTrips.filter(trip => trip.path_id === path.getId());
+        // Validate actual trip content
+        expect(outboundTrips.length).toEqual(expectedTripCntPerDirection);
+        for (let i = 0; i < expectedTripCntPerDirection; i++) {
+            const currentTrip = outboundTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(expectedFirstDeparture + i * (minutesToSeconds(testFrequencyMinutesPeriod1) as number))
+            expect(currentTrip.path_id).toEqual(path.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(expectedPathDuration + expectedFirstDeparture + i * (minutesToSeconds(testFrequencyMinutesPeriod1) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+
+        // Validate inbound trips
+        const inboundTrips = scheduledTrips.filter(trip => trip.path_id === returnPath.getId());
+        expect(inboundTrips.length).toEqual(expectedTripCntPerDirection);
+        const returnTripOffset = path.attributes.data.operatingTimeWithLayoverTimeSeconds as number;
+        for (let i = 1; i < expectedTripCntPerDirection; i++) {
+            const currentTrip = inboundTrips[i];
+            expect(currentTrip.departure_time_seconds).toEqual(returnTripOffset + expectedFirstDeparture + (i - 1) * (minutesToSeconds(testFrequencyMinutesPeriod1) as number))
+            expect(currentTrip.path_id).toEqual(returnPath.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(returnTripOffset + expectedPathDuration + expectedFirstDeparture + (i - 1) * (minutesToSeconds(testFrequencyMinutesPeriod1) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+
+        //********** Test for second period */
+        // FIXME Issue #681: First trip of period 1 is too close to the last of period 0
+        const { trips: tripsPeriod2 } = schedule.generateForPeriod(testPeriods[1].period_shortname as string);
+
+        // Expected values
+        const expectedTripCntPerDirection2 = 6;
+        const expectedFirstDeparture2 = timeStrToSecondsSinceMidnight('12:00') as number;
+        const expectedPathDuration2 = (path.attributes.data.segments as any[]).reduce((total, current) => total + current.travelTimeSeconds, 0) + dwellTimes.reduce((total, current) => total + current, 0) - dwellTimes[dwellTimes.length - 1];
+
+        // Validate return value and 1.2 vehicles
+        const scheduledTripsPeriod2 = schedule.attributes.periods[1].trips;
+        expect(scheduledTripsPeriod2).toEqual(tripsPeriod2);
+        expect(schedule.attributes.periods[1].calculated_number_of_units).toEqual(((path.attributes.data.operatingTimeWithLayoverTimeSeconds as number) + (returnPath.attributes.data.operatingTimeWithLayoverTimeSeconds as number)) / (testFrequencyMinutesPeriod2 * 60));
+
+        // Validate outbound trips
+        const outboundTrips2 = scheduledTripsPeriod2.filter(trip => trip.path_id === path.getId());
+        // Validate actual trip content
+        expect(outboundTrips2.length).toEqual(expectedTripCntPerDirection2);
+        for (let i = 0; i < expectedTripCntPerDirection2; i++) {
+            const currentTrip = outboundTrips2[i];
+            expect(currentTrip.departure_time_seconds).toEqual(expectedFirstDeparture2 + i * (minutesToSeconds(testFrequencyMinutesPeriod2) as number))
+            expect(currentTrip.path_id).toEqual(path.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(expectedPathDuration2 + expectedFirstDeparture2 + i * (minutesToSeconds(testFrequencyMinutesPeriod2) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+
+        // Validate inbound trips, there's one more trip, starting at start time for the second unit
+        const inboundTrips2 = scheduledTripsPeriod2.filter(trip => trip.path_id === returnPath.getId());
+        expect(inboundTrips2.length).toEqual(expectedTripCntPerDirection2);
+        const returnTripOffset2 = path.attributes.data.operatingTimeWithLayoverTimeSeconds as number;
+        for (let i = 0; i < expectedTripCntPerDirection2; i++) {
+            const currentTrip = inboundTrips2[i];
+            expect(currentTrip.departure_time_seconds).toEqual(returnTripOffset2 + expectedFirstDeparture2 + i * (minutesToSeconds(testFrequencyMinutesPeriod2) as number))
+            expect(currentTrip.path_id).toEqual(returnPath.getId());
+            expect(currentTrip.arrival_time_seconds).toEqual(returnTripOffset2 + expectedPathDuration2 + expectedFirstDeparture2 + i * (minutesToSeconds(testFrequencyMinutesPeriod2) as number))
+            expect(currentTrip.node_departure_times_seconds.length).toEqual(path.attributes.nodes.length);
+            expect(currentTrip.node_arrival_times_seconds.length).toEqual(path.attributes.nodes.length);
+        }
+    });
+
+
 });

--- a/packages/transition-common/src/services/schedules/__tests__/ScheduleData.test.ts
+++ b/packages/transition-common/src/services/schedules/__tests__/ScheduleData.test.ts
@@ -6,6 +6,7 @@
  */
 import { v4 as uuidV4 } from 'uuid';
 import _cloneDeep from 'lodash/cloneDeep';
+import { ScheduleAttributes } from '../Schedule';
 
 const defaultLineId = uuidV4();
 const defaultServiceId = uuidV4();
@@ -13,7 +14,8 @@ const defaultPathId = uuidV4();
 const defaultScheduleId = uuidV4();
 const periodIds = [uuidV4(), uuidV4(), uuidV4()];
 
-export const getScheduleAttributes = ({
+// FIXME: departure/arrival times need to be set to number[] even if they have null. Make sure ScheduleAttributes have the proper types or review how times are used.
+export const getScheduleAttributes: (params: any) => ScheduleAttributes = ({
     lineId = defaultLineId,
     serviceId = defaultServiceId,
     pathId = defaultPathId,
@@ -31,21 +33,23 @@ export const getScheduleAttributes = ({
             // Period with start and end hours and multiple trips
             id: periodIds[0],
             schedule_id: scheduleId,
-            inbound_path_id: null,
+            inbound_path_id: undefined,
             outbound_path_id: pathId,
             interval_seconds: 1800,        
             period_shortname: "morning",
             start_at_hour: 7,
             end_at_hour: 12,
+            data: {},
             trips: [{
                 id: uuidV4(),
                 schedule_id: scheduleId,
                 schedule_period_id: periodIds[0],
+                data: {},
                 path_id: pathId,
                 departure_time_seconds: 25200,
                 arrival_time_seconds: 27015,
-                node_arrival_times_seconds: [null, 25251, 26250, 27015],
-                node_departure_times_seconds: [25200, 25261, 26260, null],
+                node_arrival_times_seconds: [null, 25251, 26250, 27015] as number[],
+                node_departure_times_seconds: [25200, 25261, 26260, null] as number[],
                 nodes_can_board: [true, true, true, false],
                 nodes_can_unboard: [false, true, true, true],
                 seated_capacity: 20,
@@ -54,11 +58,12 @@ export const getScheduleAttributes = ({
                 id: uuidV4(),
                 schedule_id: scheduleId,
                 schedule_period_id: periodIds[0],
+                data: {},
                 path_id: pathId,
                 departure_time_seconds: 30601,
                 arrival_time_seconds: 32416,
-                node_arrival_times_seconds: [null, 30652, 31650, 32416],
-                node_departure_times_seconds: [30601, 30662, 31660, null],
+                node_arrival_times_seconds: [null, 30652, 31650, 32416] as number[],
+                node_departure_times_seconds: [30601, 30662, 31660, null] as number[],
                 nodes_can_board: [true, true, true, false],
                 nodes_can_unboard: [false, true, true, true],
                 seated_capacity: 20,
@@ -67,11 +72,12 @@ export const getScheduleAttributes = ({
                 id: uuidV4(),
                 schedule_id: scheduleId,
                 schedule_period_id: periodIds[0],
+                data: {},
                 path_id: pathId,
                 arrival_time_seconds: 34216,
                 departure_time_seconds: 32401,
-                node_arrival_times_seconds: [null, 32452, 33450, 34216],
-                node_departure_times_seconds: [32401, 32462, 33460, null],
+                node_arrival_times_seconds: [null, 32452, 33450, 34216] as number[],
+                node_departure_times_seconds: [32401, 32462, 33460, null] as number[],
                 nodes_can_board: [true, true, true, false],
                 nodes_can_unboard: [false, true, true, true],
                 seated_capacity: 20,
@@ -84,20 +90,22 @@ export const getScheduleAttributes = ({
             custom_start_at_str: "13:15",
             custom_end_at_str: "17:24",
             end_at_hour: 18,
-            inbound_path_id: null,
+            inbound_path_id: undefined,
             number_of_units: 4,
             outbound_path_id: pathId,
             period_shortname: "midday",
             start_at_hour: 13,
+            data: {},
             trips: [{
                 id: uuidV4(),
                 schedule_id: scheduleId,
                 schedule_period_id: periodIds[1],
+                data: {},
                 path_id: pathId,
                 arrival_time_seconds: 50000,
                 departure_time_seconds: 48000,
-                node_arrival_times_seconds: [null, 48050, 49450, 50000],
-                node_departure_times_seconds: [48000, 48060, 49460, null],
+                node_arrival_times_seconds: [null, 48050, 49450, 50000] as number[],
+                node_departure_times_seconds: [48000, 48060, 49460, null] as number[],
                 nodes_can_board: [true, true, true, false],
                 nodes_can_unboard: [false, true, true, true],
                 seated_capacity: 20,
@@ -107,10 +115,11 @@ export const getScheduleAttributes = ({
             // Period with custom start and end, without trips
             id: periodIds[2],
             schedule_id: scheduleId,
+            data: {},
             custom_start_at_str: '18:00',
             custom_end_at_str: '23:00',
             end_at_hour: 23,
-            inbound_path_id: null,
+            inbound_path_id: undefined,
             interval_seconds: 1800,
             outbound_path_id: pathId,
             period_shortname: "pm_peaks",


### PR DESCRIPTION
fixes #844

Add tests for the `generateForPeriod` method with various use cases, with multiple directions/periods. These tests test the actual trip data, not just their numbers.

Make private some methods of the Schedule class. They don't need to be accessible from outside the class.