### PR TITLE
routing: Allow service manager to receive an array of engines

### DIFF
--- a/packages/chaire-lib-common/src/services/routing/RoutingServiceManager.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingServiceManager.ts
@@ -32,9 +32,10 @@ class RoutingServiceManagerImpl implements RoutingServiceManager {
         };
     }
 
-    public getRoutingServiceForEngine = (engine: string): RoutingService => {
-        const service = this._routingServices[engine];
-        return service ? service : this._defaultService;
+    public getRoutingServiceForEngine = (engine: string | string[]): RoutingService => {
+        const engineArray = Array.isArray(engine) ? engine : [engine];
+        const availableEngine = engineArray.find((engine) => engine in this._routingServices);
+        return availableEngine ? this._routingServices[availableEngine] : this._defaultService;
     };
 }
 

--- a/packages/chaire-lib-common/src/services/routing/__tests__/RoutingServiceManager.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/RoutingServiceManager.test.ts
@@ -23,3 +23,22 @@ test('Service Manager Default Engine', () => {
     routingService = routingServiceManager.getRoutingServiceForEngine('not an engine');
     expect(routingService).toBe(baseRoutingService);
 });
+
+test('Service Manager for array of engines', () => {
+    // Cannot type check, so checking with what is expected
+    const manualRoutingService = routingServiceManager.getRoutingServiceForEngine('manual');
+    const engineRoutingService = routingServiceManager.getRoutingServiceForEngine('engine');
+
+    // Test with manual engine first
+    const manualFirstService = routingServiceManager.getRoutingServiceForEngine(['manual', 'engine']);
+    expect(manualFirstService).toBe(manualRoutingService);
+    // Test with engine first
+    const engineFirstService = routingServiceManager.getRoutingServiceForEngine(['engine', 'manual']);
+    expect(engineFirstService).toBe(engineRoutingService);
+    // Test with unknown engines, should fallback to manual
+    const unknownEnginesService = routingServiceManager.getRoutingServiceForEngine(['not an engine', 'other']);
+    expect(unknownEnginesService).toBe(manualRoutingService);
+    // Test with unknown engines and 'engine', should find first available
+    const someUnknownService = routingServiceManager.getRoutingServiceForEngine(['not an engine', 'engine']);
+    expect(someUnknownService).toBe(engineRoutingService);
+});


### PR DESCRIPTION
This allows clients to specify various routing engines, in order of preference, some of which may not apply to all modes. Only the first available one will be returned by the RoutingServiceManager.