### PR TITLE
Enable build on Node 20.x in github workflow

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/examples/config.js
     steps:


### PR DESCRIPTION
Node 20 is the current LTS, we should migrate our builds to it