### PR TITLE
API: Change `summary` endpoint from GET to POST

### DIFF
--- a/docs/APIv1/API.yml
+++ b/docs/APIv1/API.yml
@@ -85,7 +85,7 @@ paths:
                 $ref: 'routingModes.yml#/routingModes'
   
   /api/v1/summary:
-    get:
+    post:
       summary: Get summary of route calculation result
       description: Return a summary of each transit object of a certain type used by the route calculation result 
       parameters:

--- a/packages/transition-backend/src/api/__tests__/public.routes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/public.routes.test.ts
@@ -337,7 +337,7 @@ describe('Testing API endpoints', () => {
         expect(ScenariosAPIResponse).toBeCalled();
     });
 
-    test('GET /api/v1/summary', async () => {
+    test('POST /api/v1/summary', async () => {
         const attributes = { 
             originGeojson: TestUtils.makePoint([1, 2]),
             destinationGeojson: TestUtils.makePoint([3, 4]),
@@ -352,7 +352,7 @@ describe('Testing API endpoints', () => {
 
         mockSummary.mockResolvedValueOnce(result);
 
-        const response = await request(app).get('/api/v1/summary').send(attributes);
+        const response = await request(app).post('/api/v1/summary').send(attributes);
         
         expect(response.status).toStrictEqual(200);
         expect(response.body).toStrictEqual(result);

--- a/packages/transition-backend/src/api/public.routes.ts
+++ b/packages/transition-backend/src/api/public.routes.ts
@@ -30,7 +30,10 @@ import RoutingModesAPIResponse from './public/RoutingModesAPIResponse';
 import RouteAPIResponse from './public/RouteAPIResponse';
 import AccessibilityMapAPIResponse from './public/AccessibilityMapAPIResponse';
 import { validateAndCreateTripRoutingAttributes } from 'chaire-lib-common/lib/services/routing/RoutingAttributes';
-import { validateAndCreateSummaryAttributes, SummaryQueryAttributes } from 'chaire-lib-common/lib/services/routing/SummaryAttributes';
+import {
+    validateAndCreateSummaryAttributes,
+    SummaryQueryAttributes
+} from 'chaire-lib-common/lib/services/routing/SummaryAttributes';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import trRoutingService from 'chaire-lib-backend/lib/utils/trRouting/TrRoutingServiceBackend';
 import { SummaryResponse } from 'chaire-lib-common/lib/api/TrRouting/trRoutingApiV2';
@@ -144,7 +147,7 @@ export default function (app: express.Express, passport: PassportStatic) {
         }
     });
 
-    router.get('/summary', async (req, res, next) => {
+    router.post('/summary', async (req, res, next) => {
         try {
             const body: SummaryQueryAttributes = req.body;
             const summaryAttributes = validateAndCreateSummaryAttributes(body);


### PR DESCRIPTION
This API should mirror the `route` API, which is also a POST. While they could be GET API, as the same parameters expect to return the same data and it does not trigger any data update in the system, the fact that they pass geojson features makes it easier to use a POST request. For a GET, ideally, only the coordinates should be returned.