### PR TITLE
debug: Remove log statements from `TrRoutingServiceBackend`'s route

### DIFF
--- a/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
+++ b/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
@@ -140,23 +140,14 @@ class TrRoutingServiceBackend {
         parameters: TrRoutingApi.TransitRouteQueryOptions,
         hostPort: TrRoutingApi.HostPort = {}
     ): Promise<TrRoutingApi.TrRoutingV2.RouteResponse> {
-        const origDestStr = `${parameters.originDestination[0].geometry.coordinates.join(',')} to ${parameters.originDestination[1].geometry.coordinates.join(',')}`;
-        console.log(`tripRouting: Getting route from trRouting for ${origDestStr}`);
-        try {
-            const trRoutingQuery = this.routeOptionsToQueryString(parameters);
+        const trRoutingQuery = this.routeOptionsToQueryString(parameters);
 
-            const result = this.request<TrRoutingApi.TrRoutingV2.RouteResponse>(
-                trRoutingQuery,
-                hostPort.host,
-                hostPort.port,
-                'v2/route'
-            );
-            console.log(`tripRouting: Done getting route from trRouting for ${origDestStr}`);
-            return result;
-        } catch (error) {
-            console.log(`tripRouting: Error getting route from trRouting for ${origDestStr}`);
-            throw error;
-        }
+        return this.request<TrRoutingApi.TrRoutingV2.RouteResponse>(
+            trRoutingQuery,
+            hostPort.host,
+            hostPort.port,
+            'v2/route'
+        );
     }
 
     summary(parameters: TrRoutingApi.TransitRouteQueryOptions): Promise<TrRoutingApi.TrRoutingV2.SummaryResponse> {


### PR DESCRIPTION
reverts changes done in this file in https://github.com/tahini/transition/commit/657976c2b9e1d3a828514125a28d4c89e4fc989f

This log statements were wrongly placed as the request is a promise and the log happened before awaiting for the promise completion.

Also, with the TransitRoutingService in the backend, this log is not necessary anymore, as the caller already has log statements.