### PR TITLE
GTFS: Use postgis to get existing nodes when aggregation radius is 0

### DIFF
--- a/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
@@ -307,6 +307,36 @@ describe(`${objectName}`, () => {
         expect(Math.abs(nodesWithinBirdRadius100000[1].distance - sortedExpectedNodes[1][1])).toBeLessThanOrEqual(25);
     });
 
+    test('should get nodes within bird radius from point', async () => {
+        const point = newObjectAttributes.geography;
+
+        // With same geography as one of the nodes, should contain the node with this geography for 0 and 1000 meters
+        const nodesWithinBirdRadius = await dbQueries.getNodesInBirdDistanceFromPoint(point, 1000);
+        expect(nodesWithinBirdRadius).toEqual([
+            { id: newObjectAttributes.id, distance: 0 }
+        ]);
+        const nodesWithinBirdRadius0 = await dbQueries.getNodesInBirdDistanceFromPoint(point, 0);
+        expect(nodesWithinBirdRadius0).toEqual([
+            { id: newObjectAttributes.id, distance: 0 }
+        ]);
+
+        // With higher distance, there should be more nodes
+        const distanceToN2 = turfDistance(newObjectAttributes.geography.coordinates, newObjectAttributes2.geography.coordinates, { units: 'meters'});
+        const distanceToN3 = turfDistance(newObjectAttributes.geography.coordinates, newObjectAttributes3.geography.coordinates, { units: 'meters'});
+        const sortedExpectedNodes: [any, any][] = distanceToN2 < distanceToN3 ? [[newObjectAttributes, 0], [newObjectAttributes2, distanceToN2], [newObjectAttributes3, distanceToN3]] : [[newObjectAttributes, 0], [newObjectAttributes3, distanceToN3], [newObjectAttributes2, distanceToN2]];
+        const nodesWithinBirdRadius100000 = await dbQueries.getNodesInBirdDistanceFromPoint(point, 100000);
+        expect(nodesWithinBirdRadius100000).toEqual([
+            { id: sortedExpectedNodes[0][0].id, distance: expect.anything() },
+            { id: sortedExpectedNodes[1][0].id, distance: expect.anything() },
+            { id: sortedExpectedNodes[2][0].id, distance: expect.anything() }
+        ]);
+
+        // turf and postgis do not have the exact same distance algorithm. Simply make sure they are within 25 meters of each other
+        expect(Math.abs(nodesWithinBirdRadius100000[0].distance - sortedExpectedNodes[0][1])).toBeLessThanOrEqual(25);
+        expect(Math.abs(nodesWithinBirdRadius100000[1].distance - sortedExpectedNodes[1][1])).toBeLessThanOrEqual(25);
+        expect(Math.abs(nodesWithinBirdRadius100000[2].distance - sortedExpectedNodes[2][1])).toBeLessThanOrEqual(25);
+    });
+
     test('should not delete nodes from database if paths exist', async () => {
 
         // delete an object that has paths associated, it should not be possible

--- a/packages/transition-backend/src/services/nodes/NodeCollectionUtils.ts
+++ b/packages/transition-backend/src/services/nodes/NodeCollectionUtils.ts
@@ -117,3 +117,14 @@ export const saveAllNodesToCache = async (
     // TODO: What about failures? Should we track them, reject upon first failure (using Promise.all), just console.error them?
     await Promise.allSettled(addPromises);
 };
+
+/**
+ * Get nodes within bird distance of a given existing node
+ * @param nodeId The ID of the node from which to get nodes within bird distance
+ * @param distanceMeters The distance within which the node should be located
+ * @returns An array of objects containing the node ID and the distance
+ */
+export const getNodesInBirdDistance = async (
+    nodeId: string,
+    distanceMeters: number
+): Promise<{ id: string; distance: number }[]> => nodesDbQueries.getNodesInBirdDistance(nodeId, distanceMeters);

--- a/packages/transition-backend/src/services/nodes/NodeCollectionUtils.ts
+++ b/packages/transition-backend/src/services/nodes/NodeCollectionUtils.ts
@@ -128,3 +128,14 @@ export const getNodesInBirdDistance = async (
     nodeId: string,
     distanceMeters: number
 ): Promise<{ id: string; distance: number }[]> => nodesDbQueries.getNodesInBirdDistance(nodeId, distanceMeters);
+
+/**
+ * Get nodes within bird distance of a point
+ * @param point The point from which to get nodes within bird distance
+ * @param distanceMeters The distance within which the node should be located
+ * @returns An array of objects containing the node ID and the distance
+ */
+export const getNodesInBirdDistanceFromPoint = async (
+    point: GeoJSON.Point,
+    distanceMeters: number
+): Promise<{ id: string; distance: number }[]> => nodesDbQueries.getNodesInBirdDistanceFromPoint(point, distanceMeters);

--- a/packages/transition-backend/src/services/nodes/TransferableNodeUtils.ts
+++ b/packages/transition-backend/src/services/nodes/TransferableNodeUtils.ts
@@ -6,10 +6,10 @@
  */
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import routingServiceManager from 'chaire-lib-common/lib/services/routing/RoutingServiceManager';
-import transitNodesDbQueries from '../../models/db/transitNodes.db.queries';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import TransitNode, { TransferableNodes } from 'transition-common/lib/services/nodes/Node';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
+import { getNodesInBirdDistance } from './NodeCollectionUtils';
 
 const getTransferableNodesFromBirdRadius = (
     nodesInBirdRadius: { id: string; distance: number }[],
@@ -117,9 +117,6 @@ export const getDefaultTransferableNodeDistance = (
     const walkingSpeedMetersPerSeconds = Preferences.get('defaultWalkingSpeedMetersPerSeconds');
     return maxWalkingTravelTimeRadiusSeconds * walkingSpeedMetersPerSeconds;
 };
-
-export const getNodesInBirdDistance = async (nodeId: string, distanceMeters: number) =>
-    transitNodesDbQueries.getNodesInBirdDistance(nodeId, distanceMeters);
 
 /**
  * Get the nodes in the collection that are within a certain distance of the

--- a/packages/transition-backend/src/services/nodes/TransitNode.ts
+++ b/packages/transition-backend/src/services/nodes/TransitNode.ts
@@ -9,12 +9,9 @@ import { NodeAttributes } from 'transition-common/lib/services/nodes/Node';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
 import nodesDbQueries from '../../models/db/transitNodes.db.queries';
 import transitNodeTransferableDbQueries from '../../models/db/transitNodeTransferable.db.queries';
-import {
-    getDefaultTransferableNodeDistance,
-    getNodesInBirdDistance,
-    getTransferableNodesWithAffected
-} from './TransferableNodeUtils';
+import { getDefaultTransferableNodeDistance, getTransferableNodesWithAffected } from './TransferableNodeUtils';
 import { objectToCache } from '../../models/capnpCache/transitNodes.cache.queries';
+import { getNodesInBirdDistance } from './NodeCollectionUtils';
 
 /**
  * Saves a node to the database and to cache. If the geography has changed, it

--- a/packages/transition-backend/src/services/nodes/__tests__/TransferableNodeUtils.test.ts
+++ b/packages/transition-backend/src/services/nodes/__tests__/TransferableNodeUtils.test.ts
@@ -84,44 +84,6 @@ beforeEach(() => {
     mockedGetNodesInBirdDistance.mockClear();
 });
 
-describe('getNodesInBirdDistance', () => {
-    test('no data', async () => {
-        mockedGetNodesInBirdDistance.mockResolvedValueOnce([]);
-        const distance = 1000;
-        const nodesInBirdDistance = await TransferableNodeUtils.getNodesInBirdDistance(referenceNode.id, distance);
-        expect(nodesInBirdDistance).toEqual([]);
-        expect(mockedGetNodesInBirdDistance).toHaveBeenCalledWith(referenceNode.id, distance);
-    });
-
-    test('some nodes returned, not including requested one', async () => {
-        mockedGetNodesInBirdDistance.mockResolvedValueOnce([
-            { id: nodeAttributesClose1.id, distance: 300 }, 
-            { id: nodeAttributesClose2.id, distance: 700 }
-        ]);
-        const distance = 1000;
-        const nodesInBirdDistance = await TransferableNodeUtils.getNodesInBirdDistance(referenceNode.id, distance);
-        expect(nodesInBirdDistance).toEqual([
-            { id: nodeAttributesClose1.id, distance: 300 }, 
-            { id: nodeAttributesClose2.id, distance: 700 }
-        ]);
-        expect(mockedGetNodesInBirdDistance).toHaveBeenCalledWith(referenceNode.id, distance);
-    });
-
-    test('some nodes returned, including requested one', async () => {
-        mockedGetNodesInBirdDistance.mockResolvedValueOnce([
-            { id: nodeAttributesClose1.id, distance: 300 }, 
-            { id: nodeAttributesClose2.id, distance: 700 }
-        ]);
-        const distance = 1000;
-        const nodesInBirdDistance = await TransferableNodeUtils.getNodesInBirdDistance(referenceNode.id, distance);
-        expect(nodesInBirdDistance).toEqual([
-            { id: nodeAttributesClose1.id, distance: 300 }, 
-            { id: nodeAttributesClose2.id, distance: 700 }
-        ]);
-        expect(mockedGetNodesInBirdDistance).toHaveBeenCalledWith(referenceNode.id, distance);
-    });
-});
-
 describe('getTransferableNodes', () => {
 
     let refNode: Node;

--- a/packages/transition-backend/src/services/nodes/__tests__/TransitNode.test.ts
+++ b/packages/transition-backend/src/services/nodes/__tests__/TransitNode.test.ts
@@ -9,6 +9,7 @@ import { TestUtils, RoutingServiceManagerMock } from 'chaire-lib-common/lib/test
 import TransitNode, { NodeAttributes } from 'transition-common/lib/services/nodes/Node';
 import { v4 as uuidV4 } from 'uuid';
 import * as TransferableNodeUtils from '../TransferableNodeUtils';
+import * as NodeCollectionUtils from '../NodeCollectionUtils';
 import transitNodesDbQueries from '../../../models/db/transitNodes.db.queries';
 import transferableNodesDbQueries from '../../../models/db/transitNodeTransferable.db.queries';
 import { objectToCache } from '../../../models/capnpCache/transitNodes.cache.queries';
@@ -42,12 +43,15 @@ const mockGetForNode = transferableNodesDbQueries.getFromNode as jest.MockedFunc
 const mockSaveForNode = transferableNodesDbQueries.saveForNode as jest.MockedFunction<typeof transferableNodesDbQueries.saveForNode>;
 
 jest.mock('../TransferableNodeUtils', () => ({
-    getNodesInBirdDistance: jest.fn().mockResolvedValue([]),
     getTransferableNodesWithAffected: jest.fn(),
     getDefaultTransferableNodeDistance: jest.fn().mockReturnValue(1000)
 }));
-const mockGetNodesInBirdDistance = TransferableNodeUtils.getNodesInBirdDistance as jest.MockedFunction<typeof TransferableNodeUtils.getNodesInBirdDistance>;
 const mockGetTNodeWithAffected = TransferableNodeUtils.getTransferableNodesWithAffected as jest.MockedFunction<typeof TransferableNodeUtils.getTransferableNodesWithAffected>;
+
+jest.mock('../NodeCollectionUtils', () => ({
+    getNodesInBirdDistance: jest.fn().mockResolvedValue([]),
+}));
+const mockGetNodesInBirdDistance = NodeCollectionUtils.getNodesInBirdDistance as jest.MockedFunction<typeof NodeCollectionUtils.getNodesInBirdDistance>;
 
 jest.mock('../../../models/capnpCache/transitNodes.cache.queries', () => ({
     objectToCache: jest.fn()


### PR DESCRIPTION
fixes #908
    
Since KDBush sometimes does not return a node which is at the exact
location as another one, the main code path sometimes created new nodes
at the exact same location when the aggregation radius was set to 0.
postgis, on the other hand, does not do that, so we get the existing
node from the database in that case.

Also
* Move `getNodesInBirdDistance` to `NodeCollecitonUtils`
* Add a db and utils functions to get nodes withing distance of a point (one already existed for existing nodes)
* Run `yarn format` on the code