### PR TITLE
Bring the service duplication operation server side 

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/types.db.ts
+++ b/packages/chaire-lib-backend/src/models/db/types.db.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+export type WithTransaction = {
+    transaction?: Knex.Transaction;
+};

--- a/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import { EventEmitter } from 'events';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import transitObjectRoutes from '../transitObjects.socketRoutes';
+import { duplicateServices } from '../../services/transitObjects/transitServices/ServiceDuplicator';
+
+const socketStub = new EventEmitter();
+transitObjectRoutes(socketStub);
+jest.mock('../../services/transitObjects/transitServices/ServiceDuplicator', () => {
+    return {
+        duplicateServices: jest.fn(),
+    };
+});
+const mockedDuplicateAndSave = duplicateServices as jest.MockedFunction<typeof duplicateServices>;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('Service duplication route', () => {
+    test('Duplicate with default options', (done) => {
+        const originalServices = [uuidV4(), uuidV4()];
+        const savedServices = {
+            [originalServices[0]]: uuidV4(), 
+            [originalServices[1]]: uuidV4()
+        };
+        mockedDuplicateAndSave.mockResolvedValueOnce(Status.createOk(savedServices));
+
+        socketStub.emit('transitServices.duplicate', originalServices, {}, (status) => {
+            expect(Status.isStatusOk(status)).toEqual(true);
+            expect(Status.unwrap(status)).toEqual(savedServices);
+            expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, {});
+            done();
+        });
+    });
+
+    test('Duplicate with options', (done) => {
+        const originalServices = [uuidV4(), uuidV4()];
+        const savedServices = {
+            [originalServices[0]]: uuidV4(), 
+            [originalServices[1]]: uuidV4()
+        };
+        const options = { newServiceSuffix: ' copy'}
+        mockedDuplicateAndSave.mockResolvedValueOnce(Status.createOk(savedServices));
+
+        socketStub.emit('transitServices.duplicate', originalServices, options, (status) => {
+            expect(Status.isStatusOk(status)).toEqual(true);
+            expect(Status.unwrap(status)).toEqual(savedServices);
+            expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, options);
+            done();
+        });
+    });
+
+    test('Duplicate where error occurred', (done) => {
+        const originalServices = [uuidV4(), uuidV4()];
+        mockedDuplicateAndSave.mockResolvedValueOnce(Status.createError('An error occurred'));
+
+        socketStub.emit('transitServices.duplicate', originalServices, {}, (status) => {
+            expect(Status.isStatusOk(status)).toEqual(false);
+            expect(Status.isStatusError(status)).toEqual(true);
+            expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, {});
+            done();
+        });
+    });
+});

--- a/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
+++ b/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
@@ -6,6 +6,7 @@
  */
 import { EventEmitter } from 'events';
 import transitObjectDataHandlers from '../services/transitObjects/TransitObjectsDataHandler';
+import { duplicateServices } from '../services/transitObjects/transitServices/ServiceDuplicator';
 
 function setupObjectSocketRoutes(socket: EventEmitter) {
     for (const lowerCasePlural in transitObjectDataHandlers) {
@@ -120,6 +121,16 @@ function setupObjectSocketRoutes(socket: EventEmitter) {
             );
         }
     }
+
+    // Add duplication sockets routes. We can't add them in the loop above
+    // because they are not part of the transitObjectsDataHandlers, as each
+    // object's duplication has different additional options
+
+    // Duplicate a service
+    socket.on('transitServices.duplicate', async (serviceIds: string[], options, callback) => {
+        const response = await duplicateServices(serviceIds, options);
+        callback(response);
+    });
 }
 
 // Add operations on object socket routes for each object of Transition

--- a/packages/transition-backend/src/services/gtfsImport/ServiceImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ServiceImporter.ts
@@ -16,7 +16,7 @@ import ServiceCollection from 'transition-common/lib/services/service/ServiceCol
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { ServiceImportData, GtfsImportData } from 'transition-common/lib/services/gtfs/GtfsImportTypes';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { getUniqueServiceName } from 'transition-common/lib/services/service/ServiceUtils';
+import { getUniqueServiceName } from '../transitObjects/transitServices/ServiceUtils';
 import { GtfsObjectImporter } from './GtfsObjectImporter';
 import { formatColor, GtfsInternalData } from './GtfsImportTypes';
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
@@ -346,7 +346,7 @@ export class ServiceImporter implements GtfsObjectImporter<ServiceImportData, Se
         if (existingService) {
             return existingService;
         }
