### PR TITLE
accept discouraged access tags for foot/bicycle routing

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/cycling.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/cycling.lua
@@ -51,7 +51,8 @@ function setup()
       'routing:bicycle',
       'bicycle',
       'permissive',
-      'designated'
+      'designated',
+      'discouraged' -- discouraged is for where it is dangerous, or bicycles should find another way, but permitted
     },
 
     access_tag_blacklist = Set {

--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking.lua
@@ -35,7 +35,8 @@ function setup()
       'foot',
       'routing:foot',
       'permissive',
-      'designated'
+      'designated',
+      'discouraged' -- discouraged is for where it is dangerous, or pedestrian should find another way, but permitted
     },
 
     service_access_tag_blacklist = Set {


### PR DESCRIPTION
discouraged is used to say it is permitted, but could be dangerous, we should accept routing with this tag