### PR TITLE
debug: Add loggin before/after various routing functions

### DIFF
--- a/packages/chaire-lib-backend/src/services/routing/Routing.ts
+++ b/packages/chaire-lib-backend/src/services/routing/Routing.ts
@@ -123,7 +123,10 @@ export class Routing {
         // ** backend
         const routingPromises: Promise<TransitOrRouteCalculatorResult>[] = [];
 
-        console.log(`Routing beginning with ${routingAttributes.routingModes.length} modes`);
+        const origDestStr = `${routingAttributes.originGeojson.geometry.coordinates.join(',')} to ${routingAttributes.destinationGeojson.geometry.coordinates.join(',')}`;
+        console.log(
+            `tripRouting: Routing beginning with ${routingAttributes.routingModes.length} modes for ${origDestStr}`
+        );
         for (const routingMode of routingAttributes.routingModes) {
             if (isCancelled && isCancelled()) {
                 throw 'Cancelled';
@@ -144,7 +147,7 @@ export class Routing {
             throw 'Cancelled';
         }
 
-        console.log('Routing done');
+        console.log(`tripRouting: Routing done for ${origDestStr}`);
         const maxWalkingTime = Math.min(
             routingAttributes.maxTotalTravelTimeSeconds || 10800,
             2 * (routingAttributes.maxAccessEgressTravelTimeSeconds || 1200)
@@ -163,7 +166,9 @@ export class Routing {
         routingMode: RoutingMode | TransitMode,
         routingAttributes: TripRoutingQueryAttributes
     ): Promise<TransitOrRouteCalculatorResult> {
+        const origDestStr = `${routingAttributes.originGeojson.geometry.coordinates.join(',')} to ${routingAttributes.destinationGeojson.geometry.coordinates.join(',')}`;
         try {
+            console.log(`tripRouting: Routing single mode ${routingMode} for ${origDestStr}`);
             if (routingMode === 'transit') {
                 return {
                     routingMode,
@@ -183,6 +188,7 @@ export class Routing {
                 };
             }
         } catch (error) {
+            console.log(`tripRouting: Error routing single mode ${routingMode} for ${origDestStr}`);
             return {
                 routingMode,
                 result: !TrError.isTrError(error)
@@ -192,6 +198,8 @@ export class Routing {
                     })
                     : error
             };
+        } finally {
+            console.log(`tripRouting: Done routing single mode ${routingMode} for ${origDestStr}`);
         }
     }
 }

--- a/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
+++ b/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
@@ -140,14 +140,23 @@ class TrRoutingServiceBackend {
         parameters: TrRoutingApi.TransitRouteQueryOptions,
         hostPort: TrRoutingApi.HostPort = {}
     ): Promise<TrRoutingApi.TrRoutingV2.RouteResponse> {
-        const trRoutingQuery = this.routeOptionsToQueryString(parameters);
+        const origDestStr = `${parameters.originDestination[0].geometry.coordinates.join(',')} to ${parameters.originDestination[1].geometry.coordinates.join(',')}`;
+        console.log(`tripRouting: Getting route from trRouting for ${origDestStr}`);
+        try {
+            const trRoutingQuery = this.routeOptionsToQueryString(parameters);
 
-        return this.request<TrRoutingApi.TrRoutingV2.RouteResponse>(
-            trRoutingQuery,
-            hostPort.host,
-            hostPort.port,
-            'v2/route'
-        );
+            const result = this.request<TrRoutingApi.TrRoutingV2.RouteResponse>(
+                trRoutingQuery,
+                hostPort.host,
+                hostPort.port,
+                'v2/route'
+            );
+            console.log(`tripRouting: Done getting route from trRouting for ${origDestStr}`);
+            return result;
+        } catch (error) {
+            console.log(`tripRouting: Error getting route from trRouting for ${origDestStr}`);
+            throw error;
+        }
     }
 
     summary(parameters: TrRoutingApi.TransitRouteQueryOptions): Promise<TrRoutingApi.TrRoutingV2.SummaryResponse> {

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -142,10 +142,12 @@ class TrRoutingBatch {
             };
             const logOdTripAfter = (index: number) => {
                 if (benchmarkStart >= 0 && index > 0 && index % 100 === 0) {
+                    // Log the calculation speed every 100 calculations. Divide the number of completed calculation (substract startIndex if the task was resumed) by the time taken in seconds. Round to 2 decimals
                     console.log(
                         'calc/sec',
                         Math.round(
-                            (100 * completedRoutingsCount) / ((1 / 1000) * (performance.now() - benchmarkStart))
+                            (100 * (completedRoutingsCount - startIndex)) /
+                                ((performance.now() - benchmarkStart) / 1000)
                         ) / 100
                     );
                 }

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -164,7 +164,7 @@ class TrRoutingBatch {
                         promiseQueue.clear();
                     }
                     try {
-                        console.log('Start handling batch routing odTrip %d', odTripIndex);
+                        console.log('tripRouting: Start handling batch routing odTrip %d', odTripIndex);
                         await this.odTripTask(odTripIndex, {
                             trRoutingPort,
                             logBefore: logOdTripBefore,
@@ -179,10 +179,12 @@ class TrRoutingBatch {
                                     progress: completedRoutingsCount / odTripsCount
                                 });
                             }
-                            console.log('Handled batch routing odTrip %d', odTripIndex);
+                            console.log('tripRouting: Handled batch routing odTrip %d', odTripIndex);
                             checkpointTracker.handled(odTripIndex);
-                        } catch(error) {
-                            console.error(`Error completing od trip handling. The checkpoint will be missed: ${odTripIndex}: ${error}`);
+                        } catch (error) {
+                            console.error(
+                                `tripRouting: Error completing od trip handling. The checkpoint will be missed: ${odTripIndex}: ${error}`
+                            );
                         }
                     }
                 });
@@ -383,6 +385,8 @@ class TrRoutingBatch {
             }
             options.logBefore(odTripIndex);
 
+            const origDestStr = `${odTrip.attributes.origin_geography.coordinates.join(',')} to ${odTrip.attributes.destination_geography.coordinates.join(',')}`;
+            console.log('tripRouting: Routing odTrip %d with coordinates %s', odTripIndex, origDestStr);
             const routingResult = await routeOdTrip(odTrip, {
                 trRoutingPort: options.trRoutingPort,
                 odTripIndex: odTripIndex,
@@ -405,7 +409,7 @@ class TrRoutingBatch {
                 text: 'transit:transitRouting:errors:ErrorCalculatingOdTrip',
                 params: { id: odTrip.attributes.internal_id || String(odTripIndex) }
             });
-            console.error(`Error getting od trip result ${error}`);
+            console.error(`Error getting od trip result for ${odTripIndex}: ${error}`);
         }
     };
 }

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
@@ -59,14 +59,17 @@ const routeOdTrip = async function (odTrip: BaseOdTrip, parameters: RouteOdTripP
         timeSecondsSinceMidnight: odTrip.attributes.timeOfTrip,
         timeType: odTrip.attributes.timeType
     };
+    const origDestStr = `${originGeojson.geometry.coordinates.join(',')} to ${destinationGeojson.geometry.coordinates.join(',')}`;
 
     try {
+        console.log('tripRouting: Routing single trip... %s', origDestStr);
         const results: RoutingResultsByMode = await Routing.calculate(tripQueryAttributes);
 
         // We do not need the walkOnlyPath in the results, as it is already present in the other modes
         if (results.transit) {
             delete results.transit.walkOnlyPath;
         }
+        console.log('tripRouting: Done routing single trip %s', origDestStr);
 
         return {
             uuid,
@@ -76,6 +79,7 @@ const routeOdTrip = async function (odTrip: BaseOdTrip, parameters: RouteOdTripP
             results
         };
     } catch (error) {
+        console.log('tripRouting: Error routing single trip %s', origDestStr);
         return {
             uuid,
             internalId,


### PR DESCRIPTION
To investigate issue #1011 on instances, we add logs before and after
the calculation functions, each individual mode calculation and the
trRouting requests. The log messages include the origin/destination
coordinates to allow to track individual queries. These can be matched
with the odTripIndex from a log message in the batch routing task.