### PR TITLE
Enable build on Node 20.x in github workflow

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/examples/config.js
     steps:

--- a/packages/chaire-lib-backend/src/utils/osrm/__tests__/OSRMMode.test.ts
+++ b/packages/chaire-lib-backend/src/utils/osrm/__tests__/OSRMMode.test.ts
@@ -78,7 +78,7 @@ describe('OSRM Mode tests', function() {
         let params = {mode: 'walking' as const,
                       points: [origin, destination1] };
 
-        fetchMock.mockOnce('{ "status"');
+        fetchMock.mockOnce('{ "status":');
          await expect(aMode.route(params)).rejects.toThrow('invalid json response body at  reason: Unexpected end of JSON input');
          
      });


### PR DESCRIPTION
Node 20 is the current LTS, we should migrate our builds to it
(Copied and updated from https://github.com/chairemobilite/transition/pull/1000)