### PR TITLE
users: add a last login time to users

### DIFF
--- a/packages/chaire-lib-backend/src/config/auth/__tests__/localLogin.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/auth/__tests__/localLogin.config.test.ts
@@ -15,7 +15,8 @@ import tokensDbQueries from '../../../models/db/tokens.db.queries';
 
 jest.mock('../../../models/db/users.db.queries', () => ({
     find: jest.fn(),
-    create: jest.fn()
+    create: jest.fn(),
+    setLastLogin: jest.fn()
 }));
 jest.mock('../../../models/db/tokens.db.queries', () => ({
     getUserByToken: jest.fn()
@@ -23,6 +24,7 @@ jest.mock('../../../models/db/tokens.db.queries', () => ({
 const mockFind = usersDbQueries.find as jest.MockedFunction<typeof usersDbQueries.find>;
 const mockCreate = usersDbQueries.create as jest.MockedFunction<typeof usersDbQueries.create>;
 const mockFindToken = tokensDbQueries.getUserByToken as jest.MockedFunction<typeof tokensDbQueries.getUserByToken>
+const mockSetLastLogin = usersDbQueries.setLastLogin as jest.MockedFunction<typeof usersDbQueries.setLastLogin>;
 
 localLogin(passport, userAuthModel);
 
@@ -76,6 +78,7 @@ beforeEach(() => {
         }
     });
     process.env.HOST = url;
+    mockSetLastLogin.mockClear();
 })
 
 test('Local login strategy, valid user', async () => {
@@ -94,6 +97,7 @@ test('Local login strategy, valid user', async () => {
     expect(logInFct).toHaveBeenCalledWith({ id: validUser.id, username: validUser.username, email: undefined, firstName: undefined, lastName: undefined, preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith({ usernameOrEmail: validUsername }, false);
+    expect(mockSetLastLogin).toHaveBeenCalledTimes(1);
 });
 
 test('Local login strategy, invalid password', async () => {
@@ -109,6 +113,7 @@ test('Local login strategy, invalid password', async () => {
     expect(logInFct).not.toHaveBeenCalled();
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith({ usernameOrEmail: validUsername }, false);
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
 });
 
 test('Local login strategy, unknown user', async () => {
@@ -124,6 +129,7 @@ test('Local login strategy, unknown user', async () => {
     expect(logInFct).not.toHaveBeenCalled();
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith({ usernameOrEmail: 'unknown user' }, false);
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
 });
 
 test('Local login strategy, unconfirmed user', async () => {
@@ -149,6 +155,7 @@ test('Local login strategy, unconfirmed user', async () => {
     expect(logInFct).not.toHaveBeenCalled();
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith({ usernameOrEmail: unconfirmedUsername }, false);
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
 });
 
 test('Local login strategy, unconfirmed user, wrong password', async () => {
@@ -172,6 +179,7 @@ test('Local login strategy, unconfirmed user, wrong password', async () => {
     expect(logInFct).not.toHaveBeenCalled();
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith({ usernameOrEmail: unconfirmedUsername }, false);
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
 });
 
 test('Local signup strategy, auto-signon username and email', async () => {
@@ -214,6 +222,7 @@ test('Local signup strategy, auto-signon username and email', async () => {
         confirmation_token: null,
         preferences: null
     });
+    expect(mockSetLastLogin).toHaveBeenCalledTimes(1);
 });
 
 test('Local signup strategy, auto-signon user exists', async () => {
@@ -240,6 +249,7 @@ test('Local signup strategy, auto-signon user exists', async () => {
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith({ username: validUsername, email: newUserEmail }, true);
     expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
 
 });
 
@@ -290,6 +300,7 @@ test('Local signup strategy, with email confirmation by user', async () => {
             strategy: 'confirmByUser',
             confirmUrl: `${url}verify/${insertedUser.confirmation_token}`
         });
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
     
 });
 
@@ -344,6 +355,7 @@ test('Local signup strategy, with email confirmation by admin', async () => {
             strategy: 'confirmByAdmin',
             confirmUrl: `${url}verify/${insertedUser.confirmation_token}`
         });
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
 });
 
 test('Local signup strategy, with email confirmation by admin, urls without ending slash', async () => {

--- a/packages/chaire-lib-backend/src/config/auth/index.ts
+++ b/packages/chaire-lib-backend/src/config/auth/index.ts
@@ -29,9 +29,11 @@ export default <U extends IUserModel>(authModel: IAuthModel<U>): PassportStatic 
                         .then(async (user) => {
                             if (user !== undefined) {
                                 // TODO Should sanitize user, but see if other fields need to be included
+                                user.recordLogin();
                                 done(null, user.sanitize());
                             } else {
                                 const newUser = await authModel.createAndSave({ googleId: profile.id, isTest: false });
+                                newUser.recordLogin();
                                 done(null, newUser !== null ? newUser.sanitize() : false);
                             }
                             return null;
@@ -58,12 +60,14 @@ export default <U extends IUserModel>(authModel: IAuthModel<U>): PassportStatic 
                         .then(async (user) => {
                             if (user !== undefined) {
                                 // TODO Should sanitize user, but see if other fields need to be included
+                                user.recordLogin();
                                 done(null, user.sanitize());
                             } else {
                                 const newUser = await authModel.createAndSave({
                                     facebookId: profile.id,
                                     isTest: false
                                 });
+                                newUser.recordLogin();
                                 done(null, newUser !== null ? newUser.sanitize() : false);
                             }
                             return null;

--- a/packages/chaire-lib-backend/src/config/auth/localLogin.config.ts
+++ b/packages/chaire-lib-backend/src/config/auth/localLogin.config.ts
@@ -32,6 +32,7 @@ const sendEmailIfRequired = async (
     done: (error: any, user?: any, options?: LocalStrategy.IVerifyOptions) => void
 ) => {
     if (getConfirmEmail() !== true) {
+        user.recordLogin();
         done(null, user.sanitize());
         return;
     }
@@ -80,6 +81,7 @@ export default <U extends IUserModel>(passport: PassportStatic, authModel: IAuth
                             if (!model.isConfirmed) {
                                 done(null, false, { message: 'UnconfirmedUser' });
                             } else {
+                                model.recordLogin();
                                 done(null, model.sanitize());
                             }
                         } else {
@@ -103,7 +105,7 @@ export default <U extends IUserModel>(passport: PassportStatic, authModel: IAuth
                 if (!user) throw 'InvalidToken';
                 done(null, user);
             } catch (err) {
-                return done("InvalidToken");
+                return done('InvalidToken');
             }
         })
     );

--- a/packages/chaire-lib-backend/src/config/auth/passwordless.config.ts
+++ b/packages/chaire-lib-backend/src/config/auth/passwordless.config.ts
@@ -95,6 +95,7 @@ export default <U extends IUserModel>(passport: PassportStatic, authModel: IAuth
                     throw 'Invalid token, no email address';
                 }
                 const user = await getOrCreateUserWithEmail(payload.destination);
+                user.recordLogin();
                 done(undefined, user.sanitize(), { referrer: payload.referrer });
             } catch (err) {
                 done(typeof err === 'string' ? new Error(err) : (err as Error), undefined);

--- a/packages/chaire-lib-backend/src/models/db/__tests__/users.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/users.db.test.ts
@@ -170,6 +170,34 @@ test('Collection', async () => {
     expect(dbUser).toEqual(expect.objectContaining(user2));
 });
 
+test('set last login', async () => {
+    // Make sure last login is null at the beginning
+    const { last_login_at } = await dbQueries.getById(user.id) as UserAttributes;
+    expect(last_login_at).toEqual(null);
+    const now = new Date();
+
+    // Set last login and see if the time is between now and after the query setting it
+    await dbQueries.setLastLogin(user.id);
+    const { last_login_at: lastLoginAfterSet } = await dbQueries.getById(user.id) as UserAttributes;
+    expect(lastLoginAfterSet).not.toEqual(null);
+    const after = new Date();
+    const lastLoginDate = new Date(lastLoginAfterSet as string);
+    expect(now.valueOf()).toBeLessThanOrEqual(lastLoginDate.valueOf());
+    expect(lastLoginDate.valueOf()).toBeLessThanOrEqual(after.valueOf());
+
+    // Set last login again, after 1 second wait, and make sure it is now later than previous time
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for one second
+    await dbQueries.setLastLogin(user.id);
+    const { last_login_at: lastLoginAfterSetTwice } = await dbQueries.getById(user.id) as UserAttributes;
+    expect(lastLoginAfterSetTwice).not.toEqual(null);
+    const afterTwice = new Date();
+    const lastLoginDateSecond = new Date(lastLoginAfterSetTwice as string);
+    expect(lastLoginAfterSetTwice).not.toEqual(lastLoginDate);
+    expect(after.valueOf()).toBeLessThanOrEqual(lastLoginDateSecond.valueOf());
+    expect(lastLoginDateSecond.valueOf()).toBeLessThanOrEqual(afterTwice.valueOf());
+
+});
+
 describe('list users', () => {
 
     const nbUsers = 3;

--- a/packages/chaire-lib-backend/src/models/db/migrations/20240313144500_addUserLastLogin.ts
+++ b/packages/chaire-lib-backend/src/models/db/migrations/20240313144500_addUserLastLogin.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const tableName = 'users';
+
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.timestamp('last_login_at');
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.dropColumn('last_login_at');
+    });
+}

--- a/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/users.db.queries.ts
@@ -237,6 +237,19 @@ const getList = async (params: {
     }
 };
 
+const setLastLogin = async (id: number): Promise<boolean> => {
+    try {
+        const nbAffected = await knex(tableName).update({ last_login_at: knex.fn.now() }).where('id', id);
+        return nbAffected > 0 ? true : false;
+    } catch (error) {
+        throw new TrError(
+            `Cannot set user last login for user with id ${id} (knex error: ${error})`,
+            'DBQUP0004',
+            'DatabaseCannotUpdateBecauseDatabaseError'
+        );
+    }
+};
+
 export default {
     create,
     find,
@@ -244,5 +257,6 @@ export default {
     getById,
     getByUuid,
     collection,
-    getList
+    getList,
+    setLastLogin
 };

--- a/packages/chaire-lib-backend/src/services/auth/authModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/authModel.ts
@@ -26,6 +26,10 @@ export interface IUserModel {
     sanitize: () => BaseUser;
     verifyPassword: (password: string) => Promise<boolean>;
     updateAndSave(newAttribs: unknown): Promise<void>;
+    /**
+     * Function called when the user has just logged in the application.
+     */
+    recordLogin: () => Promise<void>;
 }
 
 export type NewUserParams = {
@@ -56,6 +60,15 @@ export interface IAuthModel<U extends IUserModel> {
 
     createAndSave: (userData: NewUserParams) => Promise<U>;
 
+    /**
+     * Finds a user by various fields
+     *
+     * @param findBy The attributes by which to find the user
+     * @param orWhere If there are more than one findBy attribute, whether they
+     * should all be as specified or only one
+     * @returns A single user object if found, or `undefined` if the user with
+     * those attributes does not exist
+     */
     find: (
         findBy: {
             usernameOrEmail?: string;
@@ -179,6 +192,10 @@ export abstract class UserModelBase implements IUserModel {
     /** Update the current user and save update in the database. `id`, `uuid`
      * and `username` fields cannot be updated */
     abstract updateAndSave(newAttribs: Partial<Omit<UserAttributesBase, 'id' | 'username'>>): Promise<void>;
+
+    recordLogin = async (): Promise<void> => {
+        // By default, do nothing
+    };
 
     get id(): number {
         return this.attributes.id;

--- a/packages/chaire-lib-backend/src/services/auth/pwdLessDirectSignupStrategy.ts
+++ b/packages/chaire-lib-backend/src/services/auth/pwdLessDirectSignupStrategy.ts
@@ -54,6 +54,7 @@ class PwdLessDirectSignupStrategy<A> {
             // Otherwise, add the user to the database and consider him as signed up
             try {
                 const newUser = await this.addNewUser(emailOrSms);
+                newUser.recordLogin();
                 this.success(newUser.sanitize());
             } catch (error) {
                 console.log('Error signing up new user:', error);

--- a/packages/chaire-lib-backend/src/services/auth/userAuthModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/userAuthModel.ts
@@ -117,4 +117,9 @@ export default class UserModel extends UserModelBase {
     sanitize = (): BaseUser => {
         return sanitizeUserAttributes(this.attributes);
     };
+
+    recordLogin = async (): Promise<void> => {
+        // Record current datetime as login
+        dbQueries.setLastLogin(this.attributes.id);
+    };
 }

--- a/packages/chaire-lib-backend/src/services/users/user.ts
+++ b/packages/chaire-lib-backend/src/services/users/user.ts
@@ -35,4 +35,5 @@ export type UserAttributes = UserAttributesBase & {
     is_test?: boolean | null;
     // TODO What is this?
     batch_shortname?: string | null;
+    last_login_at?: string | null;
 };


### PR DESCRIPTION
fixes #876

* Add a field: `last_login_at` to the users table.
* Add the `recordLogin` method to the UserModel to let the model implement recording login. The default implementation does nothing
* Set the last login time to the user model based on the `users` table
* Call the recordLogin method in passport strategies whenever there are successful logins.