### PR TITLE
Move RoutingResult classes to chaire-lib, add tests and use common interface

### DIFF
--- a/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
@@ -12,6 +12,10 @@ import { RoutingOrTransitMode, RoutingMode } from '../../config/routingModes';
 import TrError, { ErrorMessage } from '../../utils/TrError';
 import { TrRoutingRoute } from '../trRouting/TrRoutingService';
 
+export const pathIsRoute = (path: Route | TrRoutingRoute | undefined): path is Route => {
+    return typeof (path as any).distance === 'number';
+};
+
 // TODO Add a common type to getPath(index)
 // TODO Have a common type for all results, not requiring the TResultData generic type
 /**
@@ -82,10 +86,6 @@ export class UnimodalRoutingResult implements RoutingResult<UnimodalRoutingResul
             type: 'FeatureCollection',
             features: [this._params.origin, this._params.destination]
         };
-    }
-
-    getWalkOnlyRoute(): Route | undefined {
-        return undefined;
     }
 
     async getPathGeojson(index: number, _options: { [key: string]: any } = {}): Promise<GeoJSON.FeatureCollection> {

--- a/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
@@ -21,6 +21,17 @@ export interface RoutingResult<TResultData> {
     hasAlternatives: () => boolean;
     getAlternativesCount: () => number;
     originDestinationToGeojson: () => GeoJSON.FeatureCollection<GeoJSON.Point>;
+    /**
+     * Get the geojson geometry of the path at the given index
+     *
+     * TODO Type the options so they are common for all routing results
+     *
+     * TODO Type the FeatureCollection properties
+     *
+     * @param index The index of the alternative path to fetch
+     * @param options Additional options to pass to generate geometries
+     * @returns A feature collection with the steps of the path
+     */
     getPathGeojson: (index: number, options: { [key: string]: any }) => Promise<GeoJSON.FeatureCollection>;
     getPath: (index: number) => TrRoutingRoute | Route | undefined;
     getRoutingMode(): RoutingOrTransitMode;