-        serviceAttributes.name = getUniqueServiceName(this._existingServices, serviceAttributes.name || '');
+        serviceAttributes.name = await getUniqueServiceName(serviceAttributes.name || '');
         // Create a new service
         const newService = new Service(serviceAttributes, true);
         // TODO Save only at the end of the whole import, with a batch save

--- a/packages/transition-backend/src/services/transitObjects/transitServices/ServiceDuplicator.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitServices/ServiceDuplicator.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// This file contains functions related to the duplication and copy of the
+// services. Except for the high level database transactions, this file should
+// not contain any functions calling directly database queries. These should be
+// in the ServiceUtils.ts file.
+import { Knex } from 'knex';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import Service from 'transition-common/lib/services/service/Service';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { getServicesById, getUniqueServiceName, saveServices } from './ServiceUtils';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { WithTransaction } from 'chaire-lib-backend/lib/models/db/types.db';
+
+// TODO Add more options, like the complete name of the new service
+export type DuplicateServiceOptions = {
+    newServiceSuffix?: string;
+};
+
+/**
+ * Duplicate services and save them in the database.
+ *
+ * @param serviceIds The IDs of the services to duplicate
+ * @param options Duplication options
+ * @returns A status object a mapping of the previous service IDs to the new
+ * ones
+ */
+export const duplicateServices = async (
+    serviceIds: string[],
+    { transaction, ...options }: DuplicateServiceOptions & WithTransaction
+): Promise<Status.Status<{ [previousId: string]: string }>> => {
+    try {
+        // Nested function to require a transaction around the duplication
+        const duplicateWithTransaction = async (trx: Knex.Transaction) => {
+            const duplicatedServices: Service[] = [];
+            const oldNewIdMapping = {} as { [previousId: string]: string };
+            const services = await getServicesById(serviceIds, { transaction: trx });
+
+            for (const service of services) {
+                const duplicatedService = await duplicateService(service, { ...options, transaction: trx });
+                duplicatedServices.push(duplicatedService);
+                oldNewIdMapping[service.getId()] = duplicatedService.getId();
+            }
+
+            await saveServices(duplicatedServices, { transaction: trx });
+            return Status.createOk(oldNewIdMapping);
+        };
+        // Make sure the update is done in a transaction, use the one in the options if available
+        return transaction
+            ? await duplicateWithTransaction(transaction)
+            : await knex.transaction(duplicateWithTransaction);
+    } catch (error) {
+        console.log('An error occurred while duplicating services: ', error);
+        return Status.createError('An error occurred while duplicating services');
+    }
+};
+
+/**
+ * Duplicate a service and return the new service. The new service will have a
+ * unique name. It is not saved in the database at this point.
+ *
+ * @param service The service to duplicate
+ * @param options The service duplication options
+ * @returns The duplicated service object
+ * @throws {TrError} If a unique name for the service cannot be found
+ */
+const duplicateService = async (
+    service: Service,
+    { newServiceSuffix = '', transaction }: DuplicateServiceOptions & WithTransaction
+): Promise<Service> => {
+    // Clone the complete object instead of just the attributes to make sure all
+    // unique attributes are deleted from the original data and initialized on
+    // the new object
+    const clone = service.clone(true);
+    const newService = clone as Service;
+    newService.attributes.name = await getUniqueServiceName(
+        `${newService.attributes.name}${!_isBlank(newServiceSuffix) ? `${newServiceSuffix}` : ''}`,
+        { transaction }
+    );
+
+    return newService;
+};

