### PR TITLE
debug: Add logging before/after transit route's socket calls

### DIFF
--- a/packages/chaire-lib-common/src/services/trRouting/TrRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/trRouting/TrRoutingService.ts
@@ -344,10 +344,13 @@ export class TrRoutingService {
         params: TrRoutingApi.TransitRouteQueryOptions,
         hostPort?: TrRoutingApi.HostPort
     ): Promise<TrRoutingRouteResult> {
+        const origDestStr = `${params.originDestination[0].geometry.coordinates.join(',')} to ${params.originDestination[1].geometry.coordinates.join(',')}`;
+        console.log(`tripRouting: Getting route from trRouting service for ${origDestStr}`);
         const responseStatus = await this.callTrRouting<
             { parameters: TrRoutingApi.TransitRouteQueryOptions; hostPort?: TrRoutingApi.HostPort },
             TrRoutingApi.TrRoutingV2.RouteResponse
         >(apiCalls.route, { parameters: params, hostPort });
+        console.log(`tripRouting: Received route response from trRouting service for ${origDestStr}`);
         if (Status.isStatusError(responseStatus)) {
             this.handleErrorStatus(responseStatus);
         }

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -147,12 +147,20 @@ export default function (socket: EventEmitter, userId?: number) {
     });
 
     socket.on(TrRoutingConstants.ROUTE, async ({ parameters, hostPort }, callback) => {
+        const origDestStr = `${parameters.originDestination[0].geometry.coordinates.join(',')} to ${parameters.originDestination[1].geometry.coordinates.join(',')}`;
         try {
+            console.log(`tripRouting: Received route request from socket route for ${origDestStr}`);
             const routingResults = await trRoutingService.route(parameters, hostPort);
             callback(Status.createOk(routingResults));
+            console.log(
+                `tripRouting: Called callback after successful route request from socket route for ${origDestStr}`
+            );
         } catch (error) {
             console.error(error);
             callback(Status.createError(TrError.isTrError(error) ? error.message : error));
+            console.log(
+                `tripRouting: Called callback after erroneous route request from socket route for ${origDestStr}`
+            );
         }
     });
 


### PR DESCRIPTION
While investigating #1011, we add logging in the trRouting's socket calls, to see if the callback is called by the server and received by teh caller.