### PR TITLE
socket: Set the `maxHttpBufferSize` when initializing socket

### DIFF
--- a/packages/transition-backend/src/socketServerApp.ts
+++ b/packages/transition-backend/src/socketServerApp.ts
@@ -65,7 +65,8 @@ const setupSocketServerApp = async function (server, session) {
 
     const io = socketIO(server, {
         pingTimeout: 60000,
-        transports: ['websocket']
+        transports: ['websocket'],
+        maxHttpBufferSize: 1e8 // 100MB
     });
 
     // FIXME Call to restore unsecure behavior from socket.io < 2.4.0 (https://socket.io/blog/socket-io-2-4-0/). We should eventually pass to socket.io v3 and make sure the app is secure.


### PR DESCRIPTION
fixes #991

The latest socket.io upgrade set the upload size default to 1MB. We set it back to 100MB since Transition users often have to upload large files for calculations.