### PR TITLE
pyTransition: Clean extra "/" at the end of an URL

### DIFF
--- a/pyTransition/pyTransition/transition.py
+++ b/pyTransition/pyTransition/transition.py
@@ -29,7 +29,11 @@ class Transition:
     def __init__(self, url, username, password, token=None):
         if url is None or url == "":
             raise ValueError("URL cannot be empty.")
-        self.base_url = url
+
+        # Clean up extra characters in the URL, like a last /
+        cleaned_url = url.rstrip("/")
+
+        self.base_url = cleaned_url
 
         # To instantiate Transition instance from token only
         if username is None and password is None and token is not None:

--- a/pyTransition/tests/test_transition.py
+++ b/pyTransition/tests/test_transition.py
@@ -58,6 +58,15 @@ class TestTransition(unittest.TestCase):
                 self.test_url, self.test_username, self.test_password
             )
 
+    def test_url_cleanup(self):
+         with requests_mock.Mocker() as m:
+            m.post(f"{self.test_url}/token", text=self.test_token, status_code=200)
+
+            url_with_extra_chars = self.test_url+"/"
+            transition_instance = Transition(url_with_extra_chars, self.test_username, self.test_password)
+            self.assertEqual(transition_instance.base_url, self.test_url)
+            self.assertEqual(transition_instance.token, self.test_token)       
+            
     def test_creation_username_password(self):
         with requests_mock.Mocker() as m:
             m.post(f"{self.test_url}/token", text=self.test_token, status_code=200)


### PR DESCRIPTION
We already add the "/" at the begin of the path in the URLs, so we should remove the extra one if the use has added one when configuring his access