### PR TITLE
batchRouting: Add logging around the checkpoints

### DIFF
--- a/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
+++ b/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
@@ -214,12 +214,14 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
         const jobProgressEmitter =
             jobListener !== undefined ? jobListener : clientEventManager.getUserEventEmitter(this.attributes.user_id);
         const { resources, data, internal_data } = this.attributes;
+        console.log('Updating job with checkpoint', internal_data.checkpoint);
         const updatedId = await jobsDbQueries.update(this.attributes.id, {
             status: this.status,
             resources,
             data,
             internal_data
         });
+        console.log('Updated job with checkpoint', internal_data.checkpoint);
         jobProgressEmitter.emit('executableJob.updated', { id: updatedId, name: this.attributes.name });
         return updatedId;
     }

--- a/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
+++ b/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
@@ -67,12 +67,14 @@ export class CheckpointTracker {
         // If the previous checkpoint is completed, then notify for the next
         // checkpoint, otherwise do nothing, we need to wait for the previous to
         // complete first
+        console.log('Maybe notify checkpoint at index', chkIndex, this.lastCheckpointIdx);
         if (this.lastCheckpointIdx === chkIndex - 1) {
             let indexToNotify = chkIndex;
             // Get the last completed checkpoint
             while (this.indexes[indexToNotify + 1] === this.chunkSize) {
                 indexToNotify++;
             }
+            console.log('Emitting checkpoint at index ', chkIndex);
             this.progressEmitter.emit('checkpoint', (indexToNotify + 1) * this.chunkSize);
             this.lastCheckpointIdx = indexToNotify;
         }

--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -29,6 +29,7 @@ function newProgressEmitter(task: ExecutableJob<JobDataType>) {
         });
     });
     eventEmitter.on('checkpoint', (checkpoint: number) => {
+        console.log('Task received checkpoint ', checkpoint);
         task.attributes.internal_data.checkpoint = checkpoint;
         task.save();
     });


### PR DESCRIPTION
This will help debug an issue where when the job restarts after theoretically 60% of the calculations have been done, the job still restarts at around 10%.

This commit can be reverted once the problem is solved.