### PR TITLE
db: Allow all queries to receive a transaction parameter

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/__tests__/tokens.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/tokens.db.test.ts
@@ -214,7 +214,7 @@ describe(`Tokens Database: Expiry`, () => {
     });
 
     test('Should throw when trying to get user by id if token is expired', async() => {
-        await expect(tokensDbQueries.getUserByToken(expiredToken.api_token as string)).rejects.toThrowError (TrError.)
+        await expect(tokensDbQueries.getUserByToken(expiredToken.api_token as string)).rejects.toThrowError (TrError)
     });
 });
 describe(`Tokens Database: Cleanup`, () => {

--- a/packages/chaire-lib-backend/src/models/db/dataSources.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/dataSources.db.queries.ts
@@ -121,16 +121,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: DataSourceAttributes, returning?: string) => {
-        return create(knex, tableName, undefined, newObject, returning);
+        return create(knex, tableName, undefined, newObject, { returning });
     },
     createMultiple: (newObjects: DataSourceAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, undefined, newObjects, returning);
+        return createMultiple(knex, tableName, undefined, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<DataSourceAttributes>, returning?: string) => {
-        return update(knex, tableName, undefined, id, updatedObject, returning);
+        return update(knex, tableName, undefined, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<DataSourceAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, undefined, updatedObjects, returning);
+        return updateMultiple(knex, tableName, undefined, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
@@ -12,7 +12,18 @@ import TrError from 'chaire-lib-common/lib/utils/TrError';
 
 // TODO Move these to a generic class, so we can use identical types for U and T in generic methods.
 
-const stringifyDataSourceIds = function (dataSourceIds: string[]): string[] {
+/**
+ * Helper function to wrap the data source IDs in '' to be used in database
+ * queries.
+ *
+ * FIXME Mostly called in the context of raw queries with a 'IN' where
+ * statement. See if we can use a regular `whereIn` instead and remove the need
+ * for this function.
+ *
+ * @param dataSourceIds An array of data source IDs to stringify
+ * @returns A DB-ready array of data source id strings
+ */
+export const stringifyDataSourceIds = function (dataSourceIds: string[]): string[] {
     if (dataSourceIds && !Array.isArray(dataSourceIds)) {
         dataSourceIds = [dataSourceIds];
     }
@@ -23,7 +34,15 @@ const stringifyDataSourceIds = function (dataSourceIds: string[]): string[] {
         : [];
 };
 
-const exists = async (knex: Knex, tableName: string, id: string): Promise<boolean> => {
+/**
+ * Check whether a record with the given id exists in the table
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param id The ID of the object
+ * @returns Whether an object with the given ID exists in the table
+ */
+export const exists = async (knex: Knex, tableName: string, id: string): Promise<boolean> => {
     if (!uuidValidate(id)) {
         throw new TrError(
             `Cannot verify if the object exists in ${tableName} because the required parameter id is missing, blank or not a valid uuid`,
@@ -53,17 +72,38 @@ const exists = async (knex: Knex, tableName: string, id: string): Promise<boolea
     }
 };
 
-const create = async <T extends GenericAttributes, U>(
+/**
+ * Insert a new record in a table
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param parser A parser function which converts an object's attributes to db
+ * fields
+ * @param newObject The new object's attributes
+ * @param options Additional options parameter. `returning` specifies which
+ * field's or fields' values to return after insert. `transaction` is an
+ * optional transaction of which this insert is part of.
+ * @returns The requested `returning` field values.
+ */
+export const create = async <T extends GenericAttributes, U>(
     knex: Knex,
     tableName: string,
     parser: ((arg: T) => U) | undefined,
     newObject: T,
-    returning: string | string[] = 'id'
+    options: {
+        returning?: string | string[];
+        transaction?: Knex.Transaction;
+    } = { returning: 'id' }
 ): Promise<string | { [key: string]: unknown }> => {
     try {
+        const returning = options.returning || 'id';
         const _newObject = parser ? parser(newObject) : newObject;
 
-        const returningArray = await knex(tableName).insert(_newObject).returning(returning);
+        const query = knex(tableName).insert(_newObject).returning(returning);
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+        const returningArray = await query;
         return typeof returning === 'string' ? returningArray[0][returning] : returningArray[0];
     } catch (error) {
         throw new TrError(
@@ -74,14 +114,32 @@ const create = async <T extends GenericAttributes, U>(
     }
 };
 
-const createMultiple = async <T extends GenericAttributes, U>(
+/**
+ * Inset multiple records in a table
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param parser A parser function which converts an object's attributes to db
+ * fields
+ * @param newObjects An array of objects to insert
+ * @param options Additional options parameter. `returning` specifies which
+ * field's or fields' values to return after insert. `transaction` is an
+ * optional transaction of which this insert is part of.
+ * @returns An array with the requested `returning` field values for all
+ * records.
+ */
+export const createMultiple = async <T extends GenericAttributes, U>(
     knex: Knex,
     tableName: string,
     parser: ((arg: T) => U) | undefined,
     newObjects: T[],
-    _returning: string[] = ['id'] // TODO Use this or remove?
+    options: {
+        returning?: string | string[];
+        transaction?: Knex.Transaction;
+    } = {}
 ): Promise<{ [key: string]: any }[]> => {
     try {
+        const returning = options.returning || 'id';
         const _newObjects =
             typeof parser === 'function'
                 ? newObjects.map((newObject) => {
@@ -92,7 +150,11 @@ const createMultiple = async <T extends GenericAttributes, U>(
 
         const chunkSize = 250;
 
-        return await knex.batchInsert(tableName, _newObjects as any, chunkSize).returning(_returning);
+        const query = knex.batchInsert(tableName, _newObjects as any, chunkSize).returning(returning);
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+        return await query;
         /*return await knex.transaction(async (tr) => {
             // TODO batchInsert does not accept newObjects with casting to any. Figure out how to correctly type it
             return await knex.batchInsert(tableName, _newObjects as any, chunkSize).transacting(tr);
@@ -103,11 +165,25 @@ const createMultiple = async <T extends GenericAttributes, U>(
             `Cannot insert objects in table ${tableName} database (knex error: ${error})`,
             'DBQCR0002',
             'DatabaseCannotCreateMultipleBecauseDatabaseError'
-        ).export();
+        );
     }
 };
 
-const read = async <T extends GenericAttributes, U>(
+/**
+ * Read an object from the database. This function throws an error if the object
+ * does not exist.
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param parser A parser function which converts the database fields to  an
+ * object's attributes
+ * @param query The raw select fields to query. Defaults to `*` to read all
+ * fields in the table
+ * @param id The ID of the object to read
+ * @returns The object attributes obtained after the `parser` function was run
+ * on the read record.
+ */
+export const read = async <T extends GenericAttributes, U>(
     knex: Knex,
     tableName: string,
     parser: ((arg: U) => Partial<T>) | undefined,
@@ -143,13 +219,30 @@ const read = async <T extends GenericAttributes, U>(
     }
 };
 
-const update = async <T extends GenericAttributes, U>(
+/**
+ * Update a single record in a table
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param parser A parser function which converts an object's attributes to db
+ * fields
+ * @param id The ID of the record to update
+ * @param attributes A subset of the object's attributes to update
+ * @param options Additional options parameter. `returning` specifies which
+ * field's or fields' values to return after update. `transaction` is an
+ * optional transaction of which this update is part of.
+ * @returns The requested `returning` field. Defaults to the ID of the object
+ */
+export const update = async <T extends GenericAttributes, U>(
     knex: Knex,
     tableName: string,
     parser: ((arg: Partial<T>) => U) | undefined,
     id: string,
     attributes: Partial<T>,
-    returning = 'id'
+    options: {
+        returning?: string;
+        transaction?: Knex.Transaction;
+    } = {}
 ): Promise<string> => {
     try {
         if (!uuidValidate(id)) {
@@ -161,7 +254,13 @@ const update = async <T extends GenericAttributes, U>(
         }
         const _attributes = parser ? parser(attributes) : attributes;
 
-        const returningArray = await knex(tableName).update(_attributes).where('id', id).returning(returning);
+        const returning = options.returning || 'id';
+        const query = knex(tableName).update(_attributes).where('id', id).returning(returning);
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+        const returningArray = await query;
+
         return returningArray[0][returning];
     } catch (error) {
         throw new TrError(
@@ -172,20 +271,43 @@ const update = async <T extends GenericAttributes, U>(
     }
 };
 
-const updateMultiple = async <T extends GenericAttributes, U>(
+/**
+ * Update multiple records in the database
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param parser A parser function which converts an object's attributes to db
+ * fields
+ * @param attributeCollection An array of object attributes to update. Each
+ * object's attributes in the collection need to have an ID attribute.
+ * @param options Additional options parameter. `returning` specifies which
+ * field's or fields' values to return after update. `transaction` is an
+ * optional transaction of which this update is part of.
+ * @returns The requested `returning` fields for each object. Defaults to the
+ * IDs of the object
+ */
+export const updateMultiple = async <T extends GenericAttributes, U>(
     knex: Knex,
     tableName: string,
     parser: ((arg: Partial<T>) => U) | undefined,
     attributeCollection: Partial<T>[],
-    returning = 'id'
+    options: {
+        returning?: string | string[];
+        transaction?: Knex.Transaction;
+    } = {}
 ): Promise<string[][]> => {
     const _attributeCollection: any[] = parser
         ? attributeCollection.map((attribute) => parser(attribute))
         : attributeCollection;
 
     try {
-        return (await knex.transaction(async (trx) => {
-            const queries = _attributeCollection.map((attributes: any) => {
+        const returning = options.returning || 'id';
+        // Nested function to require a transaction around the updates
+        const updateMultipleTransaction = async (trx: Knex.Transaction) => {
+            const queries = _attributeCollection.map((attributes: any, index) => {
+                if (!attributes.id) {
+                    throw `Object attributes at index ${index} does not have an ID.`;
+                }
                 //console.log(attributes);
                 return knex(tableName)
                     .update(attributes)
@@ -194,8 +316,13 @@ const updateMultiple = async <T extends GenericAttributes, U>(
                     .transacting(trx);
             });
             const returningArray = await Promise.all(queries);
-            return returningArray;
-        })) as string[][];
+            return returningArray as string[][];
+        };
+        // Since updates are done individually, they need to be part of a
+        // transaction. If one did not come with the options, create one.
+        return await (options.transaction !== undefined
+            ? updateMultipleTransaction(options.transaction)
+            : knex.transaction(updateMultipleTransaction));
     } catch (error) {
         throw new TrError(
             `Cannot update multiple objects from table ${tableName} (knex error: ${error})`,
@@ -205,7 +332,24 @@ const updateMultiple = async <T extends GenericAttributes, U>(
     }
 };
 
-const deleteRecord = async (knex: Knex, tableName: string, id: string) => {
+/**
+ * Delete a single record by ID from a table
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param id The ID of the record to delete
+ * @param options Additional options parameter. `transaction` is an optional
+ * transaction of which this delete is part of.
+ * @returns The ID of the deleted object
+ */
+export const deleteRecord = async (
+    knex: Knex,
+    tableName: string,
+    id: string,
+    options: {
+        transaction?: Knex.Transaction;
+    } = {}
+) => {
     try {
         if (!uuidValidate(id)) {
             throw new TrError(
@@ -214,7 +358,11 @@ const deleteRecord = async (knex: Knex, tableName: string, id: string) => {
                 'ObjectCannotDeleteBecauseIdIsMissingOrInvalid'
             );
         }
-        await knex(tableName).where('id', id).del();
+        const query = knex(tableName).where('id', id).del();
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+        await query;
         return id;
     } catch (error) {
         throw new TrError(
@@ -225,30 +373,65 @@ const deleteRecord = async (knex: Knex, tableName: string, id: string) => {
     }
 };
 
-const deleteMultiple = function (knex: Knex, tableName: string, ids: string[]): Promise<string[]> {
-    return new Promise((resolve, reject) => {
-        return knex(tableName)
-            .whereIn('id', ids)
-            .del()
-            .then(() => {
-                //const numberOfDeletedObjects = parseInt(response);
-                resolve(ids);
-            })
-            .catch((error) => {
-                reject(
-                    new TrError(
-                        `Cannot delete objects with ids ${ids} from table ${tableName} (knex error: ${error})`,
-                        'DBQDLM0001',
-                        'ObjectsCannotDeleteBecauseDatabaseError'
-                    )
-                );
-            });
-    });
+/**
+ * Delete multiple records by ID from a table
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param ids An array of record IDs to delete
+ * @param options Additional options parameter. `transaction` is an optional
+ * transaction of which this delete is part of.
+ * @returns The array of deleted IDs
+ */
+export const deleteMultiple = async (
+    knex: Knex,
+    tableName: string,
+    ids: string[],
+    options: {
+        transaction?: Knex.Transaction;
+    } = {}
+): Promise<string[]> => {
+    try {
+        const query = knex(tableName).whereIn('id', ids).del();
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+        await query;
+        return ids;
+    } catch (error) {
+        throw new TrError(
+            `Cannot delete objects with ids ${ids} from table ${tableName} (knex error: ${error})`,
+            'DBQDLM0001',
+            'ObjectsCannotDeleteBecauseDatabaseError'
+        );
+    }
 };
 
-const deleteForDataSourceId = async (knex: Knex, tableName: string, dataSourceId: string): Promise<string> => {
+/**
+ * If the table has a `data_source_id` field, this deletes all records
+ * associated with a given data source ID.
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table on which to execute the operation
+ * @param dataSourceId The ID of the datasource for which to delete records
+ * @param options Additional options parameter. `transaction` is an optional
+ * transaction of which this delete is part of.
+ * @returns
+ */
+export const deleteForDataSourceId = async (
+    knex: Knex,
+    tableName: string,
+    dataSourceId: string,
+    options: {
+        transaction?: Knex.Transaction;
+    } = {}
+): Promise<string> => {
     try {
-        await knex(tableName).where('data_source_id', dataSourceId).del();
+        const query = knex(tableName).where('data_source_id', dataSourceId).del();
+        if (options.transaction) {
+            query.transacting(options.transaction);
+        }
+        await query;
         return dataSourceId;
     } catch (error) {
         throw new TrError(
@@ -259,7 +442,17 @@ const deleteForDataSourceId = async (knex: Knex, tableName: string, dataSourceId
     }
 };
 
-const truncate = async (knex: Knex, tableName: string): Promise<string> => {
+/**
+ * Empties a database table
+ *
+ * FIXME Shoud we keep this method only for sequential tests purposes? It should
+ * not be used in production. See
+ * https://github.com/chairemobilite/transition/issues/938
+ *
+ * @param knex The database configuration object
+ * @param tableName The name of the table to empty
+ */
+export const truncate = async (knex: Knex, tableName: string): Promise<string> => {
     try {
         await knex.raw(`TRUNCATE TABLE ${tableName} CASCADE`);
         return tableName;
@@ -273,26 +466,19 @@ const truncate = async (knex: Knex, tableName: string): Promise<string> => {
     }
 };
 
-const destroy = function (
+/**
+ * FIXME Unclear what this does and likely dangerous in production. Some unit
+ * tests call it, others don't and seem to work fine anyway. Remove? See
+ * https://github.com/chairemobilite/transition/issues/938
+ *
+ * @param knex The database configuration object
+ * @param callback Callback to call after the destroy
+ */
+export const destroy = function (
     knex: Knex,
     callback: () => void = () => {
         /* nothing to do */
     }
 ) {
     knex.destroy(callback);
-};
-
-export {
-    exists,
-    create,
-    createMultiple,
-    read,
-    update,
-    updateMultiple,
-    deleteRecord,
-    deleteMultiple,
-    deleteForDataSourceId,
-    truncate,
-    destroy,
-    stringifyDataSourceIds
 };

--- a/packages/chaire-lib-backend/src/models/db/zones.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/zones.db.queries.ts
@@ -168,16 +168,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: ZoneAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: ZoneAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<ZoneAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<ZoneAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -15,6 +15,7 @@
         "migrate": "knex migrate:latest --knexfile lib/config/knexfile.js",
         "migrate:rollback": "knex migrate:down --knexfile lib/config/knexfile.js",
         "migrate-test": "cross-env NODE_ENV=test knex migrate:latest --knexfile lib/config/knexfile.js",
+        "migrate-test:rollback": "cross-env NODE_ENV=test knex migrate:down --knexfile lib/config/knexfile.js",
         "start": "yarn node --max-old-space-size=4096 lib/server.js",
         "start:tracing": "yarn node -r ../../tracing.js  --max-old-space-size=4096 lib/server.js",
         "start:debug": "cross-env DEBUG=express:* yarn node --trace-warnings --max-old-space-size=4096 lib/server.js",

--- a/packages/transition-backend/src/models/db/__mocks__/transitPaths.db.queries.ts
+++ b/packages/transition-backend/src/models/db/__mocks__/transitPaths.db.queries.ts
@@ -18,6 +18,5 @@ export default {
     truncate: jest.fn(),
     destroy: jest.fn(),
     collection: jest.fn().mockImplementation(() => []),
-    geojsonCollection: jest.fn().mockImplementation(() => []),
-    deleteForLines: jest.fn()
+    geojsonCollection: jest.fn().mockImplementation(() => [])
 };

--- a/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
@@ -7,6 +7,7 @@
 import { v4 as uuidV4 } from 'uuid';
 import _cloneDeep from 'lodash/cloneDeep';
 
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import dbQueries from '../transitNodes.db.queries';
 import pathsDbQueries from '../transitPaths.db.queries';
 import GeojsonCollection from 'transition-common/lib/services/nodes/NodeCollection';
@@ -185,7 +186,7 @@ describe(`${objectName}`, () => {
     test('should create a second new object in database, with array returning', async () => {
 
         const newObject = new ObjectClass(newObjectAttributes2, true);
-        const { id, integer_id } = await dbQueries.create(newObject.attributes, ['id', 'integer_id']) as {[key: string]: unknown}
+        const { id, integer_id } = await dbQueries.create(newObject.attributes, { returning: ['id', 'integer_id'] }) as {[key: string]: unknown}
         expect(id).toBe(newObjectAttributes2.id);
         expect(integer_id).toBeDefined();
 
@@ -380,6 +381,87 @@ describe(`${objectName}`, () => {
         const ids = await dbQueries.deleteMultipleUnused([newObjectAttributes.id, newObjectAttributes2.id]);
         expect(ids).toEqual([newObjectAttributes2.id]);
 
+    });
+
+});
+
+describe('Nodes, with transactions', () => {
+
+    beforeEach(async () => {
+        // Empty the table and add 1 object
+        await dbQueries.truncate();
+        const newObject = new ObjectClass(newObjectAttributes, true);
+        await dbQueries.create(newObject.getAttributes());
+    });
+
+    test('Create, update with success', async() => {
+        const newName = 'new name';
+        await knex.transaction(async (trx) => {
+            const newObject = new ObjectClass(newObjectAttributes2, true);
+            await dbQueries.create(newObject.getAttributes(), { transaction: trx });
+            await dbQueries.update(newObjectAttributes.id, { name: newName }, { transaction: trx });
+        });
+
+        // Make sure the new object is there and the old has been updated
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(2);
+        const { name, ...currentObject } = new ObjectClass(newObjectAttributes, true).attributes;
+        const object1 = collection.find((obj) => obj.id === newObjectAttributes.id);
+        expect(object1).toBeDefined();
+        expect(object1).toEqual(expect.objectContaining({
+            name: newName,
+            ...currentObject
+        }));
+
+        const object2 = collection.find((obj) => obj.id === newObjectAttributes2.id);
+        expect(object2).toBeDefined();
+        expect(object2).toEqual(expect.objectContaining(new ObjectClass(newObjectAttributes2, true).attributes));
+    });
+
+    test('Create, update with error', async() => {
+        let error: any = undefined;
+        try {
+            await knex.transaction(async (trx) => {
+                const newObject = new ObjectClass(newObjectAttributes2, true);
+                await dbQueries.create(newObject.getAttributes(), { transaction: trx });
+                // Update with a bad field
+                await dbQueries.update(newObjectAttributes.id, { simulation_id: uuidV4() } as any, { transaction: trx });
+            });
+        } catch(err) {
+            error = err;
+        }
+        expect(error).toBeDefined();
+
+        // The new object should not have been added and the one in DB should not have been updated
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(1);
+        const object1 = collection.find((obj) => obj.id === newObjectAttributes.id);
+        expect(object1).toBeDefined();
+        expect(object1).toEqual(expect.objectContaining(new ObjectClass(newObjectAttributes, true).attributes));
+    });
+
+    test('Create, update, delete with error', async() => {
+        const currentNodeNewName = 'new node name';
+        let error: any = undefined;
+        try {
+            await knex.transaction(async (trx) => {
+                const newObject = new ObjectClass(newObjectAttributes2, true);
+                await dbQueries.create(newObject.getAttributes(), { transaction: trx });
+                await dbQueries.update(newObjectAttributes.id, { name: currentNodeNewName }, { transaction: trx });
+                await dbQueries.delete(newObjectAttributes.id, { transaction: trx });
+                throw 'error';
+            });
+        } catch(err) {
+            error = err;
+        }
+        expect(error).toEqual('error');
+
+        // Make sure the existing object is still there and no new one has been added
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(1);
+        const object1 = collection.find((obj) => obj.id === newObjectAttributes.id);
+        expect(object1).toBeDefined();
+        expect(object1).toEqual(expect.objectContaining(new ObjectClass(newObjectAttributes, true).attributes));
     });
 
 });

--- a/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import dbQueries from '../transitServices.db.queries';
 import simulationDbQueries from '../simulations.db.queries';
@@ -324,3 +325,85 @@ describe(`${objectName}`, function() {
     });
 
 });
+
+describe('Services, with transactions', () => {
+
+    beforeEach(async () => {
+        // Empty the table and add 1 object
+        await dbQueries.truncate();
+        const newObject = new ObjectClass(newObjectAttributes, true);
+        await dbQueries.create(newObject.getAttributes());
+    });
+
+    test('Create, update with success', async() => {
+        const currentObjectNewName = 'new service name';
+        await knex.transaction(async (trx) => {
+            const newObject = new ObjectClass(newObjectAttributes2, true);
+            await dbQueries.create(newObject.getAttributes(), { transaction: trx });
+            await dbQueries.update(newObjectAttributes.id, { name: currentObjectNewName }, { transaction: trx });
+        });
+
+        // Make sure the new object is there and the old has been updated
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(2);
+        const { name, ...currentObject } = newObjectAttributes
+        const object1 = collection.find((obj) => obj.id === newObjectAttributes.id);
+        expect(object1).toBeDefined();
+        expect(object1).toEqual(expect.objectContaining({
+            name: currentObjectNewName,
+            ...currentObject
+        }));
+
+        const object2 = collection.find((obj) => obj.id === newObjectAttributes2.id);
+        expect(object2).toBeDefined();
+        expect(object2).toEqual(expect.objectContaining(newObjectAttributes2));
+    });
+
+    test('Create, update with error', async() => {
+        let error: any = undefined;
+        try {
+            await knex.transaction(async (trx) => {
+                const newObject = new ObjectClass(newObjectAttributes2, true);
+                await dbQueries.create(newObject.getAttributes(), { transaction: trx });
+                // Update with unexisting simulation ID, should throw an error
+                await dbQueries.update(newObjectAttributes.id, { simulation_id: uuidV4() }, { transaction: trx });
+            });
+        } catch(err) {
+            error = err;
+        }
+        expect(error).toBeDefined();
+
+        // The new object should not have been added and the one in DB should not have been updated
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(1);
+        const object1 = collection.find((obj) => obj.id === newObjectAttributes.id);
+        expect(object1).toBeDefined();
+        expect(object1).toEqual(expect.objectContaining(newObjectAttributes));
+    });
+
+    test('Create, update, delete with error', async() => {
+        const currentAgencyNewName = 'new agency name';
+        let error: any = undefined;
+        try {
+            await knex.transaction(async (trx) => {
+                const newObject = new ObjectClass(newObjectAttributes2, true);
+                await dbQueries.create(newObject.getAttributes(), { transaction: trx });
+                await dbQueries.update(newObjectAttributes.id, { name: currentAgencyNewName }, { transaction: trx });
+                await dbQueries.delete(newObjectAttributes.id, { transaction: trx });
+                throw 'error';
+            });
+        } catch(err) {
+            error = err;
+        }
+        expect(error).toEqual('error');
+
+        // Make sure the existing object is still there and no new one has been added
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(1);
+        const object1 = collection.find((obj) => obj.id === newObjectAttributes.id);
+        expect(object1).toBeDefined();
+        expect(object1).toEqual(expect.objectContaining(newObjectAttributes));
+    });
+
+});
+

--- a/packages/transition-backend/src/models/db/migrations/20240503162600_addUniqueScenarioServiceIdx.ts
+++ b/packages/transition-backend/src/models/db/migrations/20240503162600_addUniqueScenarioServiceIdx.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const tableName = 'tr_transit_scenario_services';
+
+/**
+ * This migration adds a unique index on the scenario_id, service_id, which
+ * should have been added from the beginning. This will allow to leverage upsert
+ * queries instead of having the check the existence of individual
+ * scenario/service pairs before adding new ones.
+ *
+ * @param knex The database configuration object
+ * @returns
+ */
+export async function up(knex: Knex): Promise<unknown> {
+    // Remove duplicates before adding the unique constraint on scenario_id, service_id
+    const countServiceQuery = knex
+        .select('scenario_id', 'service_id')
+        .from(tableName)
+        .count()
+        .groupBy('scenario_id', 'service_id')
+        .as('servCount');
+    const duplicates = await knex(countServiceQuery).where('count', '>', 1);
+    // For each duplicate, delete all then add again one record
+    for (let dupIdx = 0; dupIdx < duplicates.length; dupIdx++) {
+        const { scenario_id, service_id } = duplicates[dupIdx];
+        await knex(tableName).where('scenario_id', scenario_id).andWhere('service_id', service_id).del();
+        await knex(tableName).insert({ scenario_id, service_id });
+    }
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.unique(['scenario_id', 'service_id']);
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.dropUnique(['scenario_id', 'service_id']);
+    });
+}

--- a/packages/transition-backend/src/models/db/odPairs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/odPairs.db.queries.ts
@@ -151,16 +151,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: BaseOdTripAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: BaseOdTripAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<BaseOdTripAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<BaseOdTripAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/places.db.queries.ts
+++ b/packages/transition-backend/src/models/db/places.db.queries.ts
@@ -199,16 +199,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: PlaceAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: PlaceAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<PlaceAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<PlaceAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
@@ -243,16 +243,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: SimulationRunAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: SimulationRunAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<SimulationRunAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<SimulationRunAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRun,
     deleteMultiple: deleteMultipleRun,

--- a/packages/transition-backend/src/models/db/simulations.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulations.db.queries.ts
@@ -100,16 +100,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: SimulationAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: SimulationAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<SimulationAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<SimulationAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
@@ -23,6 +23,7 @@ import TrError from 'chaire-lib-common/lib/utils/TrError';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 
 import { AgencyAttributes } from 'transition-common/lib/services/agency/Agency';
+import { Knex } from 'knex';
 
 const tableName = 'tr_transit_agencies';
 
@@ -74,20 +75,20 @@ const collection = async (): Promise<AgencyAttributes[]> => {
 export default {
     exists: exists.bind(null, knex, tableName),
     read: read.bind(null, knex, tableName, undefined, '*'),
-    create: (newObject: AgencyAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, { returning });
-    },
-    createMultiple: (newObjects: AgencyAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
-    },
-    update: (id: string, updatedObject: Partial<AgencyAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
-    },
-    updateMultiple: (updatedObjects: Partial<AgencyAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
-    },
-    delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    create: async (newObject: AgencyAttributes, options?: Parameters<typeof create>[4]) =>
+        create(knex, tableName, attributesCleaner, newObject, options),
+    createMultiple: async (newObjects: AgencyAttributes[], options?: Parameters<typeof createMultiple>[4]) =>
+        createMultiple(knex, tableName, attributesCleaner, newObjects, options),
+    update: async (id: string, updatedObject: Partial<AgencyAttributes>, options?: Parameters<typeof update>[5]) =>
+        update(knex, tableName, attributesCleaner, id, updatedObject, options),
+    updateMultiple: async (
+        updatedObjects: Partial<AgencyAttributes>[],
+        options?: Parameters<typeof updateMultiple>[4]
+    ) => updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
+        deleteRecord(knex, tableName, id, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
+        deleteMultiple(knex, tableName, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection

--- a/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
@@ -75,16 +75,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read: read.bind(null, knex, tableName, undefined, '*'),
     create: (newObject: AgencyAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: AgencyAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<AgencyAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<AgencyAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitLines.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitLines.db.queries.ts
@@ -24,6 +24,7 @@ import Line, { LineAttributes } from 'transition-common/lib/services/line/Line';
 import { ScheduleAttributes } from 'transition-common/lib/services/schedules/Schedule';
 
 import scheduleQueries from './transitSchedules.db.queries';
+import { Knex } from 'knex';
 
 const tableName = 'tr_transit_lines';
 const joinedTable = 'tr_transit_paths';
@@ -169,22 +170,20 @@ const read = async (id: string) => {
 export default {
     exists: exists.bind(null, knex, tableName),
     read,
-    create: (newObject: LineAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, { returning });
-    },
+    create: async (newObject: LineAttributes, options?: Parameters<typeof create>[4]) =>
+        create(knex, tableName, attributesCleaner, newObject, options),
     // TODO Create multiple will have to handle schedules too or do we suppose it's only the line attributes?
-    createMultiple: (newObjects: LineAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
-    },
-    update: (id: string, updatedObject: Partial<LineAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
-    },
+    createMultiple: async (newObjects: LineAttributes[], options?: Parameters<typeof createMultiple>[4]) =>
+        createMultiple(knex, tableName, attributesCleaner, newObjects, options),
+    update: async (id: string, updatedObject: Partial<LineAttributes>, options?: Parameters<typeof update>[5]) =>
+        update(knex, tableName, attributesCleaner, id, updatedObject, options),
     // TODO Update multiple will have to handle schedules too or do we suppose it's only the line attributes?
-    updateMultiple: (updatedObjects: Partial<LineAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
-    },
-    delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    updateMultiple: async (updatedObjects: Partial<LineAttributes>[], options?: Parameters<typeof updateMultiple>[4]) =>
+        updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
+        deleteRecord(knex, tableName, id, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
+        deleteMultiple(knex, tableName, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     // TODO Should collection also return the schedules?

--- a/packages/transition-backend/src/models/db/transitLines.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitLines.db.queries.ts
@@ -170,18 +170,18 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: LineAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     // TODO Create multiple will have to handle schedules too or do we suppose it's only the line attributes?
     createMultiple: (newObjects: LineAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<LineAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     // TODO Update multiple will have to handle schedules too or do we suppose it's only the line attributes?
     updateMultiple: (updatedObjects: Partial<LineAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
@@ -330,16 +330,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: NodeAttributes, returning?: string | string[]) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: NodeAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<NodeAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<NodeAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteIfUnused,
     deleteMultipleUnused,

--- a/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
@@ -235,50 +235,24 @@ const read = async (id: string) => {
     }
 };
 
-const deleteForLines = async (lineIds: string[]): Promise<string[]> => {
-    try {
-        if (_isBlank(lineIds) && lineIds.length > 0) {
-            throw new TrError(
-                'Cannot verify if transit paths exist because the required parameter lineIds is missing, blank or not a valid id/uuid',
-                'DBQDLP0001',
-                'TransitPathsCannotDeleteBecauseLineIdsIsMissingOrInvalid'
-            );
-        }
-        const numberOfDeleteObjects = await knex('tr_transit_paths').whereIn('line_id', lineIds).del();
-        if (numberOfDeleteObjects >= 0) {
-            return lineIds;
-        }
-        throw new TrError(`Error while deleting transit paths with line ids ${lineIds} in database`, 'DBQDLP0002');
-    } catch (error) {
-        throw new TrError(
-            `Cannot delete transit paths with for line ids ${lineIds} in database (knex error: ${error})`,
-            'DBQDLP0003',
-            'TransitPathsCannotDeleteBecauseDatabaseError'
-        );
-    }
-};
-
 export default {
     exists: exists.bind(null, knex, tableName),
     read,
-    create: (newObject: PathAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, { returning });
-    },
-    createMultiple: (newObjects: PathAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
-    },
-    update: (id: string, updatedObject: Partial<PathAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
-    },
-    updateMultiple: (updatedObjects: Partial<PathAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
-    },
-    delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    create: async (newObject: PathAttributes, options?: Parameters<typeof create>[4]) =>
+        create(knex, tableName, attributesCleaner, newObject, options),
+    createMultiple: async (newObjects: PathAttributes[], options?: Parameters<typeof createMultiple>[4]) =>
+        createMultiple(knex, tableName, attributesCleaner, newObjects, options),
+    update: async (id: string, updatedObject: Partial<PathAttributes>, options?: Parameters<typeof update>[5]) =>
+        update(knex, tableName, attributesCleaner, id, updatedObject, options),
+    updateMultiple: async (updatedObjects: Partial<PathAttributes>[], options?: Parameters<typeof updateMultiple>[4]) =>
+        updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
+        deleteRecord(knex, tableName, id, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
+        deleteMultiple(knex, tableName, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection,
     geojsonCollection,
-    deleteForLines,
     geojsonCollectionForServices
 };

--- a/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
@@ -262,16 +262,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: PathAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: PathAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<PathAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<PathAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitScenarios.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitScenarios.db.queries.ts
@@ -115,7 +115,7 @@ const read = async (id: string) => {
 const create = async (newObject: ScenarioAttributes, returning?: string) => {
     const services = newObject.services || [];
     // Create the main object in main table
-    const created = await defaultCreate(knex, tableName, attributesCleaner, newObject, returning);
+    const created = await defaultCreate(knex, tableName, attributesCleaner, newObject, { returning });
     try {
         if (services.length > 0) {
             // Fill the service table
@@ -140,7 +140,7 @@ const createMultiple = async (newObjects: ScenarioAttributes[], returning?: stri
         .map((newObject) => ({ scenario_id: newObject.id, services: newObject.services || [] }))
         .filter((scServices) => scServices.services.length > 0);
     // Create the main object in main table
-    const created = await defaultCreateMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+    const created = await defaultCreateMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     try {
         if (services.length > 0) {
             // Fill the service table
@@ -184,7 +184,7 @@ const getNewAndDeletedServicesForScenario = (
 
 const update = async (id: string, updatedObject: Partial<ScenarioAttributes>, returning?: string) => {
     // Create the main object in main table
-    const updated = await defaultUpdate(knex, tableName, attributesCleaner, id, updatedObject, returning);
+    const updated = await defaultUpdate(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     try {
         // Update services if they are not undefined (partial update)
         const services = updatedObject.services;
@@ -215,7 +215,7 @@ const update = async (id: string, updatedObject: Partial<ScenarioAttributes>, re
 };
 
 const updateMultiple = async (updatedObjects: Partial<ScenarioAttributes>[], returning?: string) => {
-    const updated = await defaultUpdateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+    const updated = await defaultUpdateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     try {
         // Update services if they are not undefined (partial update)
         const objectsToUpdate = updatedObjects.filter((object) => object.services !== undefined);

--- a/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
@@ -111,7 +111,9 @@ const createFromTrip = async function (periodTrip: SchedulePeriodTrip, scheduleI
     if (!periodTrip.schedule_period_id) {
         periodTrip.schedule_period_id = periodId;
     }
-    const id = (await create(knex, tripTable, scheduleTripsAttributesCleaner, periodTrip, 'id')) as string;
+    const id = (await create(knex, tripTable, scheduleTripsAttributesCleaner, periodTrip, {
+        returning: 'id'
+    })) as string;
     return id;
 };
 
@@ -122,7 +124,9 @@ const createFromPeriod = async function (periodSchedule: SchedulePeriod, schedul
     if (!periodSchedule.schedule_id) {
         periodSchedule.schedule_id = schedule_id;
     }
-    const id = (await create(knex, periodTable, schedulePeriodsAttributesCleaner, periodSchedule, 'id')) as string;
+    const id = (await create(knex, periodTable, schedulePeriodsAttributesCleaner, periodSchedule, {
+        returning: 'id'
+    })) as string;
     if (periodSchedule.trips) {
         for (let i = 0; i < periodSchedule.trips.length; i++) {
             await createFromTrip(periodSchedule.trips[i], schedule_id, id);
@@ -133,7 +137,9 @@ const createFromPeriod = async function (periodSchedule: SchedulePeriod, schedul
 
 // create all needed inserts from scheduleData (from scheduleByServiceId[serviceId])
 const createFromScheduleData = async function (scheduleData: ScheduleAttributes) {
-    const id = (await create(knex, scheduleTable, scheduleAttributesCleaner, scheduleData, 'id')) as string;
+    const id = (await create(knex, scheduleTable, scheduleAttributesCleaner, scheduleData, {
+        returning: 'id'
+    })) as string;
     for (let i = 0; i < scheduleData.periods.length; i++) {
         await createFromPeriod(scheduleData.periods[i], id);
     }
@@ -144,14 +150,9 @@ const updateFromTrip = async function (periodTrip: Partial<SchedulePeriodTrip>) 
     if (!periodTrip.id || !periodTrip.schedule_id || !periodTrip.schedule_period_id) {
         throw 'Missing trip, schedule or period id for trip, cannot update';
     }
-    const id = (await update(
-        knex,
-        tripTable,
-        scheduleTripsAttributesCleaner,
-        periodTrip.id,
-        periodTrip,
-        'id'
-    )) as string;
+    const id = (await update(knex, tripTable, scheduleTripsAttributesCleaner, periodTrip.id, periodTrip, {
+        returning: 'id'
+    })) as string;
     return id;
 };
 
@@ -159,14 +160,9 @@ const updateFromPeriod = async function (periodSchedule: Partial<SchedulePeriod>
     if (!periodSchedule.id || !periodSchedule.schedule_id) {
         throw 'Missing schedule or period id for period, cannot update';
     }
-    const id = await update(
-        knex,
-        periodTable,
-        schedulePeriodsAttributesCleaner,
-        periodSchedule.id,
-        periodSchedule,
-        'id'
-    );
+    const id = await update(knex, periodTable, schedulePeriodsAttributesCleaner, periodSchedule.id, periodSchedule, {
+        returning: 'id'
+    });
     const tripIds = await getTripIdsForPeriod(id);
     const currentTrips: string[] = [];
     // Update or create periods in schedule
@@ -187,7 +183,9 @@ const updateFromPeriod = async function (periodSchedule: Partial<SchedulePeriod>
 };
 
 const updateFromScheduleData = async function (scheduleId: string, scheduleData: ScheduleAttributes) {
-    const id = (await update(knex, scheduleTable, scheduleAttributesCleaner, scheduleId, scheduleData, 'id')) as string;
+    const id = (await update(knex, scheduleTable, scheduleAttributesCleaner, scheduleId, scheduleData, {
+        returning: 'id'
+    })) as string;
     const periodIds = await getPeriodIdsForSchedule(id);
     const currentPeriods: string[] = [];
     // Update or create periods in schedule

--- a/packages/transition-backend/src/models/db/transitServices.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitServices.db.queries.ts
@@ -118,20 +118,22 @@ const read = async (id: string) => {
 export default {
     exists: exists.bind(null, knex, tableName),
     read,
-    create: (newObject: ServiceAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, { returning });
+    create: (newObject: ServiceAttributes, options?: Parameters<typeof create>[4]) => {
+        return create(knex, tableName, attributesCleaner, newObject, options);
     },
-    createMultiple: (newObjects: ServiceAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
+    createMultiple: (newObjects: ServiceAttributes[], options?: Parameters<typeof createMultiple>[4]) => {
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, options);
     },
-    update: (id: string, updatedObject: Partial<ServiceAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
+    update: (id: string, updatedObject: Partial<ServiceAttributes>, options?: Parameters<typeof update>[5]) => {
+        return update(knex, tableName, attributesCleaner, id, updatedObject, options);
     },
-    updateMultiple: (updatedObjects: Partial<ServiceAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
+    updateMultiple: (updatedObjects: Partial<ServiceAttributes>[], options?: Parameters<typeof updateMultiple>[4]) => {
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options);
     },
-    delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
+        deleteRecord(knex, tableName, id, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
+        deleteMultiple(knex, tableName, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection

--- a/packages/transition-backend/src/models/db/transitServices.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitServices.db.queries.ts
@@ -119,16 +119,16 @@ export default {
     exists: exists.bind(null, knex, tableName),
     read,
     create: (newObject: ServiceAttributes, returning?: string) => {
-        return create(knex, tableName, attributesCleaner, newObject, returning);
+        return create(knex, tableName, attributesCleaner, newObject, { returning });
     },
     createMultiple: (newObjects: ServiceAttributes[], returning?: string[]) => {
-        return createMultiple(knex, tableName, attributesCleaner, newObjects, returning);
+        return createMultiple(knex, tableName, attributesCleaner, newObjects, { returning });
     },
     update: (id: string, updatedObject: Partial<ServiceAttributes>, returning?: string) => {
-        return update(knex, tableName, attributesCleaner, id, updatedObject, returning);
+        return update(knex, tableName, attributesCleaner, id, updatedObject, { returning });
     },
     updateMultiple: (updatedObjects: Partial<ServiceAttributes>[], returning?: string) => {
-        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, returning);
+        return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName),

--- a/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
@@ -9,11 +9,7 @@ import { v4 as uuidV4 } from 'uuid';
 import _cloneDeep from 'lodash/cloneDeep';
 import pQueue from 'p-queue';
 import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import {
-    hoursToSeconds,
-    minutesToSeconds,
-    secondsSinceMidnightToTimeStr
-} from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import { hoursToSeconds, secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
 import { GtfsInternalData, StopTime, Frequencies, Period } from './GtfsImportTypes';
 import Schedule, { SchedulePeriod } from 'transition-common/lib/services/schedules/Schedule';
@@ -136,7 +132,7 @@ const generateAndImportSchedules = async (
                 );
                 // save line and its schedules to cache file:
                 // FIXME: Remove this step? Line is not supposed to be modified
-                await linesDbQueries.update(line.getId(), line.attributes, 'id');
+                await linesDbQueries.update(line.getId(), line.attributes, { returning: 'id' });
                 // Save schedules for line
                 const saveSchedPromises = newSchedules.map((schedule) => {
                     scheduleDbQueries.create(schedule.attributes);


### PR DESCRIPTION
Also make sure individual operations that span many tables (like scenarios and schedules) are all inside transactions to avoid errors while saving those object to leave the object is an intermediate, unknown, state.

While doing so, to make transactions as fast and short as possible, the queries that involved reading/processing/writing now try to do it in a single database query, or favor batch inserts/updates/deletes.