### PR TITLE
Add bearer strategy with token

### DIFF
--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -89,6 +89,7 @@
         "@types/node": "^17.0.38",
         "@types/nodemailer": "^6.4.1",
         "@types/passport": "^1.0.11",
+        "@types/passport-http-bearer": "^1.0.41",
         "@types/passport-local": "^1.0.34",
         "@types/socket.io": "^2.1.13",
         "@types/socket.io-file": "^2.0.4",

--- a/packages/chaire-lib-backend/src/api/auth.routes.ts
+++ b/packages/chaire-lib-backend/src/api/auth.routes.ts
@@ -116,6 +116,10 @@ export default <U extends IUserModel>(app: express.Express, authModel: IAuthMode
         app.get('/anonymous', passport.authenticate('anonymous-login'), defaultSuccessCallback, defaultFailureCallback);
     }
 
+    if (config.auth && config.auth.directToken !== undefined && config.auth.directToken !== false) {
+        app.get('/direct-token', passport.authenticate('direct-token'), defaultSuccessCallback, defaultFailureCallback);
+    }
+
     app.post('/verify', async (req, res) => {
         try {
             let callback: ((user: U) => void) | undefined = undefined;

--- a/packages/chaire-lib-backend/src/config/auth/__tests__/directToken.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/auth/__tests__/directToken.config.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import passport from 'passport';
+import each from 'jest-each';
+
+import directTokenLogin from '../directToken.config';
+import usersDbQueries from '../../../models/db/users.db.queries';
+import { userAuthModel } from '../../../services/auth/userAuthModel';
+import config from '../../server.config';
+
+// req.logIn needs to be set and is called by passport when successful
+const logInFct = jest.fn().mockImplementation((_a, _b, callback) => {
+    callback();
+});
+
+jest.mock('../../../models/db/users.db.queries', () => ({
+    find: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn(),
+    setLastLogin: jest.fn()
+}));
+const mockFind = usersDbQueries.find as jest.MockedFunction<typeof usersDbQueries.find>;
+const mockCreate = usersDbQueries.create as jest.MockedFunction<typeof usersDbQueries.create>;
+const mockSetLastLogin = usersDbQueries.setLastLogin as jest.MockedFunction<typeof usersDbQueries.setLastLogin>;
+
+const newUserId = 7;
+
+beforeEach(() => {
+    logInFct.mockClear();
+    mockFind.mockClear();
+    mockCreate.mockClear();
+    mockCreate.mockImplementation(async (attribs) => {
+        return {
+            id: newUserId,
+            uuid: 'arbitrary',
+            ...attribs
+        }
+    });
+    mockSetLastLogin.mockClear();
+});
+
+test('regex', () => {
+    expect('abcdef'.match(/[a-z]+/gi)).not.toBeNull();
+})
+
+each([
+    ['undefined format', '1234-1234', undefined, true],
+    ['undefined format, no token', '', undefined, false],
+    ['simple regex, matching token', 'abdefg', /^[a-z]+$/gi, true],
+    ['simple regex, partly matching token at start, invalid', 'abcdefg87', /^[a-z]+$/gi, false],
+    ['simple regex, partly matching token at end, invalid', '87abcdefg', /^[a-z]+$/gi, false],
+    ['simple regex, unmatching token', '', /^[a-z]+$/gi, false],
+    ['dash-separate hex regex, matching token', '1234ad-34DF-cafe-beef-c0701234ae34', /^[0-9A-F]{6}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/gi, true],
+    ['dash-separate hex regex, unmatching token', '1234AD-34df-test-hexi-c0701234ae34', /^[0-9A-F]{6}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/gi, false],
+    ['dash-separate hex regex, empty token', '', /^[0-9A-F]{6}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/gi, false],
+    ['invalid regex, missing bracket', 'testToken', '/^[a-z+$/i', false],
+    ['regex as string, valid token', 'abdefg', '^[a-z]+$', true],
+    ['regex as string, invalid token', 'abcdefg87', '^[a-z]+$', false],
+    ['simple string, valid token', 'testToken', 'testToken', true],
+    ['simple string, invalid token', 'differentToken', 'testToken', false],
+]).test('test with various token formats: %s', async(_title, token, tokenFormat, expectedResult) => {
+    config.auth = {
+        directToken: {
+            tokenFormat: tokenFormat
+        }
+    };
+    directTokenLogin(passport, userAuthModel)
+    const endFct = jest.fn();
+    const authPromise = new Promise((resolve, reject) => {
+        const res = { 
+            end: endFct.mockImplementation((message) => resolve({ result: null, err: message })),
+            json: jest.fn().mockImplementation((json) => resolve({ result: json, err: null })),
+            setHeader: jest.fn()
+        };
+        passport.authenticate('direct-token')(
+            {
+                logIn: logInFct,
+                query: { access_token: token },
+                res
+            }, res, (err, result) => {
+                resolve({ result, err });
+            }
+        );
+    });
+    const authResult: any = await authPromise;
+
+    // Verify results
+    if (expectedResult === true) {
+        expect(logInFct).toHaveBeenCalledTimes(1);
+        expect(logInFct).toHaveBeenCalledWith(expect.objectContaining({ email: undefined, username: token }), expect.anything(), expect.anything());
+        expect(authResult.err).toBeUndefined();
+        expect(authResult.result).toBeUndefined();
+    } else {
+        expect(logInFct).not.toHaveBeenCalled();
+        expect(authResult.err).toBeDefined();
+    }
+    
+});
+
+test('Complete flow with valid token', async() => {
+    config.auth = {
+        directToken: {
+            tokenFormat: undefined
+        }
+    };
+    directTokenLogin(passport, userAuthModel)
+    const endFct = jest.fn();
+    const token = 'testtoken';
+    const authPromise = new Promise((resolve, reject) => {
+        passport.authenticate('direct-token')(
+            {
+                logIn: logInFct,
+                query: { access_token: token }
+            }, {
+                end: endFct.mockImplementation((message) => resolve({ result: null, err: message }))
+            }, (err, result) => {
+                resolve({ result, err });
+            }
+        );
+    });
+    const authResult: any = await authPromise;
+
+    expect(authResult.err).toBeUndefined();
+    expect(authResult.result).toBeUndefined();
+    expect(mockFind).toHaveBeenCalledTimes(1);
+    expect(mockFind).toHaveBeenCalledWith({ username: token }, false);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith({
+        username: token,
+        email: null,
+        google_id: null,
+        facebook_id: null,
+        generated_password: null,
+        password: null,
+        first_name: '',
+        last_name: '',
+        is_admin: false,
+        is_valid: true,
+        is_test: false,
+        is_confirmed: true,
+        confirmation_token: null,
+        preferences: null
+    });
+    expect(logInFct).toHaveBeenCalledTimes(1);
+    expect(logInFct).toHaveBeenCalledWith(expect.objectContaining({ email: undefined, username: token }), expect.anything(), expect.anything());
+});

--- a/packages/chaire-lib-backend/src/config/auth/directToken.config.ts
+++ b/packages/chaire-lib-backend/src/config/auth/directToken.config.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { PassportStatic } from 'passport';
+import BearerStrategy from 'passport-http-bearer';
+import { IAuthModel, IUserModel } from '../../services/auth/authModel';
+import config from '../server.config';
+
+// Direct token login strategy: the token will be used as the username. If it
+// exists in the database, the user will be logged in, otherwise, it will be
+// automatically created.
+
+const isTokenValid = (token: string): boolean => {
+    // TODO The token regex format could be validated at the start instead of
+    // in this method. But this is called only for new users and it is easier to
+    // unit test as it is now, so we keep this here.
+    const tokenFormat = config.auth?.directToken?.tokenFormat;
+    let tokenFormatRegex: RegExp | boolean = true;
+    try {
+        tokenFormatRegex = tokenFormat !== undefined ? new RegExp(tokenFormat) : true;
+    } catch {
+        console.log(
+            'Token format for direct token Regular expression for direct token is not a valid regular expression:',
+            tokenFormat
+        );
+        tokenFormatRegex = false;
+    }
+    return typeof tokenFormatRegex === 'boolean' ? tokenFormatRegex : token.match(tokenFormatRegex) !== null;
+};
+
+export default <U extends IUserModel>(passport: PassportStatic, authModel: IAuthModel<U>) => {
+    passport.use(
+        'direct-token',
+        // We use the bearer strategy, even though this does not implement the
+        // bearer tokens specified by RFC 6750. Our token strategy is quite
+        // simple and it fits the API of the passport-http-bearer strategy,
+        // which is itself very simple and despite what the documentation says,
+        // has no mention of the specification or OAuth in its API.
+        new BearerStrategy.Strategy(async (token: string, done) => {
+            try {
+                // Validate the token has the right format
+                if (!isTokenValid(token)) {
+                    throw 'Invalid token format';
+                }
+                // Find the user whose username is the token
+                const user = await authModel.find({ username: token });
+                if (user) {
+                    done(null, user.sanitize());
+                } else {
+                    // The user is not found, create it and log in
+                    const newUser = await authModel.createAndSave({
+                        username: token
+                    });
+                    done(null, newUser.sanitize());
+                }
+            } catch (err) {
+                console.error('Error registering or validating user with token:', err);
+                return done('InvalidToken');
+            }
+        })
+    );
+};

--- a/packages/chaire-lib-backend/src/config/auth/index.ts
+++ b/packages/chaire-lib-backend/src/config/auth/index.ts
@@ -97,6 +97,12 @@ export default <U extends IUserModel>(authModel: IAuthModel<U>): PassportStatic 
             : anonymousLoginStrategy;
         passport.use('anonymous-login', new AnonymousLoginStrategy(authModel));
     }
+    if (config.auth && config.auth.directToken !== undefined && config.auth.directToken !== false) {
+        const directTokenConfig = require('./directToken.config');
+        // FIXME It used to work without the next line, not anymore... probably some compilation issue
+        const directToken = directTokenConfig.default ? directTokenConfig.default : directTokenConfig;
+        directToken(passport, authModel, config.auth.directTokenFormat);
+    }
 
     // TODO user is Express.User type and does not have an id type
     passport.serializeUser((user: any, done) => {

--- a/packages/chaire-lib-common/src/config/shared/project.config.ts
+++ b/packages/chaire-lib-common/src/config/shared/project.config.ts
@@ -20,6 +20,32 @@ export type ProjectConfiguration<AdditionalConfig> = {
             confirmEmail?: boolean;
             confirmEmailStrategy?: 'confirmByAdmin' | 'confirmByUser';
         };
+        /**
+         * Configures authentication by direct token access. The user is
+         * identified by the value of a token added as a query parameter to the
+         * login page, in the `access_token` field (ex.
+         * http://localhost:8080?access_token=token)
+         *
+         * Value can be `false` to deactivate this login method, `true` to
+         * activate with any token in parameter, or an object with the token
+         * format.
+         */
+        directToken?:
+            | boolean
+            | {
+                  /**
+                   * If specified, the token will have to match this regular
+                   * expression. See the official javascript documentation for the
+                   * regular expression format
+                   * (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions)
+                   *
+                   * example:
+                   * - /^[\d]{10}$/ for 10-number values
+                   * - /^[0-9A-F]{4}-[0-9A-F]{4}$/i for 2 dash separated sets of 4
+                   *   hexadecimal characters
+                   */
+                  tokenFormat: RegExp;
+              };
     };
     separateAdminLoginPage: boolean;
     // @deprecated

--- a/packages/chaire-lib-frontend/src/actions/Auth.tsx
+++ b/packages/chaire-lib-frontend/src/actions/Auth.tsx
@@ -47,7 +47,7 @@ export const logout = (): AuthAction => ({
     register: false
 });
 
-const redirectAfterLogin = (user: BaseUser, history: History, location?: Location, referrer?: string) => {
+export const redirectAfterLogin = (user: BaseUser, history: History, location?: Location, referrer?: string) => {
     const requestedPath =
         location && location.state && (location.state as any).referrer ? (location.state as any).referrer : undefined;
     history.push(requestedPath ? requestedPath : user.homePage ? user.homePage : appConfiguration.homePage);

--- a/packages/chaire-lib-frontend/src/components/forms/auth/anonymous/AnonymousLogin.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/anonymous/AnonymousLogin.tsx
@@ -1,9 +1,14 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
 import React from 'react';
 import { connect } from 'react-redux';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import { History, Location } from 'history';
 
-import FormErrors from '../../../pageParts/FormErrors';
 import { startAnonymousLogin } from '../../../../actions/Auth';
 
 export interface AnonymousLoginProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,6 +2967,13 @@
     "@turf/invariant" "^6.3.0"
     d3-voronoi "1.1.2"
 
+"@types/accepts@*":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.7.tgz#3b98b1889d2b2386604c2bbbe62e4fb51e95b265"
+  integrity sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -3065,6 +3072,21 @@
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.34.tgz#170a40223a6d666006d93ca128af2beb1d9b1901"
   integrity sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==
   dependencies:
+    "@types/node" "*"
+
+"@types/content-disposition@*":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.8.tgz#6742a5971f490dc41e59d277eee71361fea0b537"
+  integrity sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==
+
+"@types/cookies@*":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.9.0.tgz#a2290cfb325f75f0f28720939bee854d4142aee2"
+  integrity sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==
+  dependencies:
+    "@types/connect" "*"
+    "@types/express" "*"
+    "@types/keygrip" "*"
     "@types/node" "*"
 
 "@types/engine.io@*":
@@ -3218,6 +3240,16 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
   integrity sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==
 
+"@types/http-assert@*":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.5.tgz#dfb1063eb7c240ee3d3fe213dac5671cfb6a8dbf"
+  integrity sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==
+
+"@types/http-errors@*":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.4.tgz#7eb47726c391b7345a6ec35ad7f4de469cf5ba4f"
+  integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
+
 "@types/inquirer@^8.2.1":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-8.2.1.tgz#28a139be3105a1175e205537e8ac10830e38dbf4"
@@ -3313,6 +3345,32 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/kdbush/-/kdbush-3.0.0.tgz#ba9a14305ebb9fc5770dc5731f272bd9fa67fb18"
   integrity sha512-G7c8tWLneqgHLXqm1DKj6D7+kPPTSd9cRa5LKVgt61/kYY3enSDiS3V/yeJ8VHA4fW1bzRxfnXUYTOszolv0OA==
+
+"@types/keygrip@*":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.6.tgz#1749535181a2a9b02ac04a797550a8787345b740"
+  integrity sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==
+
+"@types/koa-compose@*":
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.8.tgz#dec48de1f6b3d87f87320097686a915f1e954b57"
+  integrity sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==
+  dependencies:
+    "@types/koa" "*"
+
+"@types/koa@*":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.15.0.tgz#eca43d76f527c803b491731f95df575636e7b6f2"
+  integrity sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==
+  dependencies:
+    "@types/accepts" "*"
+    "@types/content-disposition" "*"
+    "@types/cookies" "*"
+    "@types/http-assert" "*"
+    "@types/http-errors" "*"
+    "@types/keygrip" "*"
+    "@types/koa-compose" "*"
+    "@types/node" "*"
 
 "@types/lodash@^4.14.198":
   version "4.14.198"
@@ -3410,6 +3468,15 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/passport-http-bearer@^1.0.41":
+  version "1.0.41"
+  resolved "https://registry.yarnpkg.com/@types/passport-http-bearer/-/passport-http-bearer-1.0.41.tgz#ccf02934ff316fb16dcd147cd1c3abf623461093"
+  integrity sha512-ecW+9e8C+0id5iz3YZ+uIarsk/vaRPkKSajt1i1Am66t0mC9gDfQDKXZz9fnPOW2xKUufbmCSou4005VM94Feg==
+  dependencies:
+    "@types/express" "*"
+    "@types/koa" "*"
+    "@types/passport" "*"
 
 "@types/passport-local@^1.0.34":
   version "1.0.34"


### PR DESCRIPTION
This cleanly adds the authentication method with token. It adds a user in the auth model with the token as username (this avoids adding a new field to the user table). Relogging with the same token in the URL will cause the user to log back in with the same user data.