### PR TITLE
gtfs: Always use custom times when inferring frequencies

### DIFF
--- a/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
@@ -374,16 +374,10 @@ const getPeriodDataForDirection = (trips: TripAndStopTimes[], period: SchedulePe
     const customPeriodEndSeconds = trips[trips.length - 1].stopTimes[0].departureTimeSeconds;
     const frequencySeconds =
         trips.length === 1 ? 60 : (customPeriodEndSeconds - customPeriodStartSeconds) / (trips.length - 1);
-    // Use custom start/end if the interval between start/end of period and actual is higher than frequency
+    // TODO Determine if we should use custom start/end if the interval between start/end of period and actual is higher than frequency, but for now, simply use the observed period
     return {
-        actualStart:
-            customPeriodStartSeconds - (hoursToSeconds(period.start_at_hour) as number) > frequencySeconds
-                ? customPeriodStartSeconds
-                : (hoursToSeconds(period.start_at_hour) as number),
-        actualEnd:
-            (hoursToSeconds(period.end_at_hour) as number) - customPeriodEndSeconds > frequencySeconds
-                ? customPeriodEndSeconds
-                : (hoursToSeconds(period.end_at_hour) as number),
+        actualStart: customPeriodStartSeconds,
+        actualEnd: customPeriodEndSeconds,
         frequencySeconds
     };
 };

--- a/packages/transition-backend/src/services/gtfsImport/__tests__/ScheduleImporter.test.ts
+++ b/packages/transition-backend/src/services/gtfsImport/__tests__/ScheduleImporter.test.ts
@@ -1076,7 +1076,8 @@ describe('Generate frequency based schedules for line', () => {
             end_at_hour: importData.periodsGroup.periods[0].endAtHour,
             period_shortname: importData.periodsGroup.periods[0].shortname,
             custom_start_at_str: startTimeStr,
-            custom_end_at_str: undefined,
+            // TODO We use custom time, even if the end time is close to period end, given the frequency. Should we?
+            custom_end_at_str: '11:51',
             interval_seconds: 15 * 60,
             outbound_path_id: pathId,
             inbound_path_id: undefined
@@ -1086,6 +1087,8 @@ describe('Generate frequency based schedules for line', () => {
             start_at_hour: importData.periodsGroup.periods[1].startAtHour,
             end_at_hour: importData.periodsGroup.periods[1].endAtHour,
             period_shortname: importData.periodsGroup.periods[1].shortname,
+            // TODO We use custom time, even if the start time is close to period start, given the frequency. Should we?
+            custom_start_at_str: '12:05',
             custom_end_at_str: '18:01',
             interval_seconds: (timeStrToSecondsSinceMidnight('18:00') as number - (timeStrToSecondsSinceMidnight('12:05') as number)) / 2,
             outbound_path_id: pathId,
@@ -1160,7 +1163,8 @@ describe('Generate frequency based schedules for line', () => {
             end_at_hour: importData.periodsGroup.periods[0].endAtHour,
             period_shortname: importData.periodsGroup.periods[0].shortname,
             custom_start_at_str: '9:00',
-            custom_end_at_str: undefined,
+            // TODO We use custom time, even if the end time is close to period end, given the frequency. Should we?
+            custom_end_at_str: '11:31',
             interval_seconds: (timeStrToSecondsSinceMidnight('11:30') as number - (timeStrToSecondsSinceMidnight('9:00') as number)) / 2,
             outbound_path_id: outboundPathId,
             inbound_path_id: undefined


### PR DESCRIPTION
This seems to be currently more intuitive for end users, instead of using the period start/end if the diff between the time and closest trip time is lower than frequency.

Given various issues with schedules (#681, #854, the fact that all trips start at the exact period start, problems inferring frequency with asymetrical trips, to name a few), this sounds like an acceptable compromise.