### PR TITLE
paramValidatorUtils: Add `isInteger` and `isNumber` functions

### DIFF
--- a/packages/chaire-lib-common/src/utils/ParamsValidatorUtils.ts
+++ b/packages/chaire-lib-common/src/utils/ParamsValidatorUtils.ts
@@ -85,9 +85,25 @@ export class ParamsValidatorUtils {
         }
     }
 
+    static isInteger(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && !Number.isInteger(value)) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be an integer`)];
+        } else {
+            return [];
+        }
+    }
+
     static isPositiveNumber(attribute: string, value: unknown, displayName: string): Error[] {
         if ((value !== undefined && typeof value !== 'number') || Number(value) < 0) {
             return [new Error(`${displayName} validateParams: ${attribute} should be a positive number`)];
+        } else {
+            return [];
+        }
+    }
+
+    static isNumber(attribute: string, value: unknown, displayName: string): Error[] {
+        if (value !== undefined && (typeof value !== 'number' || !Number.isFinite(value))) {
+            return [new Error(`${displayName} validateParams: ${attribute} should be a number`)];
         } else {
             return [];
         }

--- a/packages/chaire-lib-common/src/utils/__tests__/ParamsValidatorUtils.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/ParamsValidatorUtils.test.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-
+import each from 'jest-each';
 import { ParamsValidatorUtils } from '../ParamsValidatorUtils';
 import { v4 as uuidV4 } from 'uuid';
 
@@ -173,6 +173,30 @@ describe('ParamsValidatorUtils', () => {
         });
     });
 
+    describe('isInteger', () => {
+        each([
+            [123],
+            [0],
+            [-123],
+            [undefined]
+        ]).test('should return no errors for %s', (number) => {
+            const errors = ParamsValidatorUtils.isInteger('attr', number, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        each([
+            ['a string'],
+            ['123'],
+            [[0, 1, 3]],
+            [1.23],
+            [Number.NaN]
+        ]).test('should return an error for %s', (number) => {
+            const errors = ParamsValidatorUtils.isInteger('attr', number, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be an integer');
+        });
+    });
+
     describe('isPositiveNumber', () => {
         test('should return no errors for a positive number', () => {
             const errors = ParamsValidatorUtils.isPositiveNumber('attr', 123.45, 'TestClass');
@@ -188,6 +212,30 @@ describe('ParamsValidatorUtils', () => {
             const errors = ParamsValidatorUtils.isPositiveNumber('attr', -123.45, 'TestClass');
             expect(errors).toHaveLength(1);
             expect(errors[0].message).toContain('should be a positive number');
+        });
+    });
+
+    describe('isNumber', () => {
+        each([
+            [123],
+            [0],
+            [-123],
+            [1.23],
+            [undefined]
+        ]).test('should return no errors for %s', (number) => {
+            const errors = ParamsValidatorUtils.isNumber('attr', number, 'TestClass');
+            expect(errors).toEqual([]);
+        });
+
+        each([
+            ['a string'],
+            ['123'],
+            [[0, 1, 3]],
+            [Number.NaN]
+        ]).test('should return an error for %s', (number) => {
+            const errors = ParamsValidatorUtils.isNumber('attr', number, 'TestClass');
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toContain('should be a number');
         });
     });
 


### PR DESCRIPTION
These functions validation whether the parameter is an integer or a number, whether positive, zero or negative.