### PR TITLE
Move the ParamValidatorUtils from evolution to chaire-lib

### DIFF
--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^8.2.0",
     "geobuf": "^3.0.2",
     "geojson": "^0.5.0",
+    "geojson-validation": "^1.0.2",
     "geokdbush": "^1.1.0",
     "history": "^4.9.0",
     "inquirer": "^7.3.3",

--- a/packages/chaire-lib-common/src/utils/ParamsValidatorUtils.ts
+++ b/packages/chaire-lib-common/src/utils/ParamsValidatorUtils.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { validate as uuidValidate } from 'uuid';
+import {
+    isFeature,
+    isPoint,
+    isLineString,
+    isPolygon,
+    isMultiPoint,
+    isMultiLineString,
+    isMultiPolygon,
+    isFeatureCollection
+} from 'geojson-validation';
+
+// type for a class: https://stackoverflow.com/a/64985108
+declare type Class<T = unknown> = new (...args: unknown[]) => T;
+
+export class ParamsValidatorUtils {
+    static isObject(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && typeof value !== 'object') {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an object`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isRequired(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value === undefined) {
+            return [new Error(`${displayName} validateParams: ${attribute} is required`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isInstanceOf(attribute: string, value: unknown, displayName: string, _class: Class): Error[] {
+        if (value !== undefined && !(value instanceof _class)) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an instance of ${_class.name}`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isString(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && typeof value !== 'string') {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a string`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isNonEmptyString(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (typeof value !== 'string' || value.trimStart().trim() === '')) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a non-empty string`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isBoolean(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && typeof value !== 'boolean') {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a boolean`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isUuid(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (typeof value !== 'string' || !uuidValidate(value))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a valid uuid`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isPositiveInteger(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!Number.isInteger(value) || Number(value) < 0)) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a positive integer`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isPositiveNumber(attribute: string, value: unknown, displayName: string): Error[] {
+        if ((value !== undefined && typeof value !== 'number') || Number(value) < 0) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a positive number`)];
+        } else {
+            return [];
+        }
+    }
+
+    // a date string is a string of format 'YYYY-MM-DD'
+    static isDateString(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined) {
+            const date = new Date(value + 'T00:00:00');
+            if (!(date instanceof Date) || isNaN(date.getDate())) {
+                return [new Error(`${displayName} validateParams: ${attribute} should be a valid date string`)];
+            }
+        }
+        return [];
+    }
+
+    static isIn(attribute: string, value: unknown, displayName: string, inArray: unknown[], typeName?: string) {
+        if (value !== undefined && !inArray.includes(value)) {
+            return [
+                new Error(
+                    `${displayName} validateParams: ${attribute} ${
+                        typeName ? `should be one of the valid ${typeName} values` : 'is invalid'
+                    }`
+                )
+            ];
+        } else {
+            return [];
+        }
+    }
+
+    static isArray(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && !Array.isArray(value)) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an array`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isArrayOfStrings(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!Array.isArray(value) || value.some((v) => typeof v !== 'string'))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an array of strings`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isArrayOfDateStrings(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && Array.isArray(value)) {
+            for (let i = 0, countI = value.length; i < countI; i++) {
+                if (typeof value[i] !== 'string') {
+                    return [new Error(`${displayName} validateParams: ${attribute} should be an array of strings`)];
+                }
+                const date = new Date(value[i] + 'T00:00:00');
+                if (!(date instanceof Date) || isNaN(date.getDate())) {
+                    return [
+                        new Error(`${displayName} validateParams: ${attribute} should be an array of date strings`)
+                    ];
+                }
+            }
+        } else if (value !== undefined && !Array.isArray(value)) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an array`)];
+        }
+        return [];
+    }
+
+    static isArrayOfNumbers(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!Array.isArray(value) || value.some((v) => typeof v !== 'number'))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an array of numbers`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isArrayOfUuids(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!Array.isArray(value) || value.some((v) => !uuidValidate(v)))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an array of valid uuids`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isArrayOf(attribute: string, value: unknown, displayName: string, _class: Class): Error[] {
+        if (value !== undefined && (!Array.isArray(value) || value.some((v) => !(v instanceof _class)))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an array of ${_class.name}`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonPoint(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!isFeature(value) || !isPoint((value as GeoJSON.Feature).geometry))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a valid geojson point`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonLineString(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!isFeature(value) || !isLineString((value as GeoJSON.Feature).geometry))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a valid geojson line string`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonPolygon(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!isFeature(value) || !isPolygon((value as GeoJSON.Feature).geometry))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a valid geojson polygon`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonMultiPoint(attribute, value: unknown, displayName): Error[] {
+        if (value !== undefined && (!isFeature(value) || !isMultiPoint((value as GeoJSON.Feature).geometry))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a valid geojson multi point`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonMultiLineString(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!isFeature(value) || !isMultiLineString((value as GeoJSON.Feature).geometry))) {
+            return [
+                new Error(`${displayName} validateParams: ${attribute} should be a valid geojson multi line string`)
+            ];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonMultiPolygon(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (!isFeature(value) || !isMultiPolygon((value as GeoJSON.Feature).geometry))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a valid geojson multi polygon`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isGeojsonFeatureCollection(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && !isFeatureCollection(value)) {
+            return [
+                new Error(`${displayName} validateParams: ${attribute} should be a valid geojson feature collection`)
+            ];
+        } else {
+            return [];
+        }
+    }
+}

--- a/packages/chaire-lib-common/src/utils/__tests__/ParamsValidatorUtils.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/ParamsValidatorUtils.test.ts
@@ -1,0 +1,633 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { ParamsValidatorUtils } from '../ParamsValidatorUtils';
+import { v4 as uuidV4 } from 'uuid';
+
+class TestClass { }
+
+describe('ParamsValidatorUtils', () => {
+
+    describe('isObject', () => {
+        test('should return no errors for a valid object', () => {
+            const errors = ParamsValidatorUtils.isObject('attr', {}, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isObject('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an null value', () => {
+            const errors = ParamsValidatorUtils.isObject('attr', null, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an non-empty object', () => {
+            const errors = ParamsValidatorUtils.isObject('attr', { foo: 'bar' }, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-object value', () => {
+            const errors = ParamsValidatorUtils.isObject('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an object');
+        });
+    });
+
+    describe('isRequired', () => {
+        test('should return no errors for a defined value', () => {
+            const errors = ParamsValidatorUtils.isRequired('attr', 'value', 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isRequired('attr', undefined, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('is required');
+        });
+    });
+
+    describe('isInstanceOf', () => {
+
+        class ParentClass {}
+        class ChildClass extends ParentClass {}
+
+        test('should return no errors for an instance of TestClass', () => {
+            const instance = new TestClass();
+            const errors = ParamsValidatorUtils.isInstanceOf('attr', instance, 'TestClass', TestClass
+            );
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isInstanceOf('attr', undefined, 'TestClass', TestClass);
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-instance of TestClass', () => {
+            const errors = ParamsValidatorUtils.isInstanceOf('attr', {}, 'TestClass', TestClass);
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an instance of TestClass');
+        });
+
+        test('should return no errors for an instance of a child class', () => {
+            const instance = new ChildClass();
+            const errors = ParamsValidatorUtils.isInstanceOf('attr', instance, 'ParentClass', ParentClass);
+            expect(errors).toEqual([]);
+        });
+    });
+
+    describe('isString', () => {
+        test('should return no errors for a valid string', () => {
+            const errors = ParamsValidatorUtils.isString('attr', 'string', 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isString('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-string value', () => {
+            const errors = ParamsValidatorUtils.isString('attr', 123, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a string');
+        });
+    });
+
+    describe('isNonEmptyString', () => {
+        test('should return no errors for a non-empty string', () => {
+            const errors = ParamsValidatorUtils.isNonEmptyString('attr', 'string', 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isNonEmptyString('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an empty string', () => {
+            const errors = ParamsValidatorUtils.isNonEmptyString('attr', '', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a non-empty string');
+        });
+    });
+
+    describe('isBoolean', () => {
+        test('should return no errors for a valid boolean', () => {
+            const errors = ParamsValidatorUtils.isBoolean('attr', true, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isBoolean('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-boolean value', () => {
+            const errors = ParamsValidatorUtils.isBoolean('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a boolean');
+        });
+    });
+
+    describe('isUuid', () => {
+        test('should return no errors for a valid uuid', () => {
+            const errors = ParamsValidatorUtils.isUuid('attr', '123e4567-e89b-12d3-a456-426614174000', 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isUuid('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid uuid', () => {
+            const errors = ParamsValidatorUtils.isUuid('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid uuid');
+        });
+    });
+
+    describe('isPositiveInteger', () => {
+        test('should return no errors for a positive integer', () => {
+            const errors = ParamsValidatorUtils.isPositiveInteger('attr', 123, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isPositiveInteger('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a negative integer', () => {
+            const errors = ParamsValidatorUtils.isPositiveInteger('attr', -123, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a positive integer');
+        });
+    });
+
+    describe('isPositiveNumber', () => {
+        test('should return no errors for a positive number', () => {
+            const errors = ParamsValidatorUtils.isPositiveNumber('attr', 123.45, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isPositiveNumber('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a negative number', () => {
+            const errors = ParamsValidatorUtils.isPositiveNumber('attr', -123.45, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a positive number');
+        });
+    });
+
+    describe('isDateString', () => {
+        test('should return no errors for a date string', () => {
+            const errors = ParamsValidatorUtils.isDateString('attr', '2024-01-01', 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined date string', () => {
+            const errors = ParamsValidatorUtils.isDateString('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid date string', () => {
+            const errors = ParamsValidatorUtils.isDateString('attr', '12345', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid date string');
+        });
+    });
+
+    describe('isIn', () => {
+        test('should return no errors for a value in the array', () => {
+            const errors = ParamsValidatorUtils.isIn('attr', 'value1', 'TestClass', ['value1', 'value2']);
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isIn('attr', undefined, 'TestClass', ['value1', 'value2']);
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a value not in the array', () => {
+            const errors = ParamsValidatorUtils.isIn('attr', 'value3', 'TestClass', ['value1', 'value2']);
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('is invalid');
+        });
+
+        test('should return an error for a value not in the array with type name', () => {
+            const errors = ParamsValidatorUtils.isIn('attr', 'value3', 'TestClass', ['value1', 'value2'], 'typeName');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be one of the valid typeName values');
+        });
+    });
+
+    describe('isArray', () => {
+        test('should return no errors for an array', () => {
+            const errors = ParamsValidatorUtils.isArray('attr', ['test1', 'test2'], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an empty array', () => {
+            const errors = ParamsValidatorUtils.isArray('attr', [], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isArray('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-array value', () => {
+            const errors = ParamsValidatorUtils.isArray('attr', 'invalid', 'TestClass'); expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array');
+        });
+    });
+
+    describe('isArrayOfStrings', () => {
+        test('should return no errors for an array of strings', () => {
+            const errors = ParamsValidatorUtils.isArrayOfStrings('attr', ['value1', 'value2'], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfStrings('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an empty array', () => {
+            const errors = ParamsValidatorUtils.isArrayOfStrings('attr', [], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-array value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfStrings('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of strings');
+        });
+
+        test('should return an error for an array with non-string values', () => {
+            const errors = ParamsValidatorUtils.isArrayOfStrings('attr', ['value1', 123], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of strings');
+        });
+    });
+
+    describe('isArrayOfDateStrings', () => {
+        test('should return no errors for an array of date strings', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', ['2023-01-01', '2023-01-02'], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an empty array', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', [], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-array value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array');
+        });
+
+        test('should return an error for an array with invalid date strings', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', ['2023-01-01', 'invalid'], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of date strings');
+        });
+
+        test('should return an error for an array with invalid date strings with a non-string value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', [123], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of strings');
+        });
+
+        test('should return an error for an array with invalid date strings with at least one non-string value (object)', () => {
+            const errors = ParamsValidatorUtils.isArrayOfDateStrings('attr', ['2023-01-01', {}], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of strings');
+        });
+    });
+
+    describe('isArrayOfNumbers', () => {
+        test('should return no errors for an array of numbers', () => {
+            const errors = ParamsValidatorUtils.isArrayOfNumbers('attr', [1, 2, 3], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfNumbers('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an empty array', () => {
+            const errors = ParamsValidatorUtils.isArrayOfNumbers('attr', [], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-array value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfNumbers('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of numbers');
+        });
+
+        test('should return an error for an array with non-number values', () => {
+            const errors = ParamsValidatorUtils.isArrayOfNumbers('attr', [1, 'invalid', 3], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of numbers');
+        });
+    });
+
+    describe('isArrayOfUuids', () => {
+        test('should return no errors for an array of valid UUIDs', () => {
+            const errors = ParamsValidatorUtils.isArrayOfUuids('attr', [uuidV4(), uuidV4()], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfUuids('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an empty array', () => {
+            const errors = ParamsValidatorUtils.isArrayOfUuids('attr', [], 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-array value', () => {
+            const errors = ParamsValidatorUtils.isArrayOfUuids('attr', 'invalid', 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of valid uuids');
+        });
+
+        test('should return an error for an array with invalid UUIDs', () => {
+            const errors = ParamsValidatorUtils.isArrayOfUuids('attr', ['valid-uuid', 'invalid'], 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of valid uuids');
+        });
+    });
+
+    describe('isArrayOf', () => {
+        test('should return no errors for an array of instances of the specified class', () => {
+            const errors = ParamsValidatorUtils.isArrayOf('attr', [new TestClass(), new TestClass()], 'TestClass', TestClass);
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isArrayOf('attr', undefined, 'TestClass', TestClass);
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an empty array', () => {
+            const errors = ParamsValidatorUtils.isArrayOf('attr', [], 'TestClass', TestClass);
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for a non-array value', () => {
+            const errors = ParamsValidatorUtils.isArrayOf('attr', 'invalid', 'TestClass', TestClass);
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of TestClass');
+        });
+
+        test('should return an error for an array with non-instances of the specified class', () => {
+            const errors = ParamsValidatorUtils.isArrayOf('attr', [new TestClass(), 'invalid'], 'TestClass', TestClass);
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an array of TestClass');
+        });
+    });
+
+    describe('isGeojsonPoint', () => {
+        test('should return no errors for a valid GeoJSON Point', () => {
+            const point: GeoJSON.Feature<GeoJSON.Point> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'Point',
+                    coordinates: [0, 0]
+                }
+            };
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', point, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON Point', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', { type: 'Feature', geometry: { type: 'Invalid' } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson point');
+        });
+
+        test('should return an error for an empty GeoJSON Point coordinates', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', { type: 'Feature', geometry: { type: 'Point', coordinates: [] } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson point');
+        });
+
+        test('should return an error for an undefined GeoJSON Point coordinates', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', { type: 'Feature', geometry: { type: 'Point', coordinates: undefined } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson point');
+        });
+    });
+
+    describe('isGeojsonLineString', () => {
+        test('should return no errors for a valid GeoJSON LineString', () => {
+            const lineString: GeoJSON.Feature<GeoJSON.LineString> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[0, 0], [1, 1]]
+                }
+            };
+            const errors = ParamsValidatorUtils.isGeojsonLineString('attr', lineString, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON LineString', () => {
+            const errors = ParamsValidatorUtils.isGeojsonLineString('attr', { type: 'Feature', geometry: { type: 'Invalid' } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson line string');
+        });
+    });
+
+    describe('isGeojsonPolygon', () => {
+        test('should return no errors for a valid GeoJSON Polygon', () => {
+            const polygon: GeoJSON.Feature<GeoJSON.Polygon> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'Polygon', coordinates: [
+                        [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]
+                    ]
+                }
+            };
+            const errors = ParamsValidatorUtils.isGeojsonPolygon('attr', polygon, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON Polygon', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPolygon('attr', { type: 'Feature', geometry: { type: 'Invalid' } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson polygon');
+        });
+    });
+
+    describe('isGeojsonMultiPoint', () => {
+        test('should return no errors for a valid GeoJSON MultiPoint', () => {
+            const multiPoint: GeoJSON.Feature<GeoJSON.MultiPoint> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'MultiPoint',
+                    coordinates: [[0, 0], [1, 1]]
+                }
+            };
+            const errors = ParamsValidatorUtils.isGeojsonMultiPoint('attr', multiPoint, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON MultiPoint', () => {
+            const errors = ParamsValidatorUtils.isGeojsonMultiPoint('attr', { type: 'Feature', geometry: { type: 'Invalid' } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson multi point');
+        });
+    });
+
+    describe('isGeojsonMultiLineString', () => {
+        test('should return no errors for a valid GeoJSON MultiLineString', () => {
+            const multiLineString: GeoJSON.Feature<GeoJSON.MultiLineString> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'MultiLineString',
+                    coordinates: [
+                        [[0, 0], [1, 1]],
+                        [[2, 2], [3, 3]]
+                    ]
+                }
+            };
+            const errors = ParamsValidatorUtils.isGeojsonMultiLineString('attr', multiLineString, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON MultiLineString', () => {
+            const errors = ParamsValidatorUtils.isGeojsonMultiLineString('attr', { type: 'Feature', geometry: { type: 'Invalid' } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson multi line string');
+        });
+    });
+
+    describe('isGeojsonMultiPolygon', () => {
+        test('should return no errors for a valid GeoJSON MultiPolygon', () => {
+            const multiPolygon: GeoJSON.Feature<GeoJSON.MultiPolygon> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                    type: 'MultiPolygon',
+                    coordinates: [
+                        [
+                            [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]
+                        ],
+                        [
+                            [[2, 2], [3, 2], [3, 3], [2, 3], [2, 2]]
+                        ]
+                    ]
+                }
+            };
+            const errors = ParamsValidatorUtils.isGeojsonMultiPolygon('attr', multiPolygon, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON MultiPolygon', () => {
+            const errors = ParamsValidatorUtils.isGeojsonMultiPolygon('attr', { type: 'Feature', geometry: { type: 'Invalid' } }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson multi polygon');
+        });
+    });
+
+    describe('isGeojsonFeatureCollection', () => {
+        test('should return no errors for a valid GeoJSON FeatureCollection', () => {
+            const featureCollection: GeoJSON.FeatureCollection = {
+                type: 'FeatureCollection',
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [0, 0]
+                        },
+                        properties: {}
+                    }
+                ]
+            };
+            const errors = ParamsValidatorUtils.isGeojsonFeatureCollection('attr', featureCollection, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for an undefined value', () => {
+            const errors = ParamsValidatorUtils.isGeojsonPoint('attr', undefined, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return no errors for a valid empty GeoJSON FeatureCollection', () => {
+            const featureCollection: GeoJSON.FeatureCollection = {
+                type: 'FeatureCollection',
+                features: []
+            };
+            const errors = ParamsValidatorUtils.isGeojsonFeatureCollection('attr', featureCollection, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        test('should return an error for an invalid GeoJSON FeatureCollection', () => {
+            const errors = ParamsValidatorUtils.isGeojsonFeatureCollection('attr', { type: 'Invalid' }, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a valid geojson feature collection');
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7611,6 +7611,11 @@ geojson-rbush@3.x:
     "@turf/meta" "6.x"
     rbush "^2.0.0"
 
+geojson-validation@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/geojson-validation/-/geojson-validation-1.0.2.tgz#5c11a83afbec9a1cb9d76c73d47843dbd154d3ff"
+  integrity sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A==
+
 geojson-vt@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"


### PR DESCRIPTION
This will allow to validate the [socket] route parameters more easily and return corresponding errors.