### PR TITLE
deck.gl: Support the max/minRadiusPixels properties

### DIFF
--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
@@ -158,9 +158,7 @@ const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps
                         isChecked={props.preferences.get('map.enableMapAnimations')}
                         defaultChecked={true}
                         label={props.t('main:Yes')}
-                        onValueChange={(e) =>
-                            props.onValueChange('map.enableMapAnimations', { value: e.target.value })
-                        }
+                        onValueChange={(e) => props.onValueChange('map.enableMapAnimations', { value: e.target.value })}
                     />
                     <PreferencesResetToDefaultButton
                         resetPrefToDefault={props.resetPrefToDefault}

--- a/packages/transition-frontend/src/components/map/layers/AnimatedArrowPathLayer.tsx
+++ b/packages/transition-frontend/src/components/map/layers/AnimatedArrowPathLayer.tsx
@@ -82,7 +82,8 @@ export default class AnimatedArrowPathLayer<DataT = any, ExtraProps extends obje
     }
 
     draw(opts) {
-        opts.uniforms.arrowPathTimeStep = this.props.disableAnimation === true ? 0 : (performance.now() % 100000) / 100000; // resets every 100 seconds
+        opts.uniforms.arrowPathTimeStep =
+            this.props.disableAnimation === true ? 0 : (performance.now() % 100000) / 100000; // resets every 100 seconds
         opts.uniforms.speedDivider = this.props.speedDivider;
         super.draw(opts);
     }

--- a/packages/transition-frontend/src/components/map/layers/TransitionMapLayer.tsx
+++ b/packages/transition-frontend/src/components/map/layers/TransitionMapLayer.tsx
@@ -385,6 +385,20 @@ const getScatterLayer = (
     if (lineWidthScale !== undefined) {
         layerProperties.lineWidthScale = lineWidthScale;
     }
+    const minRadiusPixels =
+        config.minRadiusPixels === undefined ? undefined : layerNumberGetter(config.minRadiusPixels, 1);
+    if (minRadiusPixels !== undefined) {
+        layerProperties.radiusMinPixels = minRadiusPixels;
+        // Keep the contour width at 1/3 of the circle radius if the radius is a number
+        layerProperties.lineWidthMinPixels = typeof minRadiusPixels === 'number' ? minRadiusPixels / 3 : undefined;
+    }
+    const maxRadiusPixels =
+        config.maxRadiusPixels === undefined ? undefined : layerNumberGetter(config.maxRadiusPixels, 1);
+    if (maxRadiusPixels !== undefined) {
+        layerProperties.radiusMaxPixels = maxRadiusPixels;
+        // Keep the contour width at 1/3 of the circle radius if the radius is a number
+        layerProperties.lineWidthMaxPixels = typeof maxRadiusPixels === 'number' ? maxRadiusPixels / 3 : undefined;
+    }
     const pickable =
         config.pickable === undefined
             ? true

--- a/packages/transition-frontend/src/config/layers.config.ts
+++ b/packages/transition-frontend/src/config/layers.config.ts
@@ -15,6 +15,7 @@ const layersConfig = {
         strokeWidth: 1,
         radius: 5,
         radiusScale: 3,
+        maxRadiusPixels: 10,
         strokeWidthScale: 3
     },
 
@@ -25,6 +26,7 @@ const layersConfig = {
         strokeWidth: 1,
         radius: 5,
         radiusScale: 3,
+        maxRadiusPixels: 10,
         strokeWidthScale: 3
     },
 
@@ -415,6 +417,7 @@ const layersConfig = {
         radius: 5,
         radiusScale: 3,
         strokeWidthScale: 3,
+        maxRadiusPixels: 10,
         autoHighlight: true,
         pickable: () => serviceLocator.selectedObjectsManager.get('node') === undefined
     },
@@ -462,6 +465,7 @@ const layersConfig = {
         strokeColor: [255, 255, 255],
         strokeWidth: 2,
         radius: 7,
+        maxRadiusPixels: 15,
         radiusScale: 3,
         strokeWidthScale: 3,
         'custom-shader': 'circleSpinner',


### PR DESCRIPTION
fixes #974
    
The `maxRadiusPixels` and `minRadiusPixels` can be set in the layer
description to prevent the points from getting too big/small when
zooming in/out. If the property is a number, the lineWidth min/max
pixels are also set to 1/3 of the corresponding radius.

Here's how it looks now (@kaligrafy 10 review points if you find where this image shows :p ):

![Capture d’écran du 2024-06-07 14-32-26](https://github.com/chairemobilite/transition/assets/4398897/0a30d68e-4596-4f1c-bf75-2fe38f6e9478)
