### PR TITLE
dep: upgrade version of `request-ip`

### DIFF
--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -57,7 +57,6 @@
         "pbf": "^3.2.1",
         "proj4": "^2.7.5",
         "random": "^3.0.6",
-        "request-ip": "^2.1.3",
         "serve-favicon": "^2.5.0",
         "slugify": "^1.6.3",
         "socket.io": "^2.5.0",

--- a/packages/transition-backend/src/serverApp.ts
+++ b/packages/transition-backend/src/serverApp.ts
@@ -19,7 +19,6 @@ import favicon from 'serve-favicon';
 import expressSession from 'express-session';
 import KnexConnection from 'connect-session-knex';
 import morgan from 'morgan'; // http logger
-import requestIp from 'request-ip';
 import authRoutes from 'chaire-lib-backend/lib/api/auth.routes';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import { UserAttributes } from 'chaire-lib-backend/lib/services/users/user';
@@ -90,7 +89,6 @@ export const setupServer = (app: Express) => {
     app.use(express.json({ limit: '500mb' }) as RequestHandler);
     app.use(express.urlencoded({ limit: '500mb', extended: true }) as RequestHandler);
     app.use(session);
-    app.use(requestIp.mw()); // to get users ip addresses
     app.use(favicon(path.join(publicDirectory, 'favicon.ico')));
     app.use(passport.initialize());
     app.use(passport.session());

--- a/yarn.lock
+++ b/yarn.lock
@@ -9266,11 +9266,6 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is_js@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
-  integrity sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -13146,13 +13141,6 @@ replace-ext@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
-
-request-ip@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.1.3.tgz#99ab2bafdeaf2002626e28083cb10597511d9e14"
-  integrity sha512-J3qdE/IhVM3BXkwMIVO4yFrvhJlU3H7JH16+6yHucadT4fePnR8dyh+vEs6FIx0S2x5TCt2ptiPfHcn0sqhbYQ==
-  dependencies:
-    is_js "^0.9.0"
 
 request@^2.85.0:
   version "2.88.2"


### PR DESCRIPTION
* request-ip: 2.1.3 => 3.3.0

This removes dependency to is_js, which has a vulnerability issue.