### PR TITLE
lua: Fix comment character in walking lua profiles

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking.lua
@@ -115,7 +115,7 @@ function setup()
 
     speeds = Sequence {
       highway = {
-        /* These speed are adjusted to penalize less pedestrian-friendly roads like trunk, primary and secondary */
+        -- These speed are adjusted to penalize less pedestrian-friendly roads like trunk, primary and secondary
         trunk           = walking_speed*0.96,
         trunk_link      = walking_speed*0.96,
         primary         = walking_speed*0.97,

--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_no_penalty.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_no_penalty.lua
@@ -115,7 +115,7 @@ function setup()
 
     speeds = Sequence {
       highway = {
-        /* These speed are adjusted to penalize less pedestrian-friendly roads like trunk, primary and secondary */
+        -- These speed are adjusted to penalize less pedestrian-friendly roads like trunk, primary and secondary
         trunk           = walking_speed*0.96,
         trunk_link      = walking_speed*0.96,
         primary         = walking_speed*0.97,

--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_way_data_as_name.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_way_data_as_name.lua
@@ -115,7 +115,7 @@ function setup()
 
     speeds = Sequence {
       highway = {
-        /* These speed are adjusted to penalize less pedestrian-friendly roads like trunk, primary and secondary */
+        -- These speed are adjusted to penalize less pedestrian-friendly roads like trunk, primary and secondary
         trunk           = walking_speed*0.96,
         trunk_link      = walking_speed*0.96,
         primary         = walking_speed*0.97,


### PR DESCRIPTION
Comments in lua start with `--`, this caused errors when reading the profile.