### PR TITLE
frontend: Extract the `verifyAuthentication` method

### DIFF
--- a/packages/chaire-lib-frontend/src/services/auth/__tests__/verifyAuthentication.test.ts
+++ b/packages/chaire-lib-frontend/src/services/auth/__tests__/verifyAuthentication.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import fetchMock from 'jest-fetch-mock';
+import verifyAuthentication from '../verifyAuthentication';
+
+const mockDispatch = jest.fn();
+
+const loginCalled = { type: 'LOGIN' };
+const logoutCalled = { type: 'LOGOUT' };
+
+jest.mock('../../../actions/Auth', () => ({
+    login: jest.fn().mockImplementation(() => loginCalled),
+    logout: jest.fn().mockImplementation(() => logoutCalled)
+}));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock.doMock();
+});
+
+describe('verifyAuthentication', () => {
+    test('Valid authenticated response', async() => {
+        fetchMock.mockOnce(JSON.stringify({ user: { id: 1 } }));
+        await verifyAuthentication(mockDispatch);
+        expect(mockDispatch).toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledWith(loginCalled);
+    });
+
+    test('Valid unauthenticated response', async () => {
+        fetchMock.mockOnce(JSON.stringify({ status: 'Unauthenticated' }));
+        await verifyAuthentication(mockDispatch);
+        expect(mockDispatch).toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledWith(logoutCalled);
+    });
+
+    test('Unauthenticated response', async() => {
+        fetchMock.mockOnce(JSON.stringify({ status: 'Internal server error'}), {
+            status: 401,
+            statusText: "ok",
+        });
+        await verifyAuthentication(mockDispatch);
+        expect(mockDispatch).toHaveBeenCalled();
+        expect(mockDispatch).toHaveBeenCalledWith(logoutCalled);
+    });
+
+    test('Other response code', async() => {
+        fetchMock.mockOnce(JSON.stringify({ status: 'Internal server error'}), {
+            status: 500,
+            statusText: "ok",
+        });
+        await verifyAuthentication(mockDispatch);
+        expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    test('throw exception', async() => {
+        fetchMock.mockRejectOnce(new Error('Some error occurred'));
+        await verifyAuthentication(mockDispatch);
+        expect(mockDispatch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/chaire-lib-frontend/src/services/auth/verifyAuthentication.ts
+++ b/packages/chaire-lib-frontend/src/services/auth/verifyAuthentication.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Dispatch } from 'redux';
+import { login, logout } from '../../actions/Auth';
+
+export default async (dispatch: Dispatch) => {
+    try {
+        const response = await fetch('/verifyAuthentication', { credentials: 'include' });
+        if (response.status === 200) {
+            // authorized (user authentication succeeded)
+            const body = await response.json();
+            if (body.user) {
+                dispatch(login(body.user, true));
+            } else {
+                dispatch(logout());
+            }
+        } else if (response.status === 401) {
+            dispatch(logout());
+        }
+    } catch (err) {
+        console.log('Error verifying authentication.', err);
+    }
+};

--- a/packages/transition-frontend/src/app-transition.tsx
+++ b/packages/transition-frontend/src/app-transition.tsx
@@ -25,6 +25,7 @@ import {
 } from './components/dashboard/TransitionDashboardContribution';
 import { SupplyDemandAnalysisDashboardContribution } from './components/dashboard/supplyDemandAnalysisModule/SupplyDemandAnalysisDashboardContribution';
 import { setApplicationConfiguration } from 'chaire-lib-frontend/lib/config/application.config';
+import verifyAuthentication from 'chaire-lib-frontend/lib/services/auth/verifyAuthentication';
 
 import 'chaire-lib-frontend/lib/styles/styles-transition.scss';
 import './styles/transition.scss';
@@ -70,26 +71,4 @@ const renderApp = () => {
     }
 };
 
-fetch('/verifyAuthentication', { credentials: 'include' })
-    .then((response) => {
-        if (response.status === 200) {
-            // authorized (user authentication succeeded)
-            response.json().then((body) => {
-                if (body.user) {
-                    store.dispatch(login(body.user, true));
-                } else {
-                    store.dispatch(logout());
-                }
-                renderApp();
-            });
-        } else if (response.status === 401) {
-            store.dispatch(logout());
-            renderApp();
-        } else {
-            renderApp();
-        }
-    })
-    .catch((err) => {
-        console.log('Error logging in.', err);
-        renderApp();
-    });
+verifyAuthentication(store.dispatch).finally(() => renderApp());


### PR DESCRIPTION
This allows other code path to re-use the app loading code to verify authentication. One example is when the user is logged out, the requests will typically return a 401 response to the application. The code handling this response code can request the server to verifyAuthentication and thus differentiate between a logged out user and one trying to access a forbidden resource.