### PR TITLE
routing: Support alternatives for single-mode routing calculations

### DIFF
--- a/packages/chaire-lib-backend/src/services/routing/Routing.ts
+++ b/packages/chaire-lib-backend/src/services/routing/Routing.ts
@@ -106,7 +106,7 @@ const calculateRoute = async (
     routingMode: RoutingMode
 ): Promise<RouteResults> => {
     // FIXME This code path will use a fake socket route to do the calculation. Move this code to the backend too
-    return await getRouteByMode(od[0], od[1], routingMode);
+    return await getRouteByMode(od[0], od[1], routingMode, routingAttributes);
 };
 
 export class Routing {

--- a/packages/chaire-lib-backend/src/services/routing/__tests__/Routing.test.ts
+++ b/packages/chaire-lib-backend/src/services/routing/__tests__/Routing.test.ts
@@ -79,7 +79,7 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(1);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
 
         expect(Object.keys(result)).toEqual(['transit', 'walking']);
         const transitResult = result['transit'] as TransitRoutingResultData;
@@ -106,7 +106,7 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(1);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
 
         expect(Object.keys(result)).toEqual(['transit', 'walking']);
         const transitResult = result['transit'] as TransitRoutingResultData;
@@ -137,7 +137,7 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(1);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
 
         expect(transitResult.paths.length).toEqual(1);
 
@@ -166,7 +166,7 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(1);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
 
         expect(transitResult.paths.length).toEqual(2);
 
@@ -183,7 +183,7 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(1);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
 
         expect(Object.keys(result)).toEqual(['transit', 'walking']);
         const transitResult = result['transit'] as TransitRoutingResultData;
@@ -205,9 +205,9 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(3);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'cycling');
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'rail');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'cycling', attributes);
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'rail', attributes);
 
         expect(Object.keys(result)).toEqual(routingModes);
         for (let i = 0; i < routingModes.length; i++) {
@@ -228,9 +228,9 @@ describe('Routing Calculations', () => {
 
         expect(mockedTrRouting.mockRouteFunction).toHaveBeenCalledTimes(1);
         expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledTimes(3);
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking');
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'cycling');
-        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'rail');
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'walking', attributes);
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'cycling', attributes);
+        expect(mockedRoutingUtils.mockGetRouteByMode).toHaveBeenCalledWith(attributes.originGeojson, attributes.destinationGeojson, 'rail', attributes);
 
         expect(Object.keys(result)).toEqual(routingModes);
         for (let i = 0; i < routingModes.length; i++) {

--- a/packages/chaire-lib-backend/src/utils/osrm/OSRMMode.ts
+++ b/packages/chaire-lib-backend/src/utils/osrm/OSRMMode.ts
@@ -14,6 +14,7 @@ import osrm from 'osrm'; // Types from the osrm API definition see https://githu
 import * as RoutingService from 'chaire-lib-common/lib/services/routing/RoutingService';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { transitionRouteOptions, transitionMatchOptions } from 'chaire-lib-common/lib/api/OSRMRouting';
+import { TripRoutingQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
 
 //TODO replace this fetch-retry library with one compatible with TS
 const fetch = require('@zeit/fetch-retry')(require('node-fetch'));
@@ -66,14 +67,17 @@ class OSRMMode {
         }
     }
 
-    public async route(params: transitionRouteOptions): Promise<Status.Status<osrm.RouteResults>> {
+    public async route(
+        params: transitionRouteOptions,
+        routingAttributes?: TripRoutingQueryAttributes
+    ): Promise<Status.Status<osrm.RouteResults>> {
         this.validateParamMode(params.mode);
         //TODO validate that points is not empty?? Does it make sense ?
 
         // Fill in default values if they are not defined
         const parameters = _merge(
             {
-                alternatives: false,
+                alternatives: routingAttributes?.withAlternatives === true ? true : false,
                 steps: false,
                 annotations: false, // use "nodes" to get all osm nodes ids
                 geometries: 'geojson',

--- a/packages/chaire-lib-backend/src/utils/osrm/OSRMService.ts
+++ b/packages/chaire-lib-backend/src/utils/osrm/OSRMService.ts
@@ -14,6 +14,7 @@ import * as RoutingService from 'chaire-lib-common/lib/services/routing/RoutingS
 import { RoutingMode, routingModes } from 'chaire-lib-common/lib/config/routingModes';
 
 import OSRMMode from './OSRMMode';
+import { TripRoutingQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
 
 class OSRMService {
     private _modeRegistry: Record<RoutingMode, OSRMMode>;
@@ -22,8 +23,11 @@ class OSRMService {
         this._modeRegistry = {} as Record<RoutingMode, OSRMMode>;
     }
 
-    public route(parameters: transitionRouteOptions): Promise<Status.Status<osrm.RouteResults>> {
-        return this.getMode(parameters.mode).route(parameters);
+    public route(
+        parameters: transitionRouteOptions,
+        routingAttributes?: TripRoutingQueryAttributes
+    ): Promise<Status.Status<osrm.RouteResults>> {
+        return this.getMode(parameters.mode).route(parameters, routingAttributes);
     }
 
     public match(parameters: transitionMatchOptions): Promise<Status.Status<osrm.MatchResults>> {

--- a/packages/chaire-lib-common/src/api/OSRMRouting.ts
+++ b/packages/chaire-lib-common/src/api/OSRMRouting.ts
@@ -12,6 +12,7 @@ https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/osrm/index.
 */
 
 import { RoutingMode } from '../config/routingModes';
+import { TripRoutingQueryAttributes } from '../services/routing/types';
 
 export interface transitionMatchOptions extends osrm.MatchOptions {
     mode: RoutingMode;
@@ -21,4 +22,5 @@ export interface transitionMatchOptions extends osrm.MatchOptions {
 export interface transitionRouteOptions extends osrm.RouteOptions {
     mode: RoutingMode;
     points: GeoJSON.Feature<GeoJSON.Point>[];
+    routingAttributes?: TripRoutingQueryAttributes;
 }

--- a/packages/chaire-lib-common/src/services/routing/ManualRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/ManualRoutingService.ts
@@ -7,6 +7,7 @@
 import * as RoutingService from './RoutingService';
 import * as turf from '@turf/turf';
 import _cloneDeep from 'lodash/cloneDeep';
+import { TripRoutingQueryAttributes } from './types';
 
 /**
  * This class provides routing services using manual routing. This mode will always return return results
@@ -82,7 +83,10 @@ export default class ManualRoutingService extends RoutingService.default {
         return this.routeToMapResults(routingResult);
     }
 
-    public async route(params: RoutingService.MapMatchParameters): Promise<RoutingService.RouteResults> {
+    public async route(
+        params: RoutingService.MapMatchParameters,
+        _routingAttributes?: TripRoutingQueryAttributes
+    ): Promise<RoutingService.RouteResults> {
         const routingResult = await this.directRouting(params.points.features, params.defaultRunningSpeed, true);
 
         return routingResult;

--- a/packages/chaire-lib-common/src/services/routing/RoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingService.ts
@@ -6,6 +6,7 @@
  */
 import GeoJSON from 'geojson';
 import { RoutingMode } from '../../config/routingModes';
+import { TripRoutingQueryAttributes } from './types';
 
 export interface MapMatchParameters {
     mode: RoutingMode;
@@ -118,9 +119,11 @@ export interface RoutingService {
      * route. Various implementations may use them differently.
      *
      * @param params
+     * @param routingAttributes Additional attributes related to the trip
+     * calculation
      * @returns Route matching result
      */
-    route(params: MapMatchParameters): Promise<RouteResults>;
+    route(params: MapMatchParameters, routingAttributes?: TripRoutingQueryAttributes): Promise<RouteResults>;
 
     /**
      * Compute the durations and distances of the fastest route between the

--- a/packages/chaire-lib-common/src/services/routing/RoutingUtils.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingUtils.ts
@@ -7,16 +7,33 @@
 import { RoutingMode } from '../../config/routingModes';
 import { default as routingServiceManager, DEFAULT_ROUTING_ENGINE } from './RoutingServiceManager';
 import { RouteResults } from './RoutingService';
+import { TripRoutingQueryAttributes } from './types';
 
+/**
+ * Calls the routing service to get a route between two points for a single mode
+ * of calculation
+ * @param { GeoJSON.Feature<GeoJSON.Point> } origin The origin point feature
+ * @param { GeoJSON.Feature<GeoJSON.Point> } destination The destination point
+ * feature
+ * @param { RoutingMode }mode The mode of routing calculation, defaults to
+ * 'walking'
+ * @param { TripRoutingQueryAttributes | undefined } routingAttributes Optional
+ * additional routing attributes for this trip calculation
+ * @returns
+ */
 export const getRouteByMode = async (
     origin: GeoJSON.Feature<GeoJSON.Point>,
     destination: GeoJSON.Feature<GeoJSON.Point>,
-    mode: RoutingMode = 'walking'
+    mode: RoutingMode = 'walking',
+    routingAttributes?: TripRoutingQueryAttributes
 ): Promise<RouteResults> => {
     const routingService = routingServiceManager.getRoutingServiceForEngine(DEFAULT_ROUTING_ENGINE);
-    const routingResult = await routingService.route({
-        mode,
-        points: { type: 'FeatureCollection', features: [origin, destination] }
-    });
+    const routingResult = await routingService.route(
+        {
+            mode,
+            points: { type: 'FeatureCollection', features: [origin, destination] }
+        },
+        routingAttributes
+    );
     return routingResult;
 };

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -32,6 +32,7 @@ import { BatchRouteJobType } from '../services/transitRouting/BatchRoutingJob';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
 import { fileKey } from 'transition-common/lib/services/jobs/Job';
+import { TripRoutingQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
 
 // TODO The socket routes should validate parameters as even typescript cannot guarantee the types over the network
 // TODO Add more unit tests as the called methods are cleaned up
@@ -46,9 +47,13 @@ export default function (socket: EventEmitter, userId?: number) {
 
     socket.on(
         'service.osrmRouting.route',
-        async (parameters: transitionRouteOptions, callback: (status: Status.Status<osrm.RouteResults>) => void) => {
+        async (
+            parameters: transitionRouteOptions,
+            routingAttributes: TripRoutingQueryAttributes | undefined,
+            callback: (status: Status.Status<osrm.RouteResults>) => void
+        ) => {
             try {
-                const routingResults = await osrmService.route(parameters);
+                const routingResults = await osrmService.route(parameters, routingAttributes);
                 callback(routingResults);
             } catch (error) {
                 console.error(error);


### PR DESCRIPTION
This requires to pass down the trip routing query attributes all the way down to the OSRM call. It is added as an optional parameter at the end of the `route` and other calculation functions, as well as in the socket route for routing calculation.

If the `withAlternatives` attribute is `true` , the osrm backend call sets the alternatives attribute to `true`.