--- a/packages/transition-backend/src/services/transitObjects/transitServices/ServiceUtils.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitServices/ServiceUtils.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// This file contains various utility functions related to the services. To
+// avoid dissiminating the database accesses, this is the place to put functions
+// that call the database queries to get or save part of the services.
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import { _makeStringUnique } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import dbQueries from '../../../models/db/transitServices.db.queries';
+import Service from 'transition-common/lib/services/service/Service';
+import { WithTransaction } from 'chaire-lib-backend/lib/models/db/types.db';
+import { Knex } from 'knex';
+
+/**
+ * Get services by their ID from the database
+ *
+ * @param {string[]} serviceIds The ID of the services
+ * @param {WithTransaction} options The optional transaction to use
+ * @returns {Promise<Service[]>} The service objects
+ * @throws {TrError} If an error occurs while querying the database
+ */
+export const getServicesById = async (
+    serviceIds: string[],
+    { transaction }: WithTransaction = {}
+): Promise<Service[]> => {
+    if (serviceIds.length === 0) {
+        return [];
+    }
+    const servicesAttributes = await dbQueries.collection({ serviceIds, transaction });
+    return servicesAttributes.map((attributes) => new Service(attributes, false));
+};
+
+/**
+ * Save services in the database. New services will be inserted, existing ones
+ * will be updated.
+ *
+ * @param services The services to save
+ * @param {WithTransaction} options The optional transaction to use. If not set,
+ * the operations are still run in a transaction
+ * @returns
+ * @throws {TrError} If an error occurs while saving the services
+ */
+export const saveServices = async (services: Service[], options: WithTransaction = {}): Promise<void> => {
+    // Split in new and existing services
+    const newServices = services.filter((service) => service.isNew());
+    const existingServices = services.filter((service) => !service.isNew());
+
+    const saveServicesWithTransaction = async (trx: Knex.Transaction) => {
+        const promises: Promise<unknown>[] = [];
+        if (newServices.length > 0) {
+            promises.push(
+                dbQueries.createMultiple(
+                    newServices.map((service) => service.attributes),
+                    { transaction: trx, returning: 'id' }
+                )
+            );
+        }
+        if (existingServices.length > 0) {
+            promises.push(
+                dbQueries.updateMultiple(
+                    existingServices.map((service) => service.attributes),
+                    { transaction: trx, returning: 'id' }
+                )
+            );
+        }
+        await Promise.all(promises);
+    };
+
+    // In a transaction, update and insert the services
+    return options.transaction
+        ? await saveServicesWithTransaction(options.transaction)
+        : await knex.transaction(saveServicesWithTransaction);
+};
+
+/**
+ * Get a unique name for a service by looking for duplicate names in the
+ * database and adding a suffix to the name.
+ *
+ * @param {string} serviceName The name to make unique
+ * @param {WithTransaction} options The optional transaction to use
+ * @returns {Promise<string>} The unique name
+ * @throws {TrError} If a unique name for the service cannot be found
+ */
+export const getUniqueServiceName = async (serviceName: string, options: WithTransaction = {}): Promise<string> => {
+    const similarNames = await dbQueries.getServiceNamesStartingWith(serviceName, options);
+    return _makeStringUnique(serviceName, similarNames);
+};

