### PR TITLE
accessibilityMap: Bring the calculation to the backend

### DIFF
--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -54,6 +54,7 @@
         "papaparse": "^5.3.1",
         "passport": "^0.7.0",
         "pbf": "^3.2.1",
+        "polygon-clipping": "^0.15.3",
         "proj4": "^2.7.5",
         "random": "^3.0.6",
         "serve-favicon": "^2.5.0",

--- a/packages/transition-backend/src/api/public.routes.ts
+++ b/packages/transition-backend/src/api/public.routes.ts
@@ -21,7 +21,7 @@ import {
     calculateRoute
 } from '../services/routingCalculation/RoutingCalculator';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
-import { getAttributesOrDefault } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { getAttributesOrDefault } from '../services/accessibilityMap/TransitAccessibilityMapCalculator';
 import { FeatureCollection, LineString, Point } from 'geojson';
 import PathsAPIResponse from './public/PathsAPIResponse';
 import NodesAPIResponse from './public/NodesAPIResponse';

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -32,6 +32,9 @@ import { BatchRouteJobType } from '../services/transitRouting/BatchRoutingJob';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 import TransitOdDemandFromCsv from 'transition-common/lib/services/transitDemand/TransitOdDemandFromCsv';
 import { fileKey } from 'transition-common/lib/services/jobs/Job';
+import { TransitMapCalculationOptions } from 'transition-common/lib/services/accessibilityMap/types';
+import { TransitAccessibilityMapCalculator } from '../services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 
 // TODO The socket routes should validate parameters as even typescript cannot guarantee the types over the network
 // TODO Add more unit tests as the called methods are cleaned up
@@ -173,6 +176,30 @@ export default function (socket: EventEmitter, userId?: number) {
             callback(Status.createError(TrError.isTrError(error) ? error.message : error));
         }
     });
+
+    socket.on(
+        'accessibiliyMap.calculateWithPolygons',
+        async (
+            routingAttributes: AccessibilityMapAttributes,
+            options: TransitMapCalculationOptions,
+            callback: (status: Status.Status<TransitAccessibilityMapWithPolygonResult>) => void
+        ) => {
+            try {
+                const resultsWithPolygon = await TransitAccessibilityMapCalculator.calculateWithPolygons(
+                    routingAttributes,
+                    options
+                );
+                callback(Status.createOk(resultsWithPolygon));
+            } catch (error) {
+                console.error(error);
+                callback(
+                    Status.createError(
+                        error instanceof Error ? error.message : 'Error occurred while calculating route'
+                    )
+                );
+            }
+        }
+    );
 
     // These routes create tasks, which need to be associated to a user. If
     // there is no userId here, it means the socket routes are set from CLI and

