### PR TITLE
Public API: Added important GeoJSON parameters to accessibility map polygon

### DIFF
--- a/docs/APIv1/accessibilityMap.yml
+++ b/docs/APIv1/accessibilityMap.yml
@@ -212,6 +212,18 @@ accessibilityMapResultResponsePolygons:
                 ]
           properties:
             type: object
+            required:
+              - durationSeconds
+              - areaSqM
+            properties:
+              durationSeconds: 
+                type: number
+                description: The maximum trip duration included in this polygon, in seconds
+                example: 300
+              areaSqM:
+                type: number
+                description: The total area of the polygon, in square meters
+                example: 2309327.161000439
 
 accessibilityMapResponseBadRequest:
   type: string

--- a/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
+++ b/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
@@ -36,7 +36,10 @@ type AccessibilityMapAPIResultResponse = {
         features: Array<{
             type: 'Feature';
             geometry: MultiPolygon;
-            properties: Record<string, never>; // Empty object
+            properties: {
+                durationSeconds: number;
+                areaSqM: number;
+            }
         }>;
     };
 };
@@ -91,7 +94,10 @@ export default class AccessibilityMapAPIResponse extends APIResponseBase<
                         features: resultParams.polygons.features.map((feature: Feature<MultiPolygon>) => ({
                             type: feature.type,
                             geometry: feature.geometry,
-                            properties: {}
+                            properties: {
+                                durationSeconds: feature.properties!.durationSeconds,
+                                areaSqM: feature.properties!.areaSqM
+                            }
                         }))
                     }
                     : undefined


### PR DESCRIPTION
The `durationSeconds` and `areaSqM` parameters have been added to the accessibility map GeoJSON in the /api/v1/accessibility endpoint response. The `durationSeconds` parameter especially is necessary to differentiate between the travel time represented by each polygon generated in the response. Also, the QGIS plugin needs this information to differentiate between the polygons.