--- a/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceDuplicator.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceDuplicator.test.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import Service from 'transition-common/lib/services/service/Service';
+import { duplicateServices } from '../ServiceDuplicator';
+import { getServicesById, getUniqueServiceName, saveServices } from '../ServiceUtils';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+
+// Mock the knex transaction object.
+const transactionObjectMock = new Object(3);
+
+jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => {
+    const originalModule =
+        jest.requireActual<typeof import('chaire-lib-backend/lib/config/shared/db.config')>('chaire-lib-backend/lib/config/shared/db.config');
+
+    return {
+        ...originalModule,
+        transaction: jest.fn().mockImplementation(async (callback) => await callback(transactionObjectMock))
+    };
+});
+
+// Mock the ServiceUtils module
+const defaultSuffix = '-0';
+jest.mock('../ServiceUtils', () => ({
+    getUniqueServiceName: jest.fn().mockImplementation((name) => name + defaultSuffix),
+    getServicesById: jest.fn().mockImplementation((serviceIds) => 
+        serviceIds.map((id: string) => id === serviceAttributes1.id 
+            ? new Service(serviceAttributes1, false) 
+            : id === serviceAttributes2.id ? new Service(serviceAttributes2, false) : undefined)
+        .filter((service) => service !== undefined)),
+    saveServices: jest.fn().mockResolvedValue(undefined)
+}));
+const mockGetUniqueServiceName = getUniqueServiceName as jest.MockedFunction<typeof getUniqueServiceName>;
+const mockGetServicesById = getServicesById as jest.MockedFunction<typeof getServicesById>;
+const mockSaveServices = saveServices as jest.MockedFunction<typeof saveServices>;
+
+const serviceAttributes1 = {
+    id: uuidV4(),
+    name: 'Service1',
+    data: {
+        variables: {}
+    },
+    monday: true,
+    tuesday: true,
+    wednesday: true,
+    thursday: true,
+    friday: true,
+    saturday: false,
+    sunday: false,
+    start_date: '2020-01-01',
+    end_date: '2020-12-31',
+    is_frozen: false
+};
+
+const serviceAttributes2 = {
+    id: uuidV4(),
+    name: 'Service2',
+    data: {
+        variables: {}
+    },
+    monday: true,
+    tuesday: true,
+    wednesday: true,
+    thursday: true,
+    friday: true,
+    saturday: false,
+    sunday: false,
+    start_date: '2020-01-01',
+    end_date: '2020-12-31',
+    is_frozen: false
+};
+
+describe('duplicateAndSaveServices', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should duplicate and save a service with default options', async () => {
+        // Duplicate and save the service
+        const duplicateStatus = await duplicateServices([serviceAttributes1.id, serviceAttributes2.id], {});
+        expect(Status.isStatusOk(duplicateStatus)).toEqual(true);
+        const duplicatedServiceMapping = Status.unwrap(duplicateStatus);
+        expect(Object.keys(duplicatedServiceMapping).length).toEqual(2);
+
+        // Validate the inner calls
+        expect(mockGetUniqueServiceName).toHaveBeenCalledWith(serviceAttributes1.name, { transaction: transactionObjectMock });
+        expect(mockGetUniqueServiceName).toHaveBeenCalledWith(serviceAttributes2.name, { transaction: transactionObjectMock });
+        expect(mockGetServicesById).toHaveBeenCalledWith([serviceAttributes1.id, serviceAttributes2.id], { transaction: transactionObjectMock })
+        expect(mockSaveServices).toHaveBeenCalledTimes(1);
+        expect(mockSaveServices).toHaveBeenCalledWith(expect.anything(), { transaction: transactionObjectMock });
+        const savedServices = mockSaveServices.mock.calls[0][0];
+        expect(savedServices.length).toEqual(2);
+        const firstDuplicatedService = savedServices.find((service) => service.attributes.id === duplicatedServiceMapping[serviceAttributes1.id]);
+        expect(firstDuplicatedService).toBeDefined();
+        expect((firstDuplicatedService as Service).attributes).toEqual(expect.objectContaining({
+            ...serviceAttributes1,
+            id: duplicatedServiceMapping[serviceAttributes1.id],
+            name: serviceAttributes1.name + defaultSuffix
+        }));
+        const secondDuplicatedService = savedServices.find((service) => service.attributes.id === duplicatedServiceMapping[serviceAttributes2.id]);
+        expect(secondDuplicatedService).toBeDefined();
+        expect((secondDuplicatedService as Service).attributes).toEqual(expect.objectContaining({
+            ...serviceAttributes2,
+            id: duplicatedServiceMapping[serviceAttributes2.id],
+            name: serviceAttributes2.name + defaultSuffix
+        }));
+    });
+
+    it('should duplicate and save a service with default options and transaction', async () => {
+        const currentTransaction = new Object(2) as any;
+        expect(currentTransaction).not.toEqual(transactionObjectMock);
+
+        // Duplicate and save the service
+        const duplicateStatus = await duplicateServices([serviceAttributes1.id, serviceAttributes2.id], { transaction: currentTransaction});
+        expect(Status.isStatusOk(duplicateStatus)).toEqual(true);
+        const duplicatedServiceMapping = Status.unwrap(duplicateStatus);
+        expect(Object.keys(duplicatedServiceMapping).length).toEqual(2);
+
+        // Validate the inner calls
+        expect(mockGetUniqueServiceName).toHaveBeenCalledWith(serviceAttributes1.name, { transaction: currentTransaction });
+        expect(mockGetUniqueServiceName).toHaveBeenCalledWith(serviceAttributes2.name, { transaction: currentTransaction });
+        expect(mockGetServicesById).toHaveBeenCalledWith([serviceAttributes1.id, serviceAttributes2.id], { transaction: currentTransaction })
+        expect(mockSaveServices).toHaveBeenCalledTimes(1);
+        expect(mockSaveServices).toHaveBeenCalledWith(expect.anything(), { transaction: currentTransaction })
+        const savedServices = mockSaveServices.mock.calls[0][0];
+        expect(savedServices.length).toEqual(2);
+        const firstDuplicatedService = savedServices.find((service) => service.attributes.id === duplicatedServiceMapping[serviceAttributes1.id]);
+        expect(firstDuplicatedService).toBeDefined();
+        expect((firstDuplicatedService as Service).attributes).toEqual(expect.objectContaining({
+            ...serviceAttributes1,
+            id: duplicatedServiceMapping[serviceAttributes1.id],
+            name: serviceAttributes1.name + defaultSuffix
+        }));
+        const secondDuplicatedService = savedServices.find((service) => service.attributes.id === duplicatedServiceMapping[serviceAttributes2.id]);
+        expect(secondDuplicatedService).toBeDefined();
+        expect((secondDuplicatedService as Service).attributes).toEqual(expect.objectContaining({
+            ...serviceAttributes2,
+            id: duplicatedServiceMapping[serviceAttributes2.id],
+            name: serviceAttributes2.name + defaultSuffix
+        }));
+    });
+
+    it('should duplicate and save a service with a new service suffix', async () => {
+        const newServiceSuffix = '_copy';
+
+        // Duplicate and save the service
+        const duplicateStatus = await duplicateServices([serviceAttributes1.id, serviceAttributes2.id], { newServiceSuffix });
+        expect(Status.isStatusOk(duplicateStatus)).toEqual(true);
+        const duplicatedServiceMapping = Status.unwrap(duplicateStatus);
+        expect(Object.keys(duplicatedServiceMapping).length).toEqual(2);
+
+        // Validate the inner calls
+        expect(mockGetUniqueServiceName).toHaveBeenCalledWith(serviceAttributes1.name + newServiceSuffix, { transaction: transactionObjectMock });
+        expect(mockGetUniqueServiceName).toHaveBeenCalledWith(serviceAttributes2.name + newServiceSuffix, { transaction: transactionObjectMock });
+        expect(mockGetServicesById).toHaveBeenCalledWith([serviceAttributes1.id, serviceAttributes2.id], { transaction: transactionObjectMock })
+        expect(mockSaveServices).toHaveBeenCalledTimes(1);
+        expect(mockSaveServices).toHaveBeenCalledWith(expect.anything(), { transaction: transactionObjectMock });
+        const savedServices = mockSaveServices.mock.calls[0][0];
+        expect(savedServices.length).toEqual(2);
+        const firstDuplicatedService = savedServices.find((service) => service.attributes.id === duplicatedServiceMapping[serviceAttributes1.id]);
+        expect(firstDuplicatedService).toBeDefined();
+        expect((firstDuplicatedService as Service).attributes).toEqual(expect.objectContaining({
+            ...serviceAttributes1,
+            id: duplicatedServiceMapping[serviceAttributes1.id],
+            name: serviceAttributes1.name + newServiceSuffix + defaultSuffix
+        }));
+        const secondDuplicatedService = savedServices.find((service) => service.attributes.id === duplicatedServiceMapping[serviceAttributes2.id]);
+        expect(secondDuplicatedService).toBeDefined();
+        expect((secondDuplicatedService as Service).attributes).toEqual(expect.objectContaining({
+            ...serviceAttributes2,
+            id: duplicatedServiceMapping[serviceAttributes2.id],
+            name: serviceAttributes2.name + newServiceSuffix + defaultSuffix
+        }));
+    });
+
+    it('should return an error if an exception occurred while saving', async () => {
+        // Reject the save operation
+        const error = 'Error while saving';
+        mockSaveServices.mockRejectedValueOnce(new TrError(error, 'ERRORSAVING'));
+
+        // Duplicate the service
+        const duplicateStatus = await duplicateServices([serviceAttributes1.id], { });
+        expect(Status.isStatusError(duplicateStatus)).toEqual(true);
+        expect(mockSaveServices).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return an error if an exception occurred while duplicating', async () => {
+        // Reject the duplication operation
+        const error = 'Error while fetching services';
+        mockGetServicesById.mockRejectedValueOnce(new TrError(error, 'ERRORFETCHING'));
+
+        // Duplicate the service
+        const duplicateStatus = await duplicateServices([serviceAttributes1.id], { });
+        expect(Status.isStatusError(duplicateStatus)).toEqual(true);
+        expect(mockGetServicesById).toHaveBeenCalled();
+        expect(mockSaveServices).not.toHaveBeenCalled();
+    });
+
+    it('should not duplicate the service if there is an error getting unique name', async () => {
+        // Reject the duplication operation
+        const error = 'Error while fetching services';
+        mockGetUniqueServiceName.mockRejectedValueOnce(new TrError(error, 'ERRORGETTINGUNIQUE'));
+
+        // Duplicate the service
+        const duplicateStatus = await duplicateServices([serviceAttributes1.id], { });
+        expect(Status.isStatusError(duplicateStatus)).toEqual(true);
+        expect(mockGetServicesById).toHaveBeenCalled();
+        expect(mockSaveServices).not.toHaveBeenCalled();
+    });
+});