--- a/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
@@ -6,14 +6,18 @@
  */
 import _get from 'lodash/get';
 
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import { Route } from 'chaire-lib-common/lib/services/routing/RoutingService';
-import { RoutingOrTransitMode, RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import { TrRoutingRoute } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
+import Preferences from '../../config/Preferences';
+import { Route } from './RoutingService';
+import { RoutingOrTransitMode, RoutingMode } from '../../config/routingModes';
+import TrError, { ErrorMessage } from '../../utils/TrError';
+import { TrRoutingRoute } from '../trRouting/TrRoutingService';
 
 // TODO Add a common type to getPath(index)
-export interface RouteCalculatorResult<InputParams> {
+// TODO Have a common type for all results, not requiring the TResultData generic type
+/**
+ * Represents a routing result, for either uni or multimodal routing.
+ */
+export interface RoutingResult<TResultData> {
     hasAlternatives: () => boolean;
     getAlternativesCount: () => number;
     originDestinationToGeojson: () => GeoJSON.FeatureCollection<GeoJSON.Point>;
@@ -22,10 +26,15 @@ export interface RouteCalculatorResult<InputParams> {
     getRoutingMode(): RoutingOrTransitMode;
     hasError: () => boolean;
     getError: () => TrError | undefined;
-    getParams: () => InputParams;
+    getParams: () => TResultData;
 }
 
-export interface ResultParams {
+/**
+ * Describe a unimodal routing result data
+ *
+ * TODO Have one single type for the routing results, whether uni or multi-modal
+ */
+export interface UnimodalRoutingResultData {
     routingMode: RoutingMode;
     origin: GeoJSON.Feature<GeoJSON.Point>;
     destination: GeoJSON.Feature<GeoJSON.Point>;
@@ -33,9 +42,12 @@ export interface ResultParams {
     error?: { localizedMessage: ErrorMessage; error: string; errorCode: string };
 }
 
-export class UnimodalRouteCalculationResult implements RouteCalculatorResult<ResultParams> {
-    constructor(private _params: ResultParams) {
-        /** Nothin to do */
+/**
+ * Represents a unimodal routing result
+ */
+export class UnimodalRoutingResult implements RoutingResult<UnimodalRoutingResultData> {
+    constructor(private _params: UnimodalRoutingResultData) {
+        /** Nothing to do */
     }
 
     getRoutingMode(): RoutingOrTransitMode {
@@ -98,5 +110,5 @@ export class UnimodalRouteCalculationResult implements RouteCalculatorResult<Res
         return error !== undefined ? new TrError(error.error, error.errorCode, error.localizedMessage) : undefined;
     }
 
-    getParams = (): ResultParams => this._params;
+    getParams = (): UnimodalRoutingResultData => this._params;
 }

--- a/packages/chaire-lib-common/src/services/routing/TransitRoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/TransitRoutingResult.ts
@@ -80,17 +80,12 @@ export class TransitRoutingResult implements RoutingResult<TransitRoutingResultD
         return 'transit';
     }
 
-    // TODO Why do we return undefined for the walk only path? It should be a path. Refactor when the routing calculations are generalized
-    getPath(index: number): TrRoutingRoute | undefined {
+    getPath(index: number): Route | TrRoutingRoute | undefined {
         return index === this._walkOnlyPathIndex
-            ? undefined
+            ? this._params.walkOnlyPath
             : this._walkOnlyPathIndex !== -1 && index >= this._walkOnlyPathIndex
                 ? this._params.paths[index - 1]
                 : this._params.paths[index];
-    }
-
-    getWalkOnlyRoute(): Route | undefined {
-        return this._params.walkOnlyPath;
     }
 
     originDestinationToGeojson(): GeoJSON.FeatureCollection<GeoJSON.Point> {
@@ -161,7 +156,7 @@ export class TransitRoutingResult implements RoutingResult<TransitRoutingResultD
         };
     }
 
-    getWalkPathGeojson(): GeoJSON.FeatureCollection {
+    private getWalkPathGeojson(): GeoJSON.FeatureCollection {
         // TODO tahini: A route to geojson should be somewhere else than here
         if (!this._params.walkOnlyPath) {
             throw 'Walk only path not available!';

--- a/packages/chaire-lib-common/src/services/routing/TransitRoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/TransitRoutingResult.ts
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2022-2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _get from 'lodash/get';
+
+import Preferences from '../../config/Preferences';
+import { TrRoutingV2 } from '../../api/TrRouting';
+import { TrRoutingRoute } from '../trRouting/TrRoutingService';
+import { Route, RouteResults } from './RoutingService';
+import { getRouteByMode } from './RoutingUtils';
+import TrError, { ErrorMessage } from '../../utils/TrError';
+import { RoutingResult } from './RoutingResult';
+import { RoutingOrTransitMode } from '../../config/routingModes';
+
+export interface StepGeojsonProperties {
+    distanceMeters: number;
+    travelTimeSeconds: number;
+    color?: string;
+    stepSequence?: number;
+    mode?: string;
+    action?: 'walking' | 'ride';
+    type?: string;
+    departureTimeSeconds?: number;
+    agencyAcronym?: string;
+    agencyUuid?: string;
+    lineShortname?: string;
+    lineUuid?: string;
+    pathUuid?: string;
+    legSequenceInTrip?: number;
+    arrivalTimeSeconds?: number;
+    inVehicleTimeSeconds?: number;
+    inVehicleDistanceMeters?: number;
+}
+
+// TODO tahini: paths and walkOnlyPath should share a same type
+export interface TransitRoutingResultData {
+    origin: GeoJSON.Feature<GeoJSON.Point>;
+    destination: GeoJSON.Feature<GeoJSON.Point>;
+    paths: TrRoutingRoute[];
+    walkOnlyPath?: Route;
+    error?: { localizedMessage: ErrorMessage; error: string; errorCode: string };
+}
+
+export type SegmentToGeoJSON = (
+    boardingStep: TrRoutingV2.TripStepBoarding,
+    unboardingStep: TrRoutingV2.TripStepUnboarding,
+    completeData: boolean,
+    currentStepIndex: number
+) => Promise<GeoJSON.Feature<GeoJSON.LineString>>;
+
+export class TransitRoutingResult implements RoutingResult<TransitRoutingResultData> {
+    private _hasAlternatives: boolean;
+    private _walkOnlyPathIndex: number;
+
+    constructor(private _params: TransitRoutingResultData) {
+        this._hasAlternatives = this._params.paths.length > 1;
+
+        // Find the index at which to place the walk only path
+        if (this._params.walkOnlyPath) {
+            const walkPathDuration = this._params.walkOnlyPath.duration;
+            const walkIndex = this._params.paths.findIndex((path) => walkPathDuration <= path.totalTravelTime);
+            this._walkOnlyPathIndex = walkIndex >= 0 ? walkIndex : this._params.paths.length;
+        } else {
+            this._walkOnlyPathIndex = -1;
+        }
+    }
+
+    hasAlternatives(): boolean {
+        return this._walkOnlyPathIndex !== -1 ? true : this._hasAlternatives;
+    }
+
+    getAlternativesCount(): number {
+        return this._walkOnlyPathIndex !== -1 ? this._params.paths.length + 1 : this._params.paths.length;
+    }
+
+    getRoutingMode(): RoutingOrTransitMode {
+        return 'transit';
+    }
+
+    // TODO Why do we return undefined for the walk only path? It should be a path. Refactor when the routing calculations are generalized
+    getPath(index: number): TrRoutingRoute | undefined {
+        return index === this._walkOnlyPathIndex
+            ? undefined
+            : this._walkOnlyPathIndex !== -1 && index >= this._walkOnlyPathIndex
+                ? this._params.paths[index - 1]
+                : this._params.paths[index];
+    }
+
+    getWalkOnlyRoute(): Route | undefined {
+        return this._params.walkOnlyPath;
+    }
+
+    originDestinationToGeojson(): GeoJSON.FeatureCollection<GeoJSON.Point> {
+        return {
+            type: 'FeatureCollection',
+            features: [this._params.origin, this._params.destination]
+        };
+    }
+
+    private async generatePathGeojson(
+        steps: TrRoutingV2.TripStep[],
+        walkingSegmentsGeojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties>[],
+        options: { completeData?: boolean; segmentToGeojson?: SegmentToGeoJSON } = { completeData: false }
+    ): Promise<GeoJSON.FeatureCollection> {
+        //console.log('steps', steps);
+        const features: GeoJSON.Feature[] = [];
+        let walkingSegmentIndex = 0;
+        let currentStepIndex = 0;
+        const completeData = options.completeData || false;
+
+        // FIXME tahini Do something about the walking only segment
+        for (let i = 0, count = steps.length; i < count; i++) {
+            const step = steps[i];
+            if (step.action === 'walking') {
+                const walkingSegmentGeojson = walkingSegmentsGeojson[walkingSegmentIndex];
+                if (walkingSegmentGeojson) {
+                    // TODO: transferring at same node doesn't generate a path, we should deal with this.
+                    walkingSegmentGeojson.id = i + 2;
+                    // TODO tahini: this class shouldn't access preferences, properties could be passed somehow
+                    walkingSegmentGeojson.properties = {
+                        ...walkingSegmentGeojson.properties,
+                        color: _get(Preferences.current, 'transit.routing.transit.walkingSegmentsColor'),
+                        mode: 'walking',
+                        action: 'walking',
+                        stepSequence: currentStepIndex++
+                    };
+                    if (completeData) {
+                        walkingSegmentGeojson.properties = {
+                            ...walkingSegmentGeojson.properties,
+                            type: step.type,
+                            departureTimeSeconds: step.departureTime,
+                            arrivalTimeSeconds: step.arrivalTime
+                        };
+                    }
+                    features.push(walkingSegmentGeojson);
+                }
+                walkingSegmentIndex++;
+            }
+            if (step.action === 'boarding') {
+                const boardStep = step as TrRoutingV2.TripStepBoarding;
+                const nextStep = steps[i + 1];
+                if (nextStep && nextStep.action === 'unboarding' && nextStep.pathUuid && options.segmentToGeojson) {
+                    const stepGeoJSON = await options.segmentToGeojson(
+                        boardStep,
+                        nextStep,
+                        completeData,
+                        currentStepIndex
+                    );
+                    features.push(stepGeoJSON);
+                }
+                currentStepIndex++;
+            }
+        }
+
+        return {
+            type: 'FeatureCollection',
+            features
+        };
+    }
+
+    getWalkPathGeojson(): GeoJSON.FeatureCollection {
+        // TODO tahini: A route to geojson should be somewhere else than here
+        if (!this._params.walkOnlyPath) {
+            throw 'Walk only path not available!';
+        }
+        if (this._params.walkOnlyPath.geometry) {
+            const geojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties> = {
+                type: 'Feature',
+                geometry: this._params.walkOnlyPath.geometry,
+                properties: {
+                    distanceMeters: this._params.walkOnlyPath.distance,
+                    travelTimeSeconds: this._params.walkOnlyPath.duration,
+                    mode: 'walking',
+                    color: _get(Preferences.current, 'transit.routing.transit.walkingSegmentsColor')
+                } as StepGeojsonProperties
+            };
+            return {
+                type: 'FeatureCollection',
+                features: [geojson]
+            };
+        }
+        throw 'Geometry should be in the route, it is not';
+    }
+
+    async getPathGeojson(
+        index: number,
+        options: { completeData?: boolean; segmentToGeojson?: SegmentToGeoJSON } = { completeData: false }
+    ): Promise<GeoJSON.FeatureCollection> {
+        // TODO tahini: Path vs walk only route should be better managed
+        // Find whether we display a path, or the walk only route
+        if (index === this._walkOnlyPathIndex) {
+            return this.getWalkPathGeojson();
+        }
+        const path =
+            this._walkOnlyPathIndex !== -1 && index >= this._walkOnlyPathIndex
+                ? this._params.paths[index - 1]
+                : this._params.paths[index];
+        if (!path) {
+            return {
+                type: 'FeatureCollection',
+                features: []
+            };
+        }
+        const walkingSegmentsRoutingPromises: Promise<RouteResults>[] = [];
+        const steps = path.steps;
+
+        steps.forEach((step, stepIndex) => {
+            // TODO tahini: there's an assumption on the type of the next step. This class shouldn't be responsible for it
+            if (step.action !== 'walking') {
+                return;
+            }
+            const walkingStep = step as TrRoutingV2.TripStepWalking;
+            if (walkingStep.type === 'access') {
+                // access segment
+                const nextBoardingStep = steps[stepIndex + 1] as TrRoutingV2.TripStepBoarding;
+                const nodeCoordinates = nextBoardingStep.nodeCoordinates;
+                walkingSegmentsRoutingPromises.push(
+                    getRouteByMode(
+                        {
+                            type: 'Feature',
+                            geometry: { type: 'Point', coordinates: this._params.origin.geometry.coordinates },
+                            properties: {}
+                        },
+                        { type: 'Feature', geometry: { type: 'Point', coordinates: nodeCoordinates }, properties: {} }
+                    )
+                );
+            } else if (walkingStep.type === 'egress') {
+                // egress segment
+                const prevUnboardingStep = steps[stepIndex - 1] as TrRoutingV2.TripStepUnboarding;
+                const nodeCoordinates = prevUnboardingStep.nodeCoordinates;
+                walkingSegmentsRoutingPromises.push(
+                    getRouteByMode(
+                        { type: 'Feature', geometry: { type: 'Point', coordinates: nodeCoordinates }, properties: {} },
+                        {
+                            type: 'Feature',
+                            geometry: { type: 'Point', coordinates: this._params.destination.geometry.coordinates },
+                            properties: {}
+                        }
+                    )
+                );
+            } else if (walkingStep.type === 'transfer') {
+                const nextBoardingStep = steps[stepIndex + 1] as TrRoutingV2.TripStepBoarding;
+                const prevUnboardingStep = steps[stepIndex - 1] as TrRoutingV2.TripStepUnboarding;
+                const alightingNodeCoordinates = prevUnboardingStep.nodeCoordinates;
+                const boardingNodeCoordinates = nextBoardingStep.nodeCoordinates;
+                walkingSegmentsRoutingPromises.push(
+                    getRouteByMode(
+                        {
+                            type: 'Feature',
+                            geometry: { type: 'Point', coordinates: alightingNodeCoordinates },
+                            properties: {}
+                        },
+                        {
+                            type: 'Feature',
+                            geometry: { type: 'Point', coordinates: boardingNodeCoordinates },
+                            properties: {}
+                        }
+                    )
+                );
+            }
+        });
+
+        const walkingSegmentsGeojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties>[] = [];
+        const routingResults = await Promise.allSettled(walkingSegmentsRoutingPromises);
+        routingResults.forEach((walkingRoutingResult, routingIndex) => {
+            if (walkingRoutingResult.status === 'rejected') {
+                return;
+            }
+            const routes = walkingRoutingResult.value.routes;
+            if (routes.length === 0) {
+                return;
+            }
+            const route = routes[0];
+            if (route.geometry) {
+                const geojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties> = {
+                    type: 'Feature',
+                    geometry: route.geometry,
+                    properties: {
+                        distanceMeters: route.distance,
+                        travelTimeSeconds: route.duration
+                    } as StepGeojsonProperties
+                };
+                walkingSegmentsGeojson.push(geojson);
+            }
+        });
+
+        return await this.generatePathGeojson(steps, walkingSegmentsGeojson, options);
+    }
+
+    hasError(): boolean {
+        return this._params.error !== undefined;
+    }
+
+    getError(): TrError | undefined {
+        const error = this._params.error;
+        return error !== undefined ? new TrError(error.error, error.errorCode, error.localizedMessage) : undefined;
+    }
+
+    getParams = (): TransitRoutingResultData => this._params;
+}

--- a/packages/chaire-lib-common/src/services/routing/__tests__/RoutingResult.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/RoutingResult.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import TrError from "../../../utils/TrError";
+import { UnimodalRoutingResult } from "../RoutingResult";
+
+const origin = {
+    type: 'Feature' as const,
+    geometry: {
+        type: 'Point' as const,
+        coordinates: [0, 0],
+    },
+    properties: {},
+};
+const destination = {
+    type: 'Feature' as const,
+    geometry: {
+        type: 'Point' as const,
+        coordinates: [1, 1],
+    },
+    properties: {},
+};
+
+describe('UnimodalRoutingResult, with valid parameters', () => {
+    const routingMode = 'driving' as const;
+    const paths = [
+        {
+            distance: 1000,
+            duration: 600,
+            geometry: {
+                type: 'LineString' as const,
+                coordinates: [
+                    [0, 0],
+                    [1, 1],
+                ],
+            },
+            legs: []
+        },
+    ];
+
+    const validParams = {
+        routingMode,
+        origin,
+        destination,
+        paths
+    };
+
+    const routingResult = new UnimodalRoutingResult(validParams);
+
+    test('Should return right params', () => {
+        expect(routingResult.getParams()).toEqual(validParams);
+    });
+
+    test('Should return the right routing mode', () => {
+        expect(routingResult.getRoutingMode()).toEqual(routingMode);
+    });
+
+    test('Should return the right alternatives count', () => {
+        expect(routingResult.hasAlternatives()).toEqual(false);
+        expect(routingResult.getAlternativesCount()).toEqual(1);
+    });
+
+    test('Should return the right path', () => {
+        expect(routingResult.getPath(0)).toEqual(paths[0]);
+        expect(routingResult.getPath(1)).toBeUndefined();
+    });
+
+    test('Should return the right origin and destination', () => {
+        expect(routingResult.originDestinationToGeojson()).toEqual({
+            type: 'FeatureCollection',
+            features: [origin, destination]
+        });
+    });
+
+    test('Should return the right walk only route', () => {
+        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
+    });
+
+    test('Should return the right path geojson', async () => {
+        const geojson = await routingResult.getPathGeojson(0);
+        expect(geojson).toEqual({
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature',
+                    geometry: paths[0].geometry,
+                    properties: {
+                        distanceMeters: paths[0].distance,
+                        travelTimeSeconds: paths[0].duration,
+                        mode: routingMode,
+                        color: expect.anything()
+                    }
+                }
+            ]
+        });
+    });
+
+    test('Should return no error', () => {
+        expect(routingResult.hasError()).toEqual(false);
+        expect(routingResult.getError()).toBeUndefined();
+    });
+
+});
+
+describe('UnimodalRoutingResult, with error parameters', () => {
+    const routingMode = 'cycling' as const;
+    // No paths
+    const paths = [];
+    const error = {
+        localizedMessage: 'Error occurred',
+        error: 'Some error',
+        errorCode: '123',
+    };
+
+    const paramsWithError = {
+        routingMode,
+        origin,
+        destination,
+        paths,
+        error,
+    };
+
+    const routingResult = new UnimodalRoutingResult(paramsWithError);
+
+    it('Should return right params', () => {
+        expect(routingResult.getParams()).toEqual(paramsWithError);
+    });
+
+    test('Should return the right routing mode', () => {
+        expect(routingResult.getRoutingMode()).toEqual(routingMode);
+    });
+
+    test('Should return the right alternatives count', () => {
+        expect(routingResult.hasAlternatives()).toEqual(false);
+        expect(routingResult.getAlternativesCount()).toEqual(0);
+    });
+
+    test('Should return the right path', () => {
+        expect(routingResult.getPath(0)).toBeUndefined();
+        expect(routingResult.getPath(1)).toBeUndefined();
+    });
+
+    test('Should return the right origin and destination', () => {
+        expect(routingResult.originDestinationToGeojson()).toEqual({
+            type: 'FeatureCollection',
+            features: [origin, destination]
+        });
+    });
+
+    test('Should return the right walk only route', () => {
+        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
+    });
+
+    test('Should throw error if request and undefined path geojson', async () => {
+        let error: any = undefined;
+        try {
+            await routingResult.getPathGeojson(0);
+        } catch(err) {
+            error = err;
+        }
+        expect(error).toEqual('Geometry should be in the route, it is not');
+    });
+
+    test('Should return no error', () => {
+        expect(routingResult.hasError()).toEqual(true);
+        expect(routingResult.getError()).toEqual(new TrError(error.error, error.errorCode, error.localizedMessage));
+    });
+});

--- a/packages/chaire-lib-common/src/services/routing/__tests__/RoutingResult.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/RoutingResult.test.ts
@@ -75,10 +75,6 @@ describe('UnimodalRoutingResult, with valid parameters', () => {
         });
     });
 
-    test('Should return the right walk only route', () => {
-        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
-    });
-
     test('Should return the right path geojson', async () => {
         const geojson = await routingResult.getPathGeojson(0);
         expect(geojson).toEqual({
@@ -148,10 +144,6 @@ describe('UnimodalRoutingResult, with error parameters', () => {
             type: 'FeatureCollection',
             features: [origin, destination]
         });
-    });
-
-    test('Should return the right walk only route', () => {
-        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
     });
 
     test('Should throw error if request and undefined path geojson', async () => {

--- a/packages/chaire-lib-common/src/services/routing/__tests__/TransitRoutingResult.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/TransitRoutingResult.test.ts
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import TrError from "../../../utils/TrError";
+import { SegmentToGeoJSON, TransitRoutingResult } from "../TransitRoutingResult";
+import { pathNoTransferRouteResult } from '../../../test/services/trRouting/TrRoutingConstantsStubs';
+import { getRouteByMode } from "../RoutingUtils";
+
+jest.mock("../RoutingUtils", () => ({
+    getRouteByMode: jest.fn().mockImplementation(async (origin: GeoJSON.Feature<GeoJSON.Point>, destination: GeoJSON.Feature<GeoJSON.Point>, _mode) => ({
+        waypoints: [],
+        routes: [{
+            distance: 1000,
+            duration: 600,
+            geometry: {
+                type: 'LineString',
+                coordinates: [
+                    origin.geometry.coordinates,
+                    destination.geometry.coordinates,
+                ],
+            },
+            legs: []
+        }]
+    }))
+}));
+const mockedGetRouteByMode = getRouteByMode as jest.MockedFunction<typeof getRouteByMode>;
+
+describe('TransitRoutingResult, with valid single route, no walk only route', () => {
+
+    beforeEach(() => {
+        mockedGetRouteByMode.mockClear();
+    });
+
+    const validParams = {
+        origin: pathNoTransferRouteResult.originDestination[0],
+        destination: pathNoTransferRouteResult.originDestination[1],
+        paths: [pathNoTransferRouteResult],
+    }
+
+    const routingResult = new TransitRoutingResult(validParams);
+
+    test('Should return right params', () => {
+        expect(routingResult.getParams()).toEqual(validParams);
+    });
+
+    test('Should return the right routing mode', () => {
+        expect(routingResult.getRoutingMode()).toEqual('transit');
+    });
+
+    test('Should return the right alternatives count', () => {
+        expect(routingResult.hasAlternatives()).toEqual(false);
+        expect(routingResult.getAlternativesCount()).toEqual(1);
+    });
+
+    test('Should return the right path', () => {
+        expect(routingResult.getPath(0)).toEqual(pathNoTransferRouteResult);
+        expect(routingResult.getPath(1)).toBeUndefined();
+    });
+
+    test('Should return the right origin and destination', () => {
+        expect(routingResult.originDestinationToGeojson()).toEqual({
+            type: 'FeatureCollection',
+            features: [...pathNoTransferRouteResult.originDestination]
+        });
+    });
+
+    test('Should return the right walk only route', () => {
+        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
+    });
+
+    test('Should return the right path geojson', async () => {
+        // Just mock a simple boarding to unboarding location feature
+        const segmentToGeojson: SegmentToGeoJSON = jest.fn().mockImplementation(async (boardingStep, unboardingStep, completeData, index) => ({
+            type: 'Feature',
+            properties: {
+                stepSequence: index,
+                completeData
+            },
+            geometry: {
+                type: 'LineString',
+                coordinates: [
+                    boardingStep.nodeCoordinates,
+                    unboardingStep.nodeCoordinates
+                ]
+            }
+        }));
+        const geojson = await routingResult.getPathGeojson(0, { segmentToGeojson });
+        expect(segmentToGeojson).toHaveBeenCalledTimes(1);
+        expect(segmentToGeojson).toHaveBeenCalledWith(pathNoTransferRouteResult.steps[1], pathNoTransferRouteResult.steps[2], false, 1);
+        expect(mockedGetRouteByMode).toHaveBeenCalledTimes(2);
+        expect(geojson).toEqual({
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                id: expect.anything(),
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [pathNoTransferRouteResult.originDestination[0].geometry.coordinates, (pathNoTransferRouteResult.steps[1] as any).nodeCoordinates]
+                },
+                properties: {
+                    distanceMeters: 1000,
+                    travelTimeSeconds: 600,
+                    mode: 'walking',
+                    action: 'walking',
+                    stepSequence: 0,
+                    color: expect.anything()
+                }
+            },{
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [
+                        (pathNoTransferRouteResult.steps[1] as any).nodeCoordinates,
+                        (pathNoTransferRouteResult.steps[2] as any).nodeCoordinates
+                    ]
+                },
+                properties: {
+                    completeData: false,
+                    stepSequence: 1
+                }
+            }, {
+                type: 'Feature',
+                id: expect.anything(),
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [(pathNoTransferRouteResult.steps[2] as any).nodeCoordinates, pathNoTransferRouteResult.originDestination[1].geometry.coordinates]
+                },
+                properties: {
+                    distanceMeters: 1000,
+                    travelTimeSeconds: 600,
+                    mode: 'walking',
+                    action: 'walking',
+                    stepSequence: 2,
+                    color: expect.anything()
+                }
+            }]
+        });
+    });
+
+    test('Should return no error', () => {
+        expect(routingResult.hasError()).toEqual(false);
+        expect(routingResult.getError()).toBeUndefined();
+    });
+});
+
+describe('TransitRoutingResult, with valid single route, with walk only route', () => {
+
+    beforeEach(() => {
+        mockedGetRouteByMode.mockClear();
+    });
+
+    // Walk only route, faster than the first transit route
+    const walkOnlyRoute = {
+        distance: 2000,
+        duration: 1200,
+        geometry: {
+            type: 'LineString' as const,
+            coordinates: [
+                pathNoTransferRouteResult.originDestination[0].geometry.coordinates,
+                pathNoTransferRouteResult.originDestination[1].geometry.coordinates,
+            ],
+        },
+        legs: []
+    }
+    const validParams = {
+        origin: pathNoTransferRouteResult.originDestination[0],
+        destination: pathNoTransferRouteResult.originDestination[1],
+        paths: [pathNoTransferRouteResult],
+        walkOnlyPath: walkOnlyRoute
+    }
+
+    const routingResult = new TransitRoutingResult(validParams);
+
+    test('Should return right params', () => {
+        expect(routingResult.getParams()).toEqual(validParams);
+    });
+
+    test('Should return the right routing mode', () => {
+        expect(routingResult.getRoutingMode()).toEqual('transit');
+    });
+
+    test('Should return the right alternatives count', () => {
+        expect(routingResult.hasAlternatives()).toEqual(true);
+        expect(routingResult.getAlternativesCount()).toEqual(2);
+    });
+
+    test('Should return the right path', () => {
+        // FIXME The walk only path should be returned as the first path
+        expect(routingResult.getPath(0)).toBeUndefined();
+        expect(routingResult.getPath(1)).toEqual(pathNoTransferRouteResult);
+        expect(routingResult.getPath(2)).toBeUndefined();
+    });
+
+    test('Should return the right origin and destination', () => {
+        expect(routingResult.originDestinationToGeojson()).toEqual({
+            type: 'FeatureCollection',
+            features: [...pathNoTransferRouteResult.originDestination]
+        });
+    });
+
+    test('Should return the right walk only route', () => {
+        expect(routingResult.getWalkOnlyRoute()).toEqual(walkOnlyRoute);
+    });
+
+    test('Should return the right path geojson for the transit path', async () => {
+        // Just mock a simple boarding to unboarding location feature
+        const segmentToGeojson: SegmentToGeoJSON = jest.fn().mockImplementation(async (boardingStep, unboardingStep, completeData, index) => ({
+            type: 'Feature',
+            properties: {
+                stepSequence: index,
+                completeData
+            },
+            geometry: {
+                type: 'LineString',
+                coordinates: [
+                    boardingStep.nodeCoordinates,
+                    unboardingStep.nodeCoordinates
+                ]
+            }
+        }));
+        const geojson = await routingResult.getPathGeojson(1, { segmentToGeojson });
+        expect(segmentToGeojson).toHaveBeenCalledTimes(1);
+        expect(segmentToGeojson).toHaveBeenCalledWith(pathNoTransferRouteResult.steps[1], pathNoTransferRouteResult.steps[2], false, 1);
+        expect(mockedGetRouteByMode).toHaveBeenCalledTimes(2);
+        expect(geojson).toEqual({
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                id: expect.anything(),
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [pathNoTransferRouteResult.originDestination[0].geometry.coordinates, (pathNoTransferRouteResult.steps[1] as any).nodeCoordinates]
+                },
+                properties: {
+                    distanceMeters: 1000,
+                    travelTimeSeconds: 600,
+                    mode: 'walking',
+                    action: 'walking',
+                    stepSequence: 0,
+                    color: expect.anything()
+                }
+            },{
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [
+                        (pathNoTransferRouteResult.steps[1] as any).nodeCoordinates,
+                        (pathNoTransferRouteResult.steps[2] as any).nodeCoordinates
+                    ]
+                },
+                properties: {
+                    completeData: false,
+                    stepSequence: 1
+                }
+            }, {
+                type: 'Feature',
+                id: expect.anything(),
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [(pathNoTransferRouteResult.steps[2] as any).nodeCoordinates, pathNoTransferRouteResult.originDestination[1].geometry.coordinates]
+                },
+                properties: {
+                    distanceMeters: 1000,
+                    travelTimeSeconds: 600,
+                    mode: 'walking',
+                    action: 'walking',
+                    stepSequence: 2,
+                    color: expect.anything()
+                }
+            }]
+        });
+    });
+
+    test('Should return the right path geojson for the walk only path', async () => {
+        // Just mock a simple boarding to unboarding location feature
+        const segmentToGeojson: SegmentToGeoJSON = jest.fn();
+        const geojson = await routingResult.getPathGeojson(0, { segmentToGeojson });
+        expect(segmentToGeojson).not.toHaveBeenCalled();
+        expect(mockedGetRouteByMode).not.toHaveBeenCalled();
+        expect(geojson).toEqual({
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                geometry: walkOnlyRoute.geometry,
+                properties: {
+                    distanceMeters: walkOnlyRoute.distance,
+                    travelTimeSeconds: walkOnlyRoute.duration,
+                    mode: 'walking',
+                    color: expect.anything()
+                }
+            }]
+        });
+    });
+
+    test('Should return no error', () => {
+        expect(routingResult.hasError()).toEqual(false);
+        expect(routingResult.getError()).toBeUndefined();
+    });
+});
+
+describe('TransitRoutingResult, with error parameters', () => {
+
+    beforeEach(() => {
+        mockedGetRouteByMode.mockClear();
+    });
+
+    const error = {
+        localizedMessage: 'Error occurred',
+        error: 'Some error',
+        errorCode: '123',
+    };
+    const validParams = {
+        origin: pathNoTransferRouteResult.originDestination[0],
+        destination: pathNoTransferRouteResult.originDestination[1],
+        paths: [],
+        error
+    }
+
+    const routingResult = new TransitRoutingResult(validParams);
+
+    test('Should return right params', () => {
+        expect(routingResult.getParams()).toEqual(validParams);
+    });
+
+    test('Should return the right routing mode', () => {
+        expect(routingResult.getRoutingMode()).toEqual('transit');
+    });
+
+    test('Should return the right alternatives count', () => {
+        expect(routingResult.hasAlternatives()).toEqual(false);
+        expect(routingResult.getAlternativesCount()).toEqual(0);
+    });
+
+    test('Should return the right path', () => {
+        expect(routingResult.getPath(0)).toBeUndefined();
+        expect(routingResult.getPath(1)).toBeUndefined();
+    });
+
+    test('Should return the right origin and destination', () => {
+        expect(routingResult.originDestinationToGeojson()).toEqual({
+            type: 'FeatureCollection',
+            features: [...pathNoTransferRouteResult.originDestination]
+        });
+    });
+
+    test('Should return the right walk only route', () => {
+        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
+    });
+
+    test('Should return the right path geojson', async () => {
+        // Just mock a simple boarding to unboarding location feature
+        const segmentToGeojson: SegmentToGeoJSON = jest.fn();
+        const geojson = await routingResult.getPathGeojson(0, { segmentToGeojson });
+        expect(segmentToGeojson).not.toHaveBeenCalled();
+        expect(mockedGetRouteByMode).not.toHaveBeenCalled();
+        expect(geojson).toEqual({
+            type: 'FeatureCollection',
+            features: []
+        });
+    });
+
+    test('Should return no error', () => {
+        expect(routingResult.hasError()).toEqual(true);
+        expect(routingResult.getError()).toEqual(new TrError(error.error, error.errorCode, error.localizedMessage));
+    });
+});

