### PR TITLE
Add configuration flag to enable use of the --cacheAllConnectionSets …

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -14,6 +14,9 @@ module.exports = {
     // Maximum number of parallel calculation
     // TODO trRouting should support multi-threading so we shouldn't have to start multiple instances
     // maxParallelCalculators: 2,
+
+    // Enable caching of connections for all scenarios in trRouting. Will use more memory
+    trRoutingCacheAllScenarios: false,
   
     mapDefaultCenter: {
       lat: 45.5092960,


### PR DESCRIPTION
…flag of trRouting

We add an option entry in the config file "trRoutingCacheAllScenarios" which default to false.

If set to true, this will add the cacheAllConnectionSets to the call to trRouting to let it cache the connections for all scenario. By default we only cache the last used. If many scenario are used, this will use quite more memory

This only apply to the "normal" trRouting, not the batch one. Usually, batch calculation only use one scenario, it it would be irrelevant.