--- a/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceUtils.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceUtils.test.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import { getUniqueServiceName, getServicesById, saveServices } from '../ServiceUtils';
+import transitServicesDbQueries from '../../../../models/db/transitServices.db.queries';
+import Service, { ServiceAttributes } from 'transition-common/lib/services/service/Service';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+
+// Mock the knex transaction object.
+const transactionObjectMock = new Object(3);
+
+jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => {
+    const originalModule =
+        jest.requireActual<typeof import('chaire-lib-backend/lib/config/shared/db.config')>('chaire-lib-backend/lib/config/shared/db.config');
+
+    return {
+        ...originalModule,
+        transaction: jest.fn().mockImplementation(async (callback) => await callback(transactionObjectMock))
+    };
+});
+
+jest.mock('../../../../models/db/transitServices.db.queries', () => ({
+    getServiceNamesStartingWith: jest.fn(),
+    collection: jest.fn(),
+    createMultiple: jest.fn(),
+    updateMultiple: jest.fn()
+}));
+const mockGetServiceNamesStartingWith = transitServicesDbQueries.getServiceNamesStartingWith as jest.MockedFunction<typeof transitServicesDbQueries.getServiceNamesStartingWith>;   
+const mockCollection = transitServicesDbQueries.collection as jest.MockedFunction<typeof transitServicesDbQueries.collection>;   
+const mockCreateMultiple = transitServicesDbQueries.createMultiple as jest.MockedFunction<typeof transitServicesDbQueries.createMultiple>;   
+const mockUpdateMultiple = transitServicesDbQueries.updateMultiple as jest.MockedFunction<typeof transitServicesDbQueries.updateMultiple>;   
+
+const serviceAttributes1: ServiceAttributes = {  
+    id           : uuidV4(),
+    name         : 'Service test',
+    internal_id  : 'internalIdTest1',
+    is_frozen    : false,
+    is_enabled   : true,
+    monday       : true,
+    tuesday      : true,
+    wednesday    : true,
+    thursday     : true,
+    friday       : true,
+    saturday     : false,
+    sunday       : false,
+    start_date   : '2019-01-01',
+    end_date     : '2019-03-09',
+    only_dates   : [],
+    except_dates : ['2019-02-02'],
+    color        : '#ffffff',
+    description  : undefined,
+    simulation_id: undefined,
+    scheduled_lines: [],
+    data         : {
+      foo: 'bar',
+      bar: 'foo',
+      variables: {}
+    }
+  };
+  
+  const serviceAttributes2: ServiceAttributes = {
+    id           : uuidV4(),
+    name         : 'Service test 2',
+    internal_id  : 'internalIdTest2',
+    is_frozen    : false,
+    is_enabled   : true,
+    monday       : false,
+    tuesday      : false,
+    wednesday    : false,
+    thursday     : false,
+    friday       : false,
+    saturday     : true,
+    sunday       : true,
+    start_date   : '2018-02-24',
+    end_date     : '2018-08-16',
+    only_dates   : ['2018-09-14', '2018-09-15'],
+    except_dates : [],
+    color        : '#000000',
+    description  : 'description test',
+    scheduled_lines: [],
+    data         : {
+      foo2: 'bar2',
+      bar2: 'foo2',
+      variables: {}
+    }
+  };
+
+describe('getServicesById', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return an empty array when no service IDs are provided', async () => {
+        const serviceIds: string[] = [];
+
+        // Make the request to get the services by ID
+        const services = await getServicesById(serviceIds);
+        expect(services).toEqual([]);
+        expect(mockCollection).not.toHaveBeenCalled();
+    });
+
+    it('should return an array of service objects when valid service IDs are provided', async () => {
+        const serviceIds: string[] = [serviceAttributes1.id, serviceAttributes2.id];
+        
+        // Mock the database query to return the expected services
+        mockCollection.mockResolvedValueOnce([serviceAttributes1, serviceAttributes2]);
+
+        // Make the request to get the services by ID
+        const services = await getServicesById(serviceIds);
+
+        // Validate the results
+        expect(services).toEqual([new Service(serviceAttributes1, false), new Service(serviceAttributes2, false)]);
+        expect(mockCollection).toHaveBeenCalledWith({ serviceIds });
+    });
+
+    it('should return an array of service objects when valid service IDs are provided', async () => {
+        const currentTransaction = new Object(2) as any;
+        const serviceIds: string[] = [serviceAttributes1.id, serviceAttributes2.id];
+        
+        // Mock the database query to return the expected services
+        mockCollection.mockResolvedValueOnce([serviceAttributes1, serviceAttributes2]);
+
+        // Make the request to get the services by ID
+        const services = await getServicesById(serviceIds, { transaction: currentTransaction });
+
+        // Validate the results
+        expect(services).toEqual([new Service(serviceAttributes1, false), new Service(serviceAttributes2, false)]);
+        expect(mockCollection).toHaveBeenCalledWith({ serviceIds, transaction: currentTransaction });
+    });
+
+    it('should handle errors when querying the database', async () => {
+        const serviceIds: string[] = [serviceAttributes1.id, serviceAttributes2.id];
+        
+        // Mock an error to the database query
+        mockCollection.mockRejectedValueOnce(new TrError('Database error', 'ERRCODE'));
+        
+        await expect(getServicesById(serviceIds)).rejects.toThrow('Database error');
+        expect(mockCollection).toHaveBeenCalledWith({ serviceIds });
+    });
+});
+
+describe('saveServices', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    
+    it('should save services to the database, only existing services', async () => {
+        const services: Service[] = [new Service(serviceAttributes1, false), new Service(serviceAttributes2, false)];
+        
+        // Make the request to save the services
+        await saveServices(services);        
+        
+        // Validate that the createMultiple function was called with the correct parameters
+        expect(mockCreateMultiple).not.toHaveBeenCalled();
+        expect(mockUpdateMultiple).toHaveBeenCalledWith(services.map(service => service.attributes), { returning: 'id', transaction: transactionObjectMock});
+    });
+
+    it('should save services to the database, only new services', async () => {
+        const services: Service[] = [new Service(serviceAttributes1, true), new Service(serviceAttributes2, true)];
+        
+        // Make the request to save the services
+        await saveServices(services);
+        
+        // Validate that the createMultiple function was called with the correct parameters
+        expect(mockCreateMultiple).toHaveBeenCalledWith(services.map(service => service.attributes), { returning: 'id', transaction: transactionObjectMock});
+        expect(mockUpdateMultiple).not.toHaveBeenCalled();
+    });
+
+    it('should save services to the database, new and existing services', async () => {
+        const services: Service[] = [new Service(serviceAttributes1, false), new Service(serviceAttributes2, true)];
+        
+        // Make the request to save the services
+        await saveServices(services);
+        
+        // Validate that the createMultiple function was called with the correct parameters
+        expect(mockCreateMultiple).toHaveBeenCalledWith([serviceAttributes2], { returning: 'id', transaction: transactionObjectMock});
+        expect(mockUpdateMultiple).toHaveBeenCalledWith([serviceAttributes1], { returning: 'id', transaction: transactionObjectMock});
+    });
+
+    it('should save services to the database, new and existing services, with transaction', async () => {
+        const currentTransaction = new Object(2) as any;
+        expect(currentTransaction).not.toEqual(transactionObjectMock);
+        const services: Service[] = [new Service(serviceAttributes1, false), new Service(serviceAttributes2, true)];
+        
+        // Make the request to save the services, with the transaction
+        await saveServices(services,  { transaction: currentTransaction});
+        
+        // Validate that the createMultiple function was called with the correct parameters
+        expect(mockCreateMultiple).toHaveBeenCalledWith([serviceAttributes2], { returning: 'id', transaction: currentTransaction});
+        expect(mockUpdateMultiple).toHaveBeenCalledWith([serviceAttributes1], { returning: 'id', transaction: currentTransaction});
+    });
+    
+    it('should handle errors when saving services to the database', async () => {
+        const services: Service[] = [new Service(serviceAttributes2, true)];
+        
+        // Mock an error when saving the services
+        mockCreateMultiple.mockRejectedValueOnce(new TrError('Database error', 'ERRCODE'));
+        
+        // Expect the saveServices function to throw an error
+        await expect(saveServices(services)).rejects.toThrow('Database error');
+        
+        // Validate that the createMultiple function was called with the correct parameters
+        expect(mockCreateMultiple).toHaveBeenCalledWith([serviceAttributes2], { returning: 'id', transaction: transactionObjectMock});
+    });
+});
+
+describe('getUniqueServiceName', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return the name itself when no duplicate names exist', async () => {
+        const serviceName = 'Service1';
+        mockGetServiceNamesStartingWith.mockResolvedValueOnce([]);
+        const uniqueName = await getUniqueServiceName(serviceName);
+        expect(uniqueName).toBe(serviceName);
+        expect(mockGetServiceNamesStartingWith).toHaveBeenCalledWith(serviceName, {});
+    });
+
+    it('should return the name itself when no duplicate names exist, with transaction', async () => {
+        const currentTransaction = new Object(2) as any;
+        const serviceName = 'Service1';
+        mockGetServiceNamesStartingWith.mockResolvedValueOnce([]);
+        const uniqueName = await getUniqueServiceName(serviceName, { transaction: currentTransaction});
+        expect(uniqueName).toBe(serviceName);
+        expect(mockGetServiceNamesStartingWith).toHaveBeenCalledWith(serviceName, { transaction: currentTransaction });
+    });
+
+    it('should return a unique name by adding a suffix when duplicate names exist', async () => {
+        const serviceName = 'Service1';
+        // Assume that a service with the same name already exists in the database
+        mockGetServiceNamesStartingWith.mockResolvedValueOnce(['Service1', 'Service1-0']);
+
+        const uniqueName = await getUniqueServiceName(serviceName);
+        expect(uniqueName).not.toBe(serviceName);
+        expect(uniqueName).toEqual("Service1-1");
+        expect(mockGetServiceNamesStartingWith).toHaveBeenCalledWith(serviceName, {});
+    });
+
+    it('should handle errors when querying the database', async () => {
+        const serviceName = 'Service1';
+        // Assume that an error occurs when querying the database
+        mockGetServiceNamesStartingWith.mockRejectedValueOnce(new Error('Database error'));
+
+        await expect(getUniqueServiceName(serviceName)).rejects.toThrow('Database error');
+        expect(mockGetServiceNamesStartingWith).toHaveBeenCalledWith(serviceName, {});
+    });
+});

