### PR TITLE
db: Add the updated_at field to the tokens table

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/__tests__/tokens.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/tokens.db.test.ts
@@ -47,28 +47,28 @@ const user2: Partial<UserAttributes> = {
 const validToken: TokenAttributes = {
     user_id: 1,
     api_token: randomUUID(),
-    creation_date: now,
+    created_at: now,
     expiry_date:  new Date((new Date()).setDate(now.getDate() + tokensDbQueries.defaultTokenLifespanDays)),
 };
 
 const badToken: TokenAttributes = {
     user_id: 2,
     api_token: randomUUID(),
-    creation_date: new Date(),
+    created_at: new Date(),
     expiry_date:  new Date(1659633411001) ,
 }
 
 const expiredToken: TokenAttributes = {
     user_id: 3,
     api_token: randomUUID(),
-    creation_date: now,
+    created_at: now,
     expiry_date:  new Date(0),
 }
 
 const validToken2: TokenAttributes = {
     user_id: 4,
     api_token: randomUUID(),
-    creation_date: now,
+    created_at: now,
     expiry_date:  new Date((new Date()).setDate(now.getDate() + tokensDbQueries.defaultTokenLifespanDays)),
 };
 
@@ -87,7 +87,7 @@ const createToken = async (knex: Knex, tableName: string, tokenRow) => {
         const newObject: TokenAttributes = { 
             user_id: tokenRow.user_id, 
             api_token: tokenRow.api_token,
-            creation_date: tokenRow.creation_date,
+            created_at: tokenRow.created_at,
             expiry_date: tokenRow.expiry_date, 
         };
         const test = await knex(tableName).insert(newObject);

--- a/packages/chaire-lib-backend/src/models/db/migrations/20240531103600_addTokenUpdatedAt.ts
+++ b/packages/chaire-lib-backend/src/models/db/migrations/20240531103600_addTokenUpdatedAt.ts
@@ -8,16 +8,20 @@ import { Knex } from 'knex';
 
 const tableName = 'tokens';
 
+// The tokens table was built with the onUpdateTrigger rules, but it didn't have
+// the updated_at column. We add it and rename the creation_date to created_at
+// to match other tables.
+
 export async function up(knex: Knex): Promise<unknown> {
     return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
-        table.timestamp('expiry_date');
-        table.timestamp('creation_date');
+        table.renameColumn('creation_date', 'created_at');
+        table.timestamp('updated_at');
     });
 }
 
 export async function down(knex: Knex): Promise<unknown> {
     return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
-        table.timestamp('expiry_date');
-        table.timestamp('creation_date');
+        table.renameColumn('created_at', 'creation_date');
+        table.dropColumn('updated_at');
     });
 }

--- a/packages/chaire-lib-backend/src/models/db/tokens.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/tokens.db.queries.ts
@@ -18,30 +18,6 @@ const defaultTokenLifespanDays: number = isNaN(Number(config.tokenLifespanDays))
     ? 10
     : Number(config.tokenLifespanDays);
 
-const attributesCleaner = function (attributes: TokenAttributes): { user_id: number; api_token: string } {
-    const { user_id, api_token, expiry_date, creation_date } = attributes;
-    const _attributes: any = {
-        number: user_id,
-        string: api_token,
-        expiry_date: expiry_date,
-        creation_date: creation_date
-    };
-
-    return _attributes;
-};
-
-const attributesParser = (dbAttributes: {
-    user_id: number;
-    apiToken: string;
-    expiryDate: string;
-    creationDate: string;
-}): TokenAttributes => ({
-    user_id: dbAttributes.user_id,
-    api_token: dbAttributes.apiToken,
-    expiry_date: dbAttributes.expiryDate,
-    creation_date: dbAttributes.creationDate
-});
-
 const getOrCreate = async (usernameOrEmail: string): Promise<string> => {
     try {
         const userId = await knex(userTableName)
@@ -81,7 +57,7 @@ const getOrCreate = async (usernameOrEmail: string): Promise<string> => {
             user_id: userId,
             api_token: apiToken,
             expiry_date: tokenExpiryDate,
-            creation_date: new Date()
+            created_at: new Date()
         };
         await knex(tableName).insert(newObject);
         return apiToken;

--- a/packages/chaire-lib-backend/src/services/auth/token.ts
+++ b/packages/chaire-lib-backend/src/services/auth/token.ts
@@ -8,5 +8,5 @@ export type TokenAttributes = {
     user_id: number;
     api_token?: string | null;
     expiry_date;
-    creation_date;
+    created_at;
 };


### PR DESCRIPTION
The table was built with the `onUpdateTrigger` constraint, but the updated_at field is not present, so it is not possible to update the table. Also rename `creation_date` to `created_at` to match other tables.