--- a/packages/transition-backend/src/services/routingCalculation/RoutingCalculator.ts
+++ b/packages/transition-backend/src/services/routingCalculation/RoutingCalculator.ts
@@ -14,7 +14,7 @@ import { resultToObject } from 'chaire-lib-common/lib/services/routing/RoutingRe
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import TransitAccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
-import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { TransitAccessibilityMapCalculator } from '../accessibilityMap/TransitAccessibilityMapCalculator';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
 import {
@@ -99,11 +99,10 @@ export async function calculateAccessibilityMap(
         // The calculateWithPolygons function in TransitAccessibilityMapCalculator requires a node collection,
         // so the nodes currently in the database are loaded here
         await updateNodeCollection();
-        routingResult = await TransitAccessibilityMapCalculator.calculateWithPolygons(routing, false, {});
+        routingResult = await TransitAccessibilityMapCalculator.calculateWithPolygons(routing.getAttributes(), {});
     } else {
         const accessibilityMap: TransitAccessibilityMapResult = await TransitAccessibilityMapCalculator.calculate(
-            routing,
-            false,
+            routing.getAttributes(),
             {}
         );
         routingResult = {

--- a/packages/transition-backend/src/services/simulation/methods/AccessibilityMapSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/AccessibilityMapSimulation.ts
@@ -15,7 +15,7 @@ import { SimulationMethodFactory, SimulationMethod } from './SimulationMethod';
 import dataSourceDbQueries from 'chaire-lib-backend/lib/models/db/dataSources.db.queries';
 import placesDbQueries from '../../../models/db/places.db.queries';
 import nodesDbQueries from '../../../models/db/transitNodes.db.queries';
-import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { TransitAccessibilityMapCalculator } from '../../accessibilityMap/TransitAccessibilityMapCalculator';
 import TransitAccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
 import AccessibleNodeCache from './AccessibleNodeCache';
@@ -202,10 +202,13 @@ export default class AccessibilityMapSimulation implements SimulationMethod {
                 accessMapRouting.attributes.locationGeojson = turfPoint(place.geography.coordinates);
                 accessMapRouting.attributes.departureTimeSecondsSinceMidnight = randomDepartureTime;
                 try {
-                    const { result } = await TransitAccessibilityMapCalculator.calculate(accessMapRouting, false, {
-                        port: options.trRoutingPort,
-                        accessibleNodes
-                    });
+                    const { result } = await TransitAccessibilityMapCalculator.calculate(
+                        accessMapRouting.getAttributes(),
+                        {
+                            port: options.trRoutingPort,
+                            accessibleNodes
+                        }
+                    );
 
                     const nodeStats = result.getAccessibilityStatsForDuration(
                         options.transitRoutingParameters.maxTotalTravelTimeSeconds || 3600,

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
@@ -10,9 +10,7 @@ import { EventEmitter } from 'events';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import TrRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
-import TransitAccessibilityMapRouting, {
-    AccessibilityMapAttributes
-} from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
+import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import { parseLocationsFromCsv } from '../accessMapLocation/AccessMapLocationProvider';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
 import nodeDbQueries from '../../models/db/transitNodes.db.queries';
@@ -20,7 +18,7 @@ import scenariosDbQueries from '../../models/db/transitScenarios.db.queries';
 import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { createAccessMapFileResultProcessor } from './TrAccessibilityMapBatchResult';
-import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { TransitAccessibilityMapCalculator } from '../accessibilityMap/TransitAccessibilityMapCalculator';
 import { AccessibilityMapLocation } from 'transition-common/lib/services/accessibilityMap/AccessibiltyMapLocation';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 
@@ -139,12 +137,10 @@ export const batchAccessibilityMap = async (
                     calculationAttributes.arrivalTimeSecondsSinceMidnight = location.timeOfTrip;
                     calculationAttributes.departureTimeSecondsSinceMidnight = undefined;
                 }
-                const accessMapRouting = new TransitAccessibilityMapRouting(calculationAttributes);
 
                 try {
                     const routingResult = await TransitAccessibilityMapCalculator.calculateWithPolygons(
-                        accessMapRouting,
-                        false,
+                        calculationAttributes,
                         {
                             port: trRoutingPort,
                             additionalProperties: {

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 import TrRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
 import { parseLocationsFromCsv } from '../../accessMapLocation/AccessMapLocationProvider';
 import { createAccessMapFileResultProcessor } from '../TrAccessibilityMapBatchResult';
-import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { TransitAccessibilityMapCalculator } from '../../accessibilityMap/TransitAccessibilityMapCalculator';
 import { batchAccessibilityMap } from '../TrAccessibilityMapBatch';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';

--- a/packages/transition-common/package.json
+++ b/packages/transition-common/package.json
@@ -38,7 +38,6 @@
     "moment-business-days": "^1.2.0",
     "p-queue": "^6.6.2",
     "pbf": "^3.2.1",
-    "polygon-clipping": "^0.15.3",
     "random": "^3.0.6",
     "slugify": "^1.6.5",
     "typescript": "^4.9.4",

--- a/packages/transition-common/src/services/accessibilityMap/types.ts
+++ b/packages/transition-common/src/services/accessibilityMap/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// TODO Move more types to this file
+
+/**
+ * Options for the calculation of the accessibility map
+ */
+export interface TransitMapCalculationOptions {
+    isCancelled?: (() => boolean) | false;
+    port?: number;
+    /**
+     * Additional properties to add to each accessibility polygon calculated
+     *
+     * @type {{ [key: string]: any }}
+     * @memberof TransitMapCalculationOptions
+     */
+    additionalProperties?: { [key: string]: any };
+    accessibleNodes?: { ids: string[]; durations: number[] };
+    [key: string]: any;
+}

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -26,7 +26,7 @@ import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pagePa
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 import TransitAccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
-import { TransitAccessibilityMapCalculator } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapCalculator';
+import { calculateAccessibilityMap } from '../../../services/routing/RoutingUtils';
 import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
 import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
@@ -127,7 +127,7 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
             const scenarioName = routing.attributes.scenarioId
                 ? this.state.scenarioCollection.getById(routing.attributes.scenarioId).get('name')
                 : '';
-            const currentResult = await TransitAccessibilityMapCalculator.calculateWithPolygons(routing, refresh, {
+            const currentResult = await calculateAccessibilityMap(routing, refresh, {
                 isCancelled,
                 additionalProperties: { scenarioName }
             });

--- a/packages/transition-frontend/src/services/routing/__tests__/RoutingUtils.test.ts
+++ b/packages/transition-frontend/src/services/routing/__tests__/RoutingUtils.test.ts
@@ -8,22 +8,29 @@ import _cloneDeep from 'lodash/cloneDeep';
 import { EventEmitter } from 'events';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 
-import { calculateRouting } from '../RoutingUtils';
+import { calculateRouting, calculateAccessibilityMap } from '../RoutingUtils';
 import TransitRouting, { TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
 import { TestUtils } from 'chaire-lib-common/lib/test';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { RoutingResultsByMode, TransitRoutingQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
+import TransitAccessibilityMapRouting, { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
+import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
+import { TransitMapCalculationOptions } from 'transition-common/lib/services/accessibilityMap/types';
 
 // Mock functions that test can use to simulate the calculation. The mocked
 // result specified in the test will be sent back to the socket route callback,
 // as the calulation response from the server.
-const calculateMock = jest.fn() as jest.MockedFunction<(arg: TransitRoutingQueryAttributes) => Status.Status<RoutingResultsByMode>>;
+const calculateRouteMock = jest.fn() as jest.MockedFunction<(arg: TransitRoutingQueryAttributes) => Status.Status<RoutingResultsByMode>>;
+const calculateAccessibilityMapMock = jest.fn() as jest.MockedFunction<(arg: AccessibilityMapAttributes, options: TransitMapCalculationOptions) => Status.Status<TransitAccessibilityMapWithPolygonResult>>;
 const socketMock = new EventEmitter();
-const calculateServerMock = jest.fn().mockImplementation((queryAttributes, callback) => callback(calculateMock(queryAttributes)));
+const calculateServerMock = jest.fn().mockImplementation((queryAttributes, callback) => callback(calculateRouteMock(queryAttributes)));
+const calculateAccessibilityMapServerMock = jest.fn().mockImplementation((queryAttributes, options, callback) => callback(calculateAccessibilityMapMock(queryAttributes, options)));
 
 socketMock.on('routing.calculate', calculateServerMock);
+socketMock.on('accessibiliyMap.calculateWithPolygons', calculateAccessibilityMapServerMock);
 serviceLocator.addService('socketEventManager', socketMock);
 jest.spyOn(TransitRouting.prototype, 'updateRoutingPrefs').mockImplementation(() => {});
+jest.spyOn(TransitAccessibilityMapRouting.prototype, 'updateRoutingPrefs').mockImplementation(() => {});
 
 describe('calculateRouting', () => {
     const defaultAttributes = {
@@ -57,11 +64,11 @@ describe('calculateRouting', () => {
                 paths: []
             }
         }
-        calculateMock.mockReturnValueOnce(Status.createOk(results));
+        calculateRouteMock.mockReturnValueOnce(Status.createOk(results));
         const routingResults = await calculateRouting(routing);
 
         expect(routingResults).toEqual(results);
-        expect(calculateMock).toHaveBeenCalledWith(
+        expect(calculateRouteMock).toHaveBeenCalledWith(
             routing.toTripRoutingQueryAttributes()
         );
         expect(routing.updateRoutingPrefs).not.toHaveBeenCalled();
@@ -84,14 +91,14 @@ describe('calculateRouting', () => {
                 paths: []
             }
         }
-        calculateMock.mockReturnValueOnce(Status.createOk(results));
+        calculateRouteMock.mockReturnValueOnce(Status.createOk(results));
 
         const routingResults = await calculateRouting(routing);
 
         expect(routingResults).toEqual({
             transit: results.transit
         });
-        expect(calculateMock).toHaveBeenCalledWith(
+        expect(calculateRouteMock).toHaveBeenCalledWith(
             {
                 ...routing.toTripRoutingQueryAttributes(),
                 routingModes: ['transit', 'walking']
@@ -122,11 +129,11 @@ describe('calculateRouting', () => {
                 paths: []
             }
         }
-        calculateMock.mockReturnValueOnce(Status.createOk(results));
+        calculateRouteMock.mockReturnValueOnce(Status.createOk(results));
         const routingResults = await calculateRouting(routing, true);
         
         expect(routingResults).toEqual(results);
-        expect(calculateMock).toHaveBeenCalledWith(
+        expect(calculateRouteMock).toHaveBeenCalledWith(
             routing.toTripRoutingQueryAttributes()
         );
         expect(routing.updateRoutingPrefs).toHaveBeenCalledTimes(1);
@@ -137,7 +144,77 @@ describe('calculateRouting', () => {
         attributes.routingModes = ['cycling'];
         const routing = new TransitRouting(attributes);
         const error = 'Error';
-        calculateMock.mockReturnValueOnce(Status.createError(error));
+        calculateRouteMock.mockReturnValueOnce(Status.createError(error));
         await expect(calculateRouting(routing, false)).rejects.toEqual(error);
     }); 
 });
+
+describe('calculateAccessibilityMap', () => {
+    const defaultAttributes = {
+        locationGeojson: TestUtils.makePoint([-73, 45]),
+        scenarioId: 'abc',
+        id: 'abcdef',
+        data: {},
+        arrivalTimeSecondsSinceMidnight: 25200,
+        maxTotalTravelTimeSeconds: 1800,
+        minWaitingTimeSeconds: 120,
+        maxAccessEgressTravelTimeSeconds: 180,
+        maxTransferTravelTimeSeconds: 120,
+        deltaSeconds: 180,
+        deltaIntervalSeconds: 60
+    };
+    
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should calculate accessibility and receive correct value when successful', async () => {
+        const attributes: AccessibilityMapAttributes = _cloneDeep(defaultAttributes);
+        const routing = new TransitAccessibilityMapRouting(attributes);
+        const results = {
+            polygons: { type: 'FeatureCollection' as const, features: [] },
+            strokes: { type: 'FeatureCollection' as const, features: [] },
+            resultByNode: undefined
+        }
+        calculateAccessibilityMapMock.mockReturnValueOnce(Status.createOk(results));
+        const routingResults = await calculateAccessibilityMap(routing);
+
+        expect(routingResults).toEqual(results);
+        expect(calculateAccessibilityMapMock).toHaveBeenCalledWith(routing.getAttributes(), {});
+        expect(routing.updateRoutingPrefs).not.toHaveBeenCalled();
+    });
+
+    it('should calculate routing and cancel', async () => {
+        const attributes: AccessibilityMapAttributes = _cloneDeep(defaultAttributes);
+        const routing = new TransitAccessibilityMapRouting(attributes);
+        const isCancelled = jest.fn().mockReturnValue(true);
+        const options = { isCancelled };
+        
+        await expect(calculateAccessibilityMap(routing, false, options)).rejects.toEqual('Cancelled');
+    });
+
+    it('should calculate routing and save preferences if requested', async () => {
+        const attributes: AccessibilityMapAttributes = _cloneDeep(defaultAttributes);
+        const routing = new TransitAccessibilityMapRouting(attributes);
+        const results = {
+            polygons: { type: 'FeatureCollection' as const, features: [] },
+            strokes: { type: 'FeatureCollection' as const, features: [] },
+            resultByNode: undefined
+        }
+        calculateAccessibilityMapMock.mockReturnValueOnce(Status.createOk(results));
+        const routingResults = await calculateAccessibilityMap(routing, true);
+        
+        expect(routingResults).toEqual(results);
+        expect(calculateAccessibilityMapMock).toHaveBeenCalledWith(routing.getAttributes(), {});
+        expect(routing.updateRoutingPrefs).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject with error if routing calculation fails', async () => {
+        const attributes: AccessibilityMapAttributes = _cloneDeep(defaultAttributes);
+        const routing = new TransitAccessibilityMapRouting(attributes);
+        const error = 'Error';
+        calculateAccessibilityMapMock.mockReturnValueOnce(Status.createError(error));
+        await expect(calculateAccessibilityMap(routing, false)).rejects.toEqual(error);
+    }); 
+});
+


### PR DESCRIPTION
The main accessibility map calculation function is now moved to the backend instead of the common package.

This adds a socket route `accessibilityMap.calculateWithPolygons` to let the frontend have access to the calculation with polygon.

This will lead to later PRs removing the TrRoutingServiceManager, which is only used in the accessibility map calculations.