--- a/packages/transition-common/src/services/service/ServiceDuplicator.ts
+++ b/packages/transition-common/src/services/service/ServiceDuplicator.ts
@@ -17,6 +17,7 @@ export interface DuplicateServiceOptions {
     serviceCollection?: ServiceCollection;
 }
 
+// @deprecated Service duplication should be done in the backend, but this function is still used in the frontend by other object's duplication
 export const duplicateService = async (
     service: Service,
     { socket, serviceCollection, newServiceSuffix = '' }: DuplicateServiceOptions

--- a/packages/transition-common/src/services/service/ServiceUtils.ts
+++ b/packages/transition-common/src/services/service/ServiceUtils.ts
@@ -8,6 +8,7 @@ import { _makeStringUnique } from 'chaire-lib-common/lib/utils/LodashExtensions'
  * @param {ServiceCollection} services The service collection to look for
  * similar names
  * @param {string} serviceName The name to make unique
+ * @deprecated Use the backend version of this function, still called in the frontend by the service duplication operation
  */
 export const getUniqueServiceName = (services: ServiceCollection | undefined, serviceName: string): any => {
     if (!services) {


### PR DESCRIPTION
First and easiest step towards #297, but it prepares the approach:

* Add argument to database `collection` function to fetch partial collection of services
* Add database queries to fetch all services names starting with a certain prefix, to generate unique names
* Add operations to duplicate single or multiple services, with separate function for saving, which allow longer running duplicate operations (like agency or line duplication), to postpone saving when all objects are ready to reduce the transaction time.
* Add socket route to duplicate services
* Let the service duplication button use this new socket route to duplicate the service. Other callers, like line duplicator are not ready yet to call the new socket route. They will themselves be moved to backend later.