### PR TITLE
Don't recalculate transferable nodes on startup

### DIFF
--- a/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
+++ b/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
@@ -39,7 +39,7 @@ type AccessibilityMapAPIResultResponse = {
             properties: {
                 durationSeconds: number;
                 areaSqM: number;
-            }
+            };
         }>;
     };
 };

--- a/packages/transition-backend/src/socketServerApp.ts
+++ b/packages/transition-backend/src/socketServerApp.ts
@@ -49,7 +49,8 @@ const setupSocketServerApp = async function (server, session) {
     if (_booleish(process.env.STARTUP_RECREATE_CACHE)) {
         console.log('Recreating cache files');
         // TODO get cachePathDIrectory from params
-        await recreateCache({ refreshTransferrableNodes: true, saveLines: true });
+        // We don't need to refresh the transferrable nodes on startup as they are saved in the DB
+        await recreateCache({ refreshTransferrableNodes: false, saveLines: true });
     }
 
     // Enqueue/resume running and pending tasks


### PR DESCRIPTION
We now save the transferable nodes in the database, so we don't really need to recalculate them at each startup. But we still need to save them to the capnp cache file.

We add a saveAllNodesToCache function to NodeCollectionUtils, based on saveAndUpdateAllNodes, that only store the node data without recalculating it. We add a else in the recreateCache function where we test for the refreshTransferrableNodes flag to call our new function in that case. (That way we always save the transferable nodes to cache)

The dbToCache were missing a mockClear, we switch it to jest.clearAllMocks() and fixes the erroneous tests

The call in socketServerApp was changed to ask for not refreshing the transferable node when recreating the cache on startup