### PR TITLE
Add support to enable DKIM signature in email sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,18 @@ MAIL_TRANSPORT_SMTP_SECURE=false
 MAIL_TRANSPORT_SMTP_AUTH_USER=myUser
 MAIL_TRANSPORT_SMTP_AUTH_PWD=password
 
+# DKIM (DomainKeys Identified Mail) signature related configuration
+# You need all three if you want to use DKIM, but you don't have to set them if you
+# do not want to add the DKIM signature to the emails
+#
+## Prefix to use to select the public key. For example, this will match the record
+## dkim._domainkey.example.com
+# MAIL_TRANSPORT_DKIM_SELECTOR=dkim
+## DNS Domain to match the public key lookup
+# MAIL_TRANSPORT_DKIM_DOMAIN=example.com
+## File path to the private key matching the one in the Selector key
+# MAIL_TRANSPORT_DKIM_PRIVATE_PATH=/path/to/privkey.pem
+
+
 # From email
 MAIL_FROM_ADDRESS=example@example.com


### PR DESCRIPTION
This add the necessary config to let nodemailer add a DKIM signature to sent email

We need 3 news environment variables:
MAIL_TRANSPORT_DKIM_SELECTOR (Select which DKIM key to use) MAIL_TRANSPORT_DKIM_DOMAIN (Domain to select the key from) MAIL_TRANSPORT_DKIM_PRIVATE_PATH (File path to the DKIM private key)