--- a/packages/chaire-lib-common/src/services/routing/__tests__/TransitRoutingResult.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/TransitRoutingResult.test.ts
@@ -67,10 +67,6 @@ describe('TransitRoutingResult, with valid single route, no walk only route', ()
         });
     });
 
-    test('Should return the right walk only route', () => {
-        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
-    });
-
     test('Should return the right path geojson', async () => {
         // Just mock a simple boarding to unboarding location feature
         const segmentToGeojson: SegmentToGeoJSON = jest.fn().mockImplementation(async (boardingStep, unboardingStep, completeData, index) => ({
@@ -189,7 +185,7 @@ describe('TransitRoutingResult, with valid single route, with walk only route', 
 
     test('Should return the right path', () => {
         // FIXME The walk only path should be returned as the first path
-        expect(routingResult.getPath(0)).toBeUndefined();
+        expect(routingResult.getPath(0)).toEqual(walkOnlyRoute);
         expect(routingResult.getPath(1)).toEqual(pathNoTransferRouteResult);
         expect(routingResult.getPath(2)).toBeUndefined();
     });
@@ -199,10 +195,6 @@ describe('TransitRoutingResult, with valid single route, with walk only route', 
             type: 'FeatureCollection',
             features: [...pathNoTransferRouteResult.originDestination]
         });
-    });
-
-    test('Should return the right walk only route', () => {
-        expect(routingResult.getWalkOnlyRoute()).toEqual(walkOnlyRoute);
     });
 
     test('Should return the right path geojson for the transit path', async () => {
@@ -344,10 +336,6 @@ describe('TransitRoutingResult, with error parameters', () => {
             type: 'FeatureCollection',
             features: [...pathNoTransferRouteResult.originDestination]
         });
-    });
-
-    test('Should return the right walk only route', () => {
-        expect(routingResult.getWalkOnlyRoute()).toBeUndefined();
     });
 
     test('Should return the right path geojson', async () => {

--- a/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
@@ -11,7 +11,7 @@ import dbQueries from '../batchRouteResults.db.queries';
 import jobsDbQueries from '../jobs.db.queries';
 import { userAuthModel } from 'chaire-lib-backend/lib/services/auth/userAuthModel';
 import { JobAttributes } from 'transition-common/lib/services/jobs/Job';
-import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { cyclingRouteResult, simplePathResult, walkingRouteResult } from '../../../services/transitRouting/__tests__/TrRoutingResultStub';
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 
@@ -69,8 +69,7 @@ const resultByMode = { transit:
     new TransitRoutingResult({
         origin: origin,
         destination: destination,
-        paths: simplePathResult.routes,
-        maxWalkingTime: 300
+        paths: simplePathResult.routes
     }),
     walking: new UnimodalRoutingResult({
         routingMode: 'walking',

--- a/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
@@ -13,7 +13,7 @@ import { userAuthModel } from 'chaire-lib-backend/lib/services/auth/userAuthMode
 import { JobAttributes } from 'transition-common/lib/services/jobs/Job';
 import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
 import { cyclingRouteResult, simplePathResult, walkingRouteResult } from '../../../services/transitRouting/__tests__/TrRoutingResultStub';
-import { UnimodalRouteCalculationResult } from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 
 
 const objectName   = 'job';
@@ -72,7 +72,7 @@ const resultByMode = { transit:
         paths: simplePathResult.routes,
         maxWalkingTime: 300
     }),
-    walking: new UnimodalRouteCalculationResult({
+    walking: new UnimodalRoutingResult({
         routingMode: 'walking',
         origin: origin,
         destination: destination,
@@ -82,7 +82,7 @@ const resultByMode = { transit:
 
 const resultByMode2 = {
     ...resultByMode,
-    cycling: new UnimodalRouteCalculationResult({
+    cycling: new UnimodalRoutingResult({
         routingMode: 'walking',
         origin: origin,
         destination: destination,

--- a/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
+++ b/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
@@ -8,7 +8,7 @@ import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import { truncate, destroy } from 'chaire-lib-backend/lib/models/db/default.db.queries';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
-import { UnimodalRouteCalculationResult } from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { ResultsByMode } from 'transition-common/lib/services/transitRouting/TransitRoutingCalculator';
 import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
 import { OdTripRouteResult } from '../../services/transitRouting/types';
@@ -69,7 +69,7 @@ const attributesParser = ({
             if (key === 'transit') {
                 resultObject[key] = new TransitRoutingResult(results[key]);
             } else {
-                resultObject[key] = new UnimodalRouteCalculationResult(results[key]);
+                resultObject[key] = new UnimodalRoutingResult(results[key]);
             }
         });
     }

--- a/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
+++ b/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
@@ -10,7 +10,7 @@ import { truncate, destroy } from 'chaire-lib-backend/lib/models/db/default.db.q
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { ResultsByMode } from 'transition-common/lib/services/transitRouting/TransitRoutingCalculator';
-import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { OdTripRouteResult } from '../../services/transitRouting/types';
 
 const tableName = 'tr_batch_route_results';

--- a/packages/transition-backend/src/services/routingCalculation/RoutingCalculator.ts
+++ b/packages/transition-backend/src/services/routingCalculation/RoutingCalculator.ts
@@ -6,10 +6,7 @@
  */
 import _isEmpty from 'lodash/isEmpty';
 import trRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
-import {
-    ResultParams,
-    UnimodalRouteCalculationResult
-} from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
+import { UnimodalRoutingResultData, UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import TransitRouting from 'transition-common/lib/services/transitRouting/TransitRouting';
 import {
     ResultsByMode,
@@ -32,7 +29,7 @@ import {
 import { TrRoutingResultAccessibilityMap } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
 import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
 
-export type UnimodalRouteCalculationResultParams = ResultParams & {
+export type UnimodalRouteCalculationResultParams = UnimodalRoutingResultData & {
     pathsGeojson?: GeoJSON.FeatureCollection<GeoJSON.LineString>[];
 };
 
@@ -66,7 +63,7 @@ export async function calculateRoute(
 
     const routingResult: RouteCalculationResultParamsByMode = {};
     for (const routingMode in resultsByMode) {
-        const modeResult: UnimodalRouteCalculationResult | TransitRoutingResult = resultsByMode[routingMode];
+        const modeResult: UnimodalRoutingResult | TransitRoutingResult = resultsByMode[routingMode];
         routingResult[routingMode] = modeResult.getParams();
 
         if (withGeojson) {

--- a/packages/transition-backend/src/services/routingCalculation/RoutingCalculator.ts
+++ b/packages/transition-backend/src/services/routingCalculation/RoutingCalculator.ts
@@ -13,9 +13,9 @@ import {
     TransitRoutingCalculator
 } from 'transition-common/lib/services/transitRouting/TransitRoutingCalculator';
 import {
-    TransitResultParams,
+    TransitRoutingResultData,
     TransitRoutingResult
-} from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+} from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import TransitAccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
@@ -28,12 +28,13 @@ import {
 } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 import { TrRoutingResultAccessibilityMap } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
 import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
+import { SegmentToGeoJSONFromPaths } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
 
 export type UnimodalRouteCalculationResultParams = UnimodalRoutingResultData & {
     pathsGeojson?: GeoJSON.FeatureCollection<GeoJSON.LineString>[];
 };
 
-export type TransitRouteCalculationResultParams = TransitResultParams & {
+export type TransitRouteCalculationResultParams = TransitRoutingResultData & {
     pathsGeojson?: GeoJSON.FeatureCollection<GeoJSON.LineString>[];
 };
 
@@ -71,7 +72,8 @@ export async function calculateRoute(
             // so the paths currently in the database are loaded here
             const pathCollection = new PathCollection([], {});
             await pathCollection.loadFromServer(serviceLocator.socketEventManager);
-            const options = { completeData: false, pathCollection: pathCollection };
+            const segmentToGeojson = new SegmentToGeoJSONFromPaths(pathCollection);
+            const options = { completeData: false, segmentToGeojson: segmentToGeojson.segmentToGeoJSONFromPaths };
 
             const pathsGeojson: GeoJSON.FeatureCollection[] = [];
             for (let i = 0; i < modeResult.getAlternativesCount(); i++) {

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatchResult.ts
@@ -23,6 +23,7 @@ import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
 import { TransitDemandFromCsvRoutingAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import { pathIsRoute } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 
 const CSV_FILE_NAME = 'batchRoutingResults.csv';
 const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';
@@ -263,7 +264,7 @@ const generateCsvWithTransit = (
     let alternativeSequence = 0;
     for (let i = 0, countI = transitResult.getAlternativesCount(); i < countI; i++) {
         const alternative = transitResult.getPath(i);
-        if (alternative === undefined) {
+        if (pathIsRoute(alternative) || alternative === undefined) {
             // This is the walk only path
             continue;
         }

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -12,7 +12,7 @@ import { batchRoute, saveOdPairs } from '../TrRoutingBatch';
 import DataSource, { DataSourceType } from 'chaire-lib-common/lib/services/dataSource/DataSource';
 import TrRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
-import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { simplePathResult } from './TrRoutingResultStub';
 import odPairsDbQueries from '../../../models/db/odPairs.db.queries';
 import resultDbQueries from '../../../models/db/batchRouteResults.db.queries';
@@ -82,8 +82,7 @@ routeOdTripMock.mockImplementation(async (odTrip: BaseOdTrip) => ({
         transit: new TransitRoutingResult({
             origin: { type: 'Feature' as const, geometry: odTrip.attributes.origin_geography, properties: {} },
             destination: { type: 'Feature' as const, geometry: odTrip.attributes.destination_geography, properties: {} },
-            paths: simplePathResult.routes,
-            maxWalkingTime: 300
+            paths: simplePathResult.routes
         })
     }
 }));

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
@@ -13,10 +13,9 @@ import { simplePathResult, transferPathResult, alternativesResult, walkingRouteR
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import { createRoutingFileResultProcessor, generateFileOutputResults } from '../TrRoutingBatchResult';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
-import TransitRouting from 'transition-common/lib/services/transitRouting/TransitRouting';
 import { getDefaultCsvAttributes, getDefaultStepsAttributes } from '../ResultAttributes';
 import { routeToUserObject, TrRoutingBoardingStep, TrRoutingUnboardingStep, TrRoutingWalkingStep } from 'chaire-lib-common/src/services/trRouting/TrRoutingResultConversion';
-import { UnimodalRouteCalculationResult } from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import Path from 'transition-common/lib/services/path/Path';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
@@ -366,13 +365,13 @@ describe('Generate CSV results only', () => {
                 paths: simplePathResult.routes,
                 maxWalkingTime: 300
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,
@@ -423,13 +422,13 @@ describe('Generate CSV results only', () => {
                 paths: alternativesResult.routes,
                 maxWalkingTime: 300
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,
@@ -507,13 +506,13 @@ describe('Generate CSV results only', () => {
                     'transit:transitRouting:errors:NoResultFound'
                 ).export()
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,
@@ -625,13 +624,13 @@ describe('detailed csv only result', () => {
                 paths: simplePathResult.routes,
                 maxWalkingTime: 300
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,
@@ -949,13 +948,13 @@ describe('geometries result', () => {
                 paths: simplePathResult.routes,
                 maxWalkingTime: 300
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchResult.test.ts
@@ -8,8 +8,8 @@ import _cloneDeep from 'lodash/cloneDeep';
 import { ObjectWritableMock } from 'stream-mock';
 
 
-import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
-import { simplePathResult, transferPathResult, alternativesResult, walkingRouteResult, cyclingRouteResult } from './TrRoutingResultStub';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
+import { simplePathResult, alternativesResult, walkingRouteResult, cyclingRouteResult } from './TrRoutingResultStub';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import { createRoutingFileResultProcessor, generateFileOutputResults } from '../TrRoutingBatchResult';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
@@ -71,8 +71,7 @@ const results = {
     result: new TransitRoutingResult({
         origin: { type: 'Feature' as const, geometry: odTrip.attributes.origin_geography, properties: {} },
         destination: { type: 'Feature' as const, geometry: odTrip.attributes.destination_geography, properties: {} },
-        paths: simplePathResult.routes,
-        maxWalkingTime: 300
+        paths: simplePathResult.routes
     })
 }
 
@@ -319,8 +318,7 @@ describe('Generate CSV results only', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             })
         };
         const { csv, csvDetailed, geometries } = await generateFileOutputResults({
@@ -362,8 +360,7 @@ describe('Generate CSV results only', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             }),
             walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
@@ -419,8 +416,7 @@ describe('Generate CSV results only', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: alternativesResult.routes,
-                maxWalkingTime: 300
+                paths: alternativesResult.routes
             }),
             walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
@@ -499,7 +495,6 @@ describe('Generate CSV results only', () => {
                 origin: origin,
                 destination: destination,
                 paths: [],
-                maxWalkingTime: 300,
                 error: new TrError(
                     `cannot calculate transit route with trRouting: no_routing_found`,
                     ErrorCodes.NoRoutingFound,
@@ -550,8 +545,7 @@ describe('detailed csv only result', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             })
         };
         const { csv, csvDetailed, geometries } = await generateFileOutputResults({
@@ -621,8 +615,7 @@ describe('detailed csv only result', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             }),
             walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
@@ -703,8 +696,7 @@ describe('detailed csv only result', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: alternativesResult.routes,
-                maxWalkingTime: 300
+                paths: alternativesResult.routes
             })
         };
 
@@ -860,7 +852,6 @@ describe('detailed csv only result', () => {
                 origin: origin,
                 destination: destination,
                 paths: [],
-                maxWalkingTime: 300,
                 error: new TrError(
                     `cannot calculate transit route with trRouting: no_routing_found`,
                     ErrorCodes.NoRoutingFound,
@@ -907,8 +898,7 @@ describe('geometries result', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             })
         };
         
@@ -945,8 +935,7 @@ describe('geometries result', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             }),
             walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
@@ -1011,7 +1000,6 @@ describe('geometries result', () => {
                 origin: origin,
                 destination: destination,
                 paths: [],
-                maxWalkingTime: 300,
                 error: new TrError(
                     `cannot calculate transit route with trRouting: no_routing_found`,
                     ErrorCodes.NoRoutingFound,

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
@@ -11,7 +11,7 @@ import { simplePathResult,  alternativesResult, walkingRouteResult, cyclingRoute
 import { TransitRouting, TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
 import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
-import { UnimodalRouteCalculationResult } from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { ErrorCodes } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
 import { routeToUserObject } from 'chaire-lib-common/src/services/trRouting/TrRoutingResultConversion';
@@ -101,13 +101,13 @@ describe('Various scenario of trip calculation', () => {
                 paths: simplePathResult.routes,
                 maxWalkingTime: 300
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,
@@ -145,13 +145,13 @@ describe('Various scenario of trip calculation', () => {
                 paths: alternativesResult.routes,
                 maxWalkingTime: 300
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,
@@ -193,13 +193,13 @@ describe('Various scenario of trip calculation', () => {
                     'transit:transitRouting:errors:NoResultFound'
                 ).export()
             }),
-            walking: new UnimodalRouteCalculationResult({
+            walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
                 origin: origin,
                 destination: destination,
                 paths: walkingRouteResult.routes
             }),
-            cycling: new UnimodalRouteCalculationResult({
+            cycling: new UnimodalRoutingResult({
                 routingMode: 'cycling',
                 origin: origin,
                 destination: destination,

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingOdTrip.test.ts
@@ -10,7 +10,7 @@ import routeOdTrip from '../TrRoutingOdTrip';
 import { simplePathResult,  alternativesResult, walkingRouteResult, cyclingRouteResult } from './TrRoutingResultStub';
 import { TransitRouting, TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
-import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { ErrorCodes } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
@@ -61,8 +61,7 @@ describe('Various scenario of trip calculation', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             })
         };
         calculateMock.mockResolvedValue(resultByMode);
@@ -98,8 +97,7 @@ describe('Various scenario of trip calculation', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: simplePathResult.routes,
-                maxWalkingTime: 300
+                paths: simplePathResult.routes
             }),
             walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
@@ -142,8 +140,7 @@ describe('Various scenario of trip calculation', () => {
             new TransitRoutingResult({
                 origin: origin,
                 destination: destination,
-                paths: alternativesResult.routes,
-                maxWalkingTime: 300
+                paths: alternativesResult.routes
             }),
             walking: new UnimodalRoutingResult({
                 routingMode: 'walking',
@@ -186,7 +183,6 @@ describe('Various scenario of trip calculation', () => {
                 origin: origin,
                 destination: destination,
                 paths: [],
-                maxWalkingTime: 300,
                 error: new TrError(
                     `cannot calculate transit route with trRouting: no_routing_found`,
                     ErrorCodes.NoRoutingFound,
@@ -234,8 +230,7 @@ test('Test reverse OD', async () => {
         new TransitRoutingResult({
             origin: origin,
             destination: destination,
-            paths: simplePathResult.routes,
-            maxWalkingTime: 300
+            paths: simplePathResult.routes
         })
     };
     calculateMock.mockResolvedValue(resultByMode);

--- a/packages/transition-common/src/services/transitRouting/TransitRoutingCalculator.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRoutingCalculator.ts
@@ -16,7 +16,7 @@ import { TransitMode, RoutingMode } from 'chaire-lib-common/lib/config/routingMo
 import { RouteResults } from 'chaire-lib-common/lib/services/routing/RoutingService';
 import { TrRoutingRouteResult } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
 import { TransitRoutingResult } from './TransitRoutingResult';
-import { UnimodalRouteCalculationResult } from './RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { HostPort, TransitRouteQueryOptions } from 'chaire-lib-common/lib/api/TrRouting';
 
 type TransitOrRouteCalculatorResult =
@@ -36,7 +36,7 @@ const resultIsRouting = (
 };
 
 export type ResultsByMode = {
-    [key in RoutingMode]?: UnimodalRouteCalculationResult;
+    [key in RoutingMode]?: UnimodalRoutingResult;
 } & {
     transit?: TransitRoutingResult;
 };
@@ -91,7 +91,7 @@ export class TransitRoutingCalculator {
                     error: TrError.isTrError(routingResult.result) ? routingResult.result.export() : undefined
                 });
             } else if (routingMode !== 'transit') {
-                results[routingMode] = new UnimodalRouteCalculationResult({
+                results[routingMode] = new UnimodalRoutingResult({
                     routingMode,
                     origin: originDestination.features[0],
                     destination: originDestination.features[1],

--- a/packages/transition-common/src/services/transitRouting/TransitRoutingCalculator.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRoutingCalculator.ts
@@ -15,7 +15,7 @@ import { routingServiceManager as trRoutingServiceManager } from 'chaire-lib-com
 import { TransitMode, RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
 import { RouteResults } from 'chaire-lib-common/lib/services/routing/RoutingService';
 import { TrRoutingRouteResult } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
-import { TransitRoutingResult } from './TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { HostPort, TransitRouteQueryOptions } from 'chaire-lib-common/lib/api/TrRouting';
 
@@ -78,7 +78,9 @@ export class TransitRoutingCalculator {
                 // walking is always added when calculating transit, so it can't be undefined
                 const walkingRouteResult = routingResults.find((result) => result.routingMode === 'walking');
                 const walkOnlyPath =
-                    walkingRouteResult && !TrError.isTrError(walkingRouteResult.result)
+                    walkingRouteResult &&
+                    !TrError.isTrError(walkingRouteResult.result) &&
+                    (walkingRouteResult.result as RouteResults).routes[0].duration <= maxWalkingTime
                         ? (walkingRouteResult.result as RouteResults).routes[0]
                         : undefined;
 
@@ -87,7 +89,6 @@ export class TransitRoutingCalculator {
                     destination: originDestination.features[1],
                     paths: TrError.isTrError(routingResult.result) ? [] : routingResult.result.routes,
                     walkOnlyPath,
-                    maxWalkingTime: maxWalkingTime,
                     error: TrError.isTrError(routingResult.result) ? routingResult.result.export() : undefined
                 });
             } else if (routingMode !== 'transit') {

--- a/packages/transition-common/src/services/transitRouting/TransitRoutingResult.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRoutingResult.ts
@@ -14,7 +14,7 @@ import { getRouteByMode } from 'chaire-lib-common/lib/services/routing/RoutingUt
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import PathCollection from '../path/PathCollection';
 import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import { RouteCalculatorResult } from './RouteCalculatorResult';
+import { RoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
 
 interface StepGeojsonProperties {
@@ -47,7 +47,7 @@ export interface TransitResultParams {
     error?: { localizedMessage: ErrorMessage; error: string; errorCode: string };
 }
 
-export class TransitRoutingResult implements RouteCalculatorResult<TransitResultParams> {
+export class TransitRoutingResult implements RoutingResult<TransitResultParams> {
     private _hasAlternatives: boolean;
     private _walkOnlyPathIndex: number;
 

--- a/packages/transition-common/src/services/transitRouting/TransitRoutingResult.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRoutingResult.ts
@@ -6,337 +6,72 @@
  */
 import _get from 'lodash/get';
 
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
-import { TrRoutingRoute } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
-import { Route, RouteResults } from 'chaire-lib-common/lib/services/routing/RoutingService';
-import { getRouteByMode } from 'chaire-lib-common/lib/services/routing/RoutingUtils';
-import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import PathCollection from '../path/PathCollection';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import { RoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
-import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import { SegmentToGeoJSON, StepGeojsonProperties } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 
-interface StepGeojsonProperties {
-    distanceMeters: number;
-    travelTimeSeconds: number;
-    color?: string;
-    stepSequence?: number;
-    mode?: string;
-    action?: 'walking' | 'ride';
-    type?: string;
-    departureTimeSeconds?: number;
-    agencyAcronym?: string;
-    agencyUuid?: string;
-    lineShortname?: string;
-    lineUuid?: string;
-    pathUuid?: string;
-    legSequenceInTrip?: number;
-    arrivalTimeSeconds?: number;
-    inVehicleTimeSeconds?: number;
-    inVehicleDistanceMeters?: number;
-}
-
-// TODO tahini: paths and walkOnlyPath should share a same type
-export interface TransitResultParams {
-    origin: GeoJSON.Feature<GeoJSON.Point>;
-    destination: GeoJSON.Feature<GeoJSON.Point>;
-    paths: TrRoutingRoute[];
-    walkOnlyPath?: Route;
-    maxWalkingTime?: number | undefined;
-    error?: { localizedMessage: ErrorMessage; error: string; errorCode: string };
-}
-
-export class TransitRoutingResult implements RoutingResult<TransitResultParams> {
-    private _hasAlternatives: boolean;
-    private _walkOnlyPathIndex: number;
-
-    constructor(private _params: TransitResultParams) {
-        this._hasAlternatives = this._params.paths.length > 1;
-
-        // Find the index at which to place the walk only path
-        if (this._params.walkOnlyPath) {
-            const walkPathDuration = this._params.walkOnlyPath.duration;
-            if (this._params.maxWalkingTime && this._params.maxWalkingTime < walkPathDuration) {
-                this._walkOnlyPathIndex = -1;
-            } else {
-                const walkIndex = this._params.paths.findIndex((path) => walkPathDuration <= path.totalTravelTime);
-                this._walkOnlyPathIndex = walkIndex >= 0 ? walkIndex : this._params.paths.length;
-            }
-        } else {
-            this._walkOnlyPathIndex = -1;
-        }
+export class SegmentToGeoJSONFromPaths {
+    constructor(private _pathCollection: PathCollection) {
+        /** Nothing to do */
     }
 
-    hasAlternatives(): boolean {
-        return this._walkOnlyPathIndex !== -1 ? true : this._hasAlternatives;
-    }
-
-    getAlternativesCount(): number {
-        return this._walkOnlyPathIndex !== -1 ? this._params.paths.length + 1 : this._params.paths.length;
-    }
-
-    getRoutingMode(): RoutingOrTransitMode {
-        return 'transit';
-    }
-
-    getPath(index: number): TrRoutingRoute | undefined {
-        return index === this._walkOnlyPathIndex
-            ? undefined
-            : this._walkOnlyPathIndex !== -1 && index >= this._walkOnlyPathIndex
-                ? this._params.paths[index - 1]
-                : this._params.paths[index];
-    }
-
-    getWalkOnlyRoute(): Route | undefined {
-        return this._params.walkOnlyPath;
-    }
-
-    originDestinationToGeojson(): GeoJSON.FeatureCollection<GeoJSON.Point> {
-        return {
-            type: 'FeatureCollection',
-            features: [this._params.origin, this._params.destination]
+    segmentToGeoJSONFromPaths: SegmentToGeoJSON = async (
+        boardStep: TrRoutingV2.TripStepBoarding,
+        unboardStep: TrRoutingV2.TripStepUnboarding,
+        completeData: boolean,
+        currentStepIndex: number
+    ): Promise<GeoJSON.Feature<GeoJSON.LineString>> => {
+        let properties: StepGeojsonProperties = {
+            distanceMeters: unboardStep.inVehicleDistance,
+            travelTimeSeconds: unboardStep.inVehicleTime,
+            stepSequence: currentStepIndex,
+            action: 'ride',
+            mode: boardStep.mode
         };
-    }
-
-    private async generatePathGeojson(
-        steps: TrRoutingV2.TripStep[],
-        walkingSegmentsGeojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties>[],
-        options: { completeData?: boolean; pathCollection?: PathCollection } = { completeData: false }
-    ): Promise<GeoJSON.FeatureCollection> {
-        //console.log('steps', steps);
-        const features: GeoJSON.Feature[] = [];
-        let walkingSegmentIndex = 0;
-        let currentStepIndex = 0;
-        const completeData = options.completeData || false;
-        const pathCollection: PathCollection = options.pathCollection || serviceLocator.collectionManager?.get('paths');
-
-        // FIXME tahini Do something about the walking only segment
-        for (let i = 0, count = steps.length; i < count; i++) {
-            const step = steps[i];
-            if (step.action === 'walking') {
-                const walkingSegmentGeojson = walkingSegmentsGeojson[walkingSegmentIndex];
-                if (walkingSegmentGeojson) {
-                    // TODO: transferring at same node doesn't generate a path, we should deal with this.
-                    walkingSegmentGeojson.id = i + 2;
-                    // TODO tahini: this class shouldn't access preferences, properties could be passed somehow
-                    walkingSegmentGeojson.properties = {
-                        ...walkingSegmentGeojson.properties,
-                        color: _get(Preferences.current, 'transit.routing.transit.walkingSegmentsColor'),
-                        mode: 'walking',
-                        action: 'walking',
-                        stepSequence: currentStepIndex++
-                    };
-                    if (completeData) {
-                        walkingSegmentGeojson.properties = {
-                            ...walkingSegmentGeojson.properties,
-                            type: step.type,
-                            departureTimeSeconds: step.departureTime,
-                            arrivalTimeSeconds: step.arrivalTime
-                        };
-                    }
-                    features.push(walkingSegmentGeojson);
-                }
-                walkingSegmentIndex++;
-            }
-            if (step.action === 'boarding') {
-                const boardStep = step as TrRoutingV2.TripStepBoarding;
-                const nextStep = steps[i + 1];
-                if (nextStep && nextStep.action === 'unboarding' && nextStep.pathUuid && pathCollection) {
-                    const unboardStep = nextStep as TrRoutingV2.TripStepUnboarding;
-                    const path = pathCollection.getById(unboardStep.pathUuid);
-                    if (path && path.geometry) {
-                        const pathCoordinates = path.geometry.coordinates;
-                        const pathSegments = path.properties.segments;
-                        const startSequence = step.legSequenceInTrip - 1;
-                        const endSequence = unboardStep.legSequenceInTrip - 1;
-                        const pathCoordinatesStartIndex = pathSegments[startSequence];
-                        const pathCoordinatesEndIndex =
-                            pathSegments.length - 1 >= endSequence + 1
-                                ? pathSegments[endSequence + 1]
-                                : pathCoordinates.length - 1;
-                        const segmentCoordinates = pathCoordinates.slice(
-                            pathCoordinatesStartIndex,
-                            pathCoordinatesEndIndex + 1
-                        ); // slice does not include end index
-                        let properties: StepGeojsonProperties = {
-                            distanceMeters: unboardStep.inVehicleDistance,
-                            travelTimeSeconds: unboardStep.inVehicleTime,
-                            color: path.properties.color,
-                            stepSequence: currentStepIndex++,
-                            action: 'ride'
-                        };
-                        if (completeData) {
-                            properties = {
-                                ...properties,
-                                departureTimeSeconds: boardStep.departureTime,
-                                agencyAcronym: boardStep.agencyAcronym,
-                                agencyUuid: boardStep.agencyUuid,
-                                lineShortname: boardStep.lineShortname,
-                                lineUuid: boardStep.lineUuid,
-                                pathUuid: boardStep.pathUuid,
-                                mode: boardStep.mode,
-                                legSequenceInTrip: boardStep.legSequenceInTrip,
-                                arrivalTimeSeconds: unboardStep.arrivalTime
-                            };
-                        }
-                        features.push({
-                            type: 'Feature',
-                            id: i + 2,
-                            properties,
-                            geometry: {
-                                type: 'LineString',
-                                coordinates: segmentCoordinates
-                            }
-                        });
-                    }
-                }
-            }
+        if (completeData) {
+            properties = {
+                ...properties,
+                departureTimeSeconds: boardStep.departureTime,
+                agencyAcronym: boardStep.agencyAcronym,
+                agencyUuid: boardStep.agencyUuid,
+                lineShortname: boardStep.lineShortname,
+                lineUuid: boardStep.lineUuid,
+                pathUuid: boardStep.pathUuid,
+                legSequenceInTrip: boardStep.legSequenceInTrip,
+                arrivalTimeSeconds: unboardStep.arrivalTime
+            };
         }
 
-        return {
-            type: 'FeatureCollection',
-            features
-        };
-    }
+        const path = this._pathCollection.getById(unboardStep.pathUuid);
+        if (path && path.geometry) {
+            const pathCoordinates = path.geometry.coordinates;
+            const pathSegments = path.properties.segments;
+            const startSequence = boardStep.legSequenceInTrip - 1;
+            const endSequence = unboardStep.legSequenceInTrip - 1;
+            const pathCoordinatesStartIndex = pathSegments[startSequence];
+            const pathCoordinatesEndIndex =
+                pathSegments.length - 1 >= endSequence + 1 ? pathSegments[endSequence + 1] : pathCoordinates.length - 1;
+            const segmentCoordinates = pathCoordinates.slice(pathCoordinatesStartIndex, pathCoordinatesEndIndex + 1); // slice does not include end index
+            properties['color'] = path.properties.color;
 
-    getWalkPathGeojson(): GeoJSON.FeatureCollection {
-        // TODO tahini: A route to geojson should be somewhere else than here
-        if (!this._params.walkOnlyPath) {
-            throw 'Walk only path not available!';
-        }
-        if (this._params.walkOnlyPath.geometry) {
-            const geojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties> = {
+            return {
                 type: 'Feature',
-                geometry: this._params.walkOnlyPath.geometry,
-                properties: {
-                    distanceMeters: this._params.walkOnlyPath.distance,
-                    travelTimeSeconds: this._params.walkOnlyPath.duration,
-                    mode: 'walking',
-                    color: _get(Preferences.current, 'transit.routing.transit.walkingSegmentsColor')
-                } as StepGeojsonProperties
-            };
-            return {
-                type: 'FeatureCollection',
-                features: [geojson]
+                id: currentStepIndex,
+                properties,
+                geometry: {
+                    type: 'LineString',
+                    coordinates: segmentCoordinates
+                }
             };
         }
-        throw 'Geometry should be in the route, it is not';
-    }
-
-    async getPathGeojson(
-        index: number,
-        options: { completeData?: boolean; pathCollection?: PathCollection } = { completeData: false }
-    ): Promise<GeoJSON.FeatureCollection> {
-        // TODO tahini: Path vs walk only route should be better managed
-        // Find whether we display a path, or the walk only route
-        if (index === this._walkOnlyPathIndex) {
-            return this.getWalkPathGeojson();
-        }
-        const path =
-            this._walkOnlyPathIndex !== -1 && index >= this._walkOnlyPathIndex
-                ? this._params.paths[index - 1]
-                : this._params.paths[index];
-        if (!path) {
-            return {
-                type: 'FeatureCollection',
-                features: []
-            };
-        }
-        const walkingSegmentsRoutingPromises: Promise<RouteResults>[] = [];
-        const steps = path.steps;
-
-        steps.forEach((step, stepIndex) => {
-            // TODO tahini: there's an assumption on the type of the next step. This class shouldn't be responsible for it
-            if (step.action !== 'walking') {
-                return;
+        return {
+            type: 'Feature',
+            id: currentStepIndex,
+            properties,
+            geometry: {
+                type: 'LineString',
+                coordinates: [boardStep.nodeCoordinates, unboardStep.nodeCoordinates]
             }
-            const walkingStep = step as TrRoutingV2.TripStepWalking;
-            if (walkingStep.type === 'access') {
-                // access segment
-                const nextBoardingStep = steps[stepIndex + 1] as TrRoutingV2.TripStepBoarding;
-                const nodeCoordinates = nextBoardingStep.nodeCoordinates;
-                walkingSegmentsRoutingPromises.push(
-                    getRouteByMode(
-                        {
-                            type: 'Feature',
-                            geometry: { type: 'Point', coordinates: this._params.origin.geometry.coordinates },
-                            properties: {}
-                        },
-                        { type: 'Feature', geometry: { type: 'Point', coordinates: nodeCoordinates }, properties: {} }
-                    )
-                );
-            } else if (walkingStep.type === 'egress') {
-                // egress segment
-                const prevUnboardingStep = steps[stepIndex - 1] as TrRoutingV2.TripStepUnboarding;
-                const nodeCoordinates = prevUnboardingStep.nodeCoordinates;
-                walkingSegmentsRoutingPromises.push(
-                    getRouteByMode(
-                        { type: 'Feature', geometry: { type: 'Point', coordinates: nodeCoordinates }, properties: {} },
-                        {
-                            type: 'Feature',
-                            geometry: { type: 'Point', coordinates: this._params.destination.geometry.coordinates },
-                            properties: {}
-                        }
-                    )
-                );
-            } else if (walkingStep.type === 'transfer') {
-                const nextBoardingStep = steps[stepIndex + 1] as TrRoutingV2.TripStepBoarding;
-                const prevUnboardingStep = steps[stepIndex - 1] as TrRoutingV2.TripStepUnboarding;
-                const alightingNodeCoordinates = prevUnboardingStep.nodeCoordinates;
-                const boardingNodeCoordinates = nextBoardingStep.nodeCoordinates;
-                walkingSegmentsRoutingPromises.push(
-                    getRouteByMode(
-                        {
-                            type: 'Feature',
-                            geometry: { type: 'Point', coordinates: alightingNodeCoordinates },
-                            properties: {}
-                        },
-                        {
-                            type: 'Feature',
-                            geometry: { type: 'Point', coordinates: boardingNodeCoordinates },
-                            properties: {}
-                        }
-                    )
-                );
-            }
-        });
-
-        const walkingSegmentsGeojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties>[] = [];
-        const routingResults = await Promise.allSettled(walkingSegmentsRoutingPromises);
-        routingResults.forEach((walkingRoutingResult, routingIndex) => {
-            if (walkingRoutingResult.status === 'rejected') {
-                return;
-            }
-            const routes = walkingRoutingResult.value.routes;
-            if (routes.length === 0) {
-                return;
-            }
-            const route = routes[0];
-            if (route.geometry) {
-                const geojson: GeoJSON.Feature<GeoJSON.Geometry, StepGeojsonProperties> = {
-                    type: 'Feature',
-                    geometry: route.geometry,
-                    properties: {
-                        distanceMeters: route.distance,
-                        travelTimeSeconds: route.duration
-                    } as StepGeojsonProperties
-                };
-                walkingSegmentsGeojson.push(geojson);
-            }
-        });
-
-        return await this.generatePathGeojson(steps, walkingSegmentsGeojson, options);
-    }
-
-    hasError(): boolean {
-        return this._params.error !== undefined;
-    }
-
-    getError(): TrError | undefined {
-        const error = this._params.error;
-        return error !== undefined ? new TrError(error.error, error.errorCode, error.localizedMessage) : undefined;
-    }
-
-    getParams = (): TransitResultParams => this._params;
+        };
+    };
 }

--- a/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingCalculator.test.ts
+++ b/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingCalculator.test.ts
@@ -14,7 +14,7 @@ import { TransitRouting, TransitRoutingAttributes } from '../TransitRouting';
 import { RouteResults } from 'chaire-lib-common/lib/services/routing/RoutingService';
 import { TransitRoutingResult } from '../TransitRoutingResult';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
-import { UnimodalRouteCalculationResult } from '../RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { TrRoutingV2 } from 'chaire-lib-common/src/api/TrRouting';
 
@@ -196,7 +196,7 @@ describe('TransitRoutingCalculator', () => {
 
         expect(Object.keys(result)).toEqual(routingModes);
         for (let i = 0; i < routingModes.length; i++) {
-            const resultForMode = result[routingModes[i]] as UnimodalRouteCalculationResult;
+            const resultForMode = result[routingModes[i]] as UnimodalRoutingResult;
             expect(resultForMode).toBeDefined();
             expect(resultForMode.hasError()).toBeFalsy();
             expect(resultForMode.getError()).toBeUndefined();
@@ -220,7 +220,7 @@ describe('TransitRoutingCalculator', () => {
 
         expect(Object.keys(result)).toEqual(routingModes);
         for (let i = 0; i < routingModes.length; i++) {
-            const resultForMode = result[routingModes[i]] as UnimodalRouteCalculationResult;
+            const resultForMode = result[routingModes[i]] as UnimodalRoutingResult;
             expect(resultForMode).toBeDefined();
             expect(resultForMode.hasError()).toBeTruthy();
             expect(TrError.isTrError(resultForMode.getError())).toBe(true);

--- a/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingCalculator.test.ts
+++ b/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingCalculator.test.ts
@@ -17,6 +17,7 @@ import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes'
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { TrRoutingV2 } from 'chaire-lib-common/src/api/TrRouting';
+import { TrRoutingRoute } from 'chaire-lib-common/lib/services/trRouting/TrRoutingService';
 
 let attributes: TransitRoutingAttributes;
 let transitRouting: TransitRouting;
@@ -63,7 +64,7 @@ describe('TransitRoutingCalculator', () => {
 		expect(transitResult.getPath(1)).toEqual(simplePathResult.routes[0]);
 		expect(transitResult.getPath(2)).toEqual(undefined);
 
-		const path1step = transitResult.getPath(1)?.steps as TrRoutingV2.TripStep[];
+		const path1step = (transitResult.getPath(1) as TrRoutingRoute).steps as TrRoutingV2.TripStep[];
 		expect(path1step).toEqual(simplePathResult.routes[0].steps);
 		expect(path1step.length).toEqual(simplePathResult.routes[0].steps.length);
 		expect(path1step[0].action).toEqual("walking");
@@ -91,7 +92,7 @@ describe('TransitRoutingCalculator', () => {
 		expect(transitResult.getPath(1)).toEqual(simplePathResult.routes[0]);
 		expect(transitResult.getPath(2)).toEqual(undefined);
 
-		const path1step = transitResult.getPath(1)?.steps as TrRoutingV2.TripStep[];
+		const path1step = (transitResult.getPath(1) as TrRoutingRoute).steps as TrRoutingV2.TripStep[];
 		expect(path1step).toEqual(simplePathResult.routes[0].steps);
 		expect(path1step.length).toEqual(simplePathResult.routes[0].steps.length);
 		expect(path1step[0].action).toEqual("walking");
@@ -117,11 +118,11 @@ describe('TransitRoutingCalculator', () => {
 		expect(transitResult.hasAlternatives()).toEqual(true);
 		expect(transitResult.getAlternativesCount()).toEqual(2);
 
-        expect(transitResult.getPath(0)).toEqual(undefined);
+        expect(transitResult.getPath(0)).toEqual(walkingRouteNoWaypointTest.routes[0]);
 		expect(transitResult.getPath(1)).toEqual(transferPathResult.routes[0]);
 		expect(transitResult.getPath(2)).toEqual(undefined);
 
-		const path1step = transitResult.getPath(1)?.steps as TrRoutingV2.TripStep[];
+		const path1step = (transitResult.getPath(1) as TrRoutingRoute).steps as TrRoutingV2.TripStep[];
 		expect(path1step.length).toEqual(transferPathResult.routes[0].steps.length);
 		expect(path1step[0].action).toEqual("walking");
 		expect(path1step[1].action).toEqual("boarding");
@@ -151,7 +152,7 @@ describe('TransitRoutingCalculator', () => {
 		const simplePathResultPath = alternativesResult.routes[0];
 		const transferPathResultPath = alternativesResult.routes[1];
 
-		expect(transitResult.getPath(0)).toEqual(undefined);
+		expect(transitResult.getPath(0)).toEqual(walkingRouteNoWaypointTest.routes[0]);
 		expect(transitResult.getPath(1)).toEqual(simplePathResultPath);
 		expect(transitResult.getPath(2)).toEqual(transferPathResultPath);
 	});

--- a/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingCalculator.test.ts
+++ b/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingCalculator.test.ts
@@ -12,7 +12,7 @@ import { simplePathResult, transferPathResult, alternativesResult } from './TrRo
 import { TransitRoutingCalculator } from '../TransitRoutingCalculator';
 import { TransitRouting, TransitRoutingAttributes } from '../TransitRouting';
 import { RouteResults } from 'chaire-lib-common/lib/services/routing/RoutingService';
-import { TransitRoutingResult } from '../TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import TrError from 'chaire-lib-common/lib/utils/TrError';

--- a/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingResult.test.ts
+++ b/packages/transition-common/src/services/transitRouting/__tests__/TransitRoutingResult.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import _cloneDeep from 'lodash/cloneDeep';
+import { SegmentToGeoJSONFromPaths } from "../TransitRoutingResult";
+import { pathNoTransferRouteResult } from 'chaire-lib-common/lib/test/services/trRouting/TrRoutingConstantsStubs';
+import { PathCollection } from '../../path/PathCollection';
+import { getPathObject } from '../../path/__tests__/PathData.test';
+import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
+
+// Add a path to the path collection
+const pathCollection = new PathCollection([], {});
+const defaultPath = getPathObject({ pathCollection }, 'default');
+const realPath = getPathObject({ pathCollection }, 'smallReal');
+
+describe('SegmentToGeoJSONFromPaths', () => {
+    const segmentToGeoJSONFromPaths = new SegmentToGeoJSONFromPaths(pathCollection);
+
+    test('segmentToGeoJSONFromPaths, with default path, without segments', async () => {
+        // Update the path uuid in the result to match the one in the path collection
+        const trRoutingResult = _cloneDeep(pathNoTransferRouteResult);
+        const boardStep = trRoutingResult.steps[1] as TrRoutingV2.TripStepBoarding;
+        const unboardStep = trRoutingResult.steps[2] as TrRoutingV2.TripStepUnboarding;
+        (trRoutingResult.steps[1] as any).pathUuid = defaultPath.id;
+        (trRoutingResult.steps[2] as any).pathUuid = defaultPath.id;
+
+        const segment = await segmentToGeoJSONFromPaths.segmentToGeoJSONFromPaths(boardStep as any, unboardStep as any, false, 0);
+        expect(segment).toEqual({
+            type: 'Feature',
+            id: 0,
+            properties: {
+                distanceMeters: unboardStep.inVehicleDistance,
+                travelTimeSeconds: unboardStep.inVehicleTime,
+                action: 'ride',
+                stepSequence: 0,
+                mode: boardStep.mode,
+                color: undefined
+            },
+            geometry: {
+                type: 'LineString',
+                // No segments, the whole path should be there
+                coordinates: defaultPath.attributes.geography.coordinates
+            }
+        });
+    });
+
+    test('segmentToGeoJSONFromPaths, with small read path, with segments', async () => {
+        // Update the path uuid and legSequence in the result to match the one in the path collection
+        const trRoutingResult = _cloneDeep(pathNoTransferRouteResult);
+        const boardStep = trRoutingResult.steps[1] as TrRoutingV2.TripStepBoarding;
+        const unboardStep = trRoutingResult.steps[2] as TrRoutingV2.TripStepUnboarding;
+        boardStep.pathUuid = realPath.id;
+        boardStep.legSequenceInTrip = 2;
+        boardStep.stopSequenceInTrip = 2;
+        unboardStep.pathUuid = realPath.id;
+        unboardStep.legSequenceInTrip = 3;
+        unboardStep.stopSequenceInTrip = 3;
+
+        const segment = await segmentToGeoJSONFromPaths.segmentToGeoJSONFromPaths(boardStep as any, unboardStep as any, false, 0);
+        expect(segment).toEqual({
+            type: 'Feature',
+            id: 0,
+            properties: {
+                distanceMeters: unboardStep.inVehicleDistance,
+                travelTimeSeconds: unboardStep.inVehicleTime,
+                action: 'ride',
+                stepSequence: 0,
+                mode: boardStep.mode,
+                color: undefined
+            },
+            geometry: {
+                type: 'LineString',
+                coordinates: realPath.attributes.geography.coordinates.slice(realPath.attributes.segments[1], realPath.attributes.geography.coordinates.length)
+            }
+        });
+    });
+});
+
+

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -47,12 +47,6 @@ const showCurrentAlternative = async (result, alternativeIndex) => {
     });
 };
 
-const resultIsTransitRoutingResult = (
-    result: UnimodalRoutingResult | TransitRoutingResult
-): result is TransitRoutingResult => {
-    return typeof (result as any).getWalkOnlyRoute === 'function';
-};
-
 const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (props: TransitRoutingResultsProps) => {
     const [alternativeIndex, setAlternativeIndex] = useState(0);
 
@@ -65,8 +59,6 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
 
     const alternativesCount = result.getAlternativesCount();
     const path = result.getPath(alternativeIndex);
-    // TODO There should be no need of a separate walkOnlyRoute once all results share a same interface
-    const walkOnlyRoute = resultIsTransitRoutingResult(result) ? result.getWalkOnlyRoute() : undefined;
 
     // TODO This may be racy (it already was) if the user switches alternative rapidly. Make it cancellable.
     showCurrentAlternative(result, alternativeIndex);
@@ -117,13 +109,8 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
                     )}
                 </div>
             </div>
-            {(path || walkOnlyRoute) && (
-                <TransitRoutingResults
-                    path={path}
-                    walkOnly={walkOnlyRoute}
-                    request={props.request}
-                    routingMode={result.getRoutingMode()}
-                />
+            {path && (
+                <TransitRoutingResults path={path} request={props.request} routingMode={result.getRoutingMode()} />
             )}
         </React.Fragment>
     );

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -14,11 +14,13 @@ import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import { TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
 import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
 import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
+import { SegmentToGeoJSONFromPaths } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
+
 export interface RoutingResultStatus {
     routingResult: UnimodalRoutingResult | TransitRoutingResult;
     alternativeIndex: number;
@@ -31,7 +33,10 @@ export interface TransitRoutingResultsProps extends WithTranslation {
 }
 
 const showCurrentAlternative = async (result, alternativeIndex) => {
-    const pathGeojson = await result.getPathGeojson(alternativeIndex, {});
+    const pathCollection = serviceLocator.collectionManager.get('paths');
+    const segmentToGeojson = new SegmentToGeoJSONFromPaths(pathCollection);
+    const options = { completeData: false, segmentToGeojson: segmentToGeojson.segmentToGeoJSONFromPaths };
+    const pathGeojson = await result.getPathGeojson(alternativeIndex, options);
     (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
         layerName: 'routingPoints',
         data: result.originDestinationToGeojson()

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -12,10 +12,7 @@ import { faAngleLeft } from '@fortawesome/free-solid-svg-icons/faAngleLeft';
 import TransitRoutingResults from './TransitRoutingResultComponent';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import {
-    RouteCalculatorResult,
-    UnimodalRouteCalculationResult
-} from 'transition-common/lib/services/transitRouting/RouteCalculatorResult';
+import { UnimodalRoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { TransitRoutingResult } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
@@ -23,13 +20,13 @@ import { TransitRoutingAttributes } from 'transition-common/lib/services/transit
 import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
 import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 export interface RoutingResultStatus {
-    routingResult: UnimodalRouteCalculationResult | TransitRoutingResult;
+    routingResult: UnimodalRoutingResult | TransitRoutingResult;
     alternativeIndex: number;
     activeStepIndex: number | null;
 }
 
 export interface TransitRoutingResultsProps extends WithTranslation {
-    result: UnimodalRouteCalculationResult | TransitRoutingResult;
+    result: UnimodalRoutingResult | TransitRoutingResult;
     request: TransitRoutingAttributes;
 }
 
@@ -46,7 +43,7 @@ const showCurrentAlternative = async (result, alternativeIndex) => {
 };
 
 const resultIsTransitRoutingResult = (
-    result: UnimodalRouteCalculationResult | TransitRoutingResult
+    result: UnimodalRoutingResult | TransitRoutingResult
 ): result is TransitRoutingResult => {
     return typeof (result as any).getWalkOnlyRoute === 'function';
 };


### PR DESCRIPTION
This commit is part of work to move the routing calculations to chaire-lib instead of Transition, so that other tools can benefit from it (#954).

The main result interface is called `RoutingResult`. 2 classes implement it `UnimodalRoutingResult` and `TransitRoutingResult`. There is no need to call the `getWalkOnlyRoute` method anymore (it has been removed), as it is not part of the interface and required custom code. Rather, the `getPath` method will return either a Route or TrRoutingRoute in the `TransitRoutingResult` class.

Tests have been added for the results class. `TransitRoutingResult` required to be split between the common chaire-lib part (the class itself) and the transition part (requiring a PathCollection to get the geojson from transition paths). A parameter allows to specify how to retrieve the geojson from the route data.

The result classes may still be improved later, as the route calculations are also moved to chaire-lib, to find more common grounds or add better types to route properties. This is mostly moving what currently exists, with minimal changes to existing code.