### PR TITLE
Allow the process manager to configure log files count and sizes

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -25,12 +25,16 @@ module.exports = {
     //         single: {
     //           port: 4000,
     //           // Enable caching of connections for all scenarios in trRouting. Will use more memory
-    //           cacheAllScenarios: false
+    //           cacheAllScenarios: false,
+    //           debug: false,
+    //           logs: { maxFileSizeKB: 5120, nbFiles: 3 }
     //         },
     //         batch: {
     //           port: 14000,
     //           // Enable caching of connections for all scenarios in trRouting. Will use more memory and may not be necessary for batch calculations as currently there's only one scenario per task
-    //           cacheAllScenarios: false
+    //           cacheAllScenarios: false,
+    //           debug: false,
+    //           logs: { maxFileSizeKB: 5120, nbFiles: 3 }
     //         }
     //       }
     //     }

--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -75,7 +75,7 @@
         "typescript": "^4.9.4",
         "uuid": "^10.0.0",
         "validator": "^13.7.0",
-        "winston": "^3.7.2",
+        "winston": "^3.14.2",
         "yargs": "^17.5.1"
     },
     "devDependencies": {

--- a/packages/chaire-lib-backend/src/config/__tests__/ServerConfig.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/ServerConfig.test.ts
@@ -28,7 +28,10 @@ describe('get routing mode and engine configs', () => {
         expect(ServerConfig.getRoutingModeConfig('transit')).toEqual({
             defaultEngine: 'trRouting',
             engines: {
-                trRouting: { single: { port: 5000, cacheAllScenarios: false }, batch: { port: 14000, cacheAllScenarios: false } }
+                trRouting: {
+                    single: { port: 5000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } },
+                    batch: { port: 14000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } }
+                }
             }
         });
     });
@@ -39,8 +42,8 @@ describe('get routing mode and engine configs', () => {
 
     test('getRoutingEngineConfigForMode, mode and engine exist', () => {
         expect(ServerConfig.getRoutingEngineConfigForMode('transit', 'trRouting')).toEqual({
-            single: { port: 5000, cacheAllScenarios: false }, 
-            batch: { port: 14000, cacheAllScenarios: false }
+            single: { port: 5000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } }, 
+            batch: { port: 14000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } }
         });
     });
 

--- a/packages/chaire-lib-backend/src/config/__tests__/server.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/server.config.test.ts
@@ -14,8 +14,8 @@ test('Expected default with env', () => {
     expect(config.projectShortname).toEqual('unitTest');
     expect(config.maxParallelCalculators).toEqual(1);
     expect(config.projectDirectory).toEqual(path.normalize(`${__dirname}/../../../../../tests/dir`));
-    expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 4000, cacheAllScenarios: false });
-    expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false });
+    expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 4000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } });
+    expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 }});
 });
 
 test('setProjectConfiguration', () => {
@@ -26,7 +26,7 @@ test('setProjectConfiguration', () => {
             transit: {
                 defaultEngine: 'trRouting',
                 engines: {
-                    trRouting: { single: { port: 5000 } } as any 
+                    trRouting: { single: { port: 5000 }, batch: { logs: { maxFileSizeKB: 10000 } } } as any 
                 }
             }
         }
@@ -35,6 +35,6 @@ test('setProjectConfiguration', () => {
     expect(config.separateAdminLoginPage).toEqual(false);
     expect(config.projectShortname).toEqual('newProject');
     // Make sure the deep merge works for object configs
-    expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 5000, cacheAllScenarios: false });
-    expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false });
+    expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 5000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } });
+    expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 10000 } });
 });

--- a/packages/chaire-lib-backend/src/config/server.config.ts
+++ b/packages/chaire-lib-backend/src/config/server.config.ts
@@ -15,6 +15,9 @@ import config, {
 import fs from 'fs';
 import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
 
+export const DEFAULT_LOG_FILE_COUNT = 3; // 3 files
+export const DEFAULT_LOG_FILE_SIZE_KB = 5 * 1024; // 5MB
+
 export type TrRoutingConfig = {
     /**
      * Port to use for this trRouting instance
@@ -25,6 +28,24 @@ export type TrRoutingConfig = {
      * trRouting. Will use more memory
      */
     cacheAllScenarios: boolean;
+    /**
+     * Whether to run trRouting in debug mode. Defaults to `false`
+     */
+    debug: boolean;
+    /**
+     * Allow to configure the amount of logging to do for the trRouting process
+     */
+    logs: {
+        // FIXME Add more logging options, for say, something else than files
+        /**
+         * The number of log files to keep. Defaults to 3
+         */
+        nbFiles?: number;
+        /**
+         * The maximum size of a log file in KB. Defaults to 5120 (5MB)
+         */
+        maxFileSizeKB?: number;
+    };
     // FIXME Do we need to configure a host here? If so, we need to properly
     // support it in both batch and single calculation
 };
@@ -126,11 +147,21 @@ setProjectConfigurationCommon<ServerSideProjectConfiguration>({
                 trRouting: {
                     single: {
                         port: 4000,
-                        cacheAllScenarios: false
+                        cacheAllScenarios: false,
+                        debug: false,
+                        logs: {
+                            nbFiles: DEFAULT_LOG_FILE_COUNT,
+                            maxFileSizeKB: DEFAULT_LOG_FILE_SIZE_KB
+                        }
                     },
                     batch: {
                         port: 14000,
-                        cacheAllScenarios: false
+                        cacheAllScenarios: false,
+                        debug: false,
+                        logs: {
+                            nbFiles: DEFAULT_LOG_FILE_COUNT,
+                            maxFileSizeKB: DEFAULT_LOG_FILE_SIZE_KB
+                        }
                     }
                 }
             }

--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
@@ -139,7 +139,9 @@ const start = function (parameters = {} as any): Promise<any> {
         const commandArgs = getOsrmRoutedStartArgs(osrmDirectoryPath, mode, port);
         const waitString = 'running and waiting for requests';
 
-        resolve(ProcessManager.startProcess(serviceName, tagName, command, commandArgs, waitString, true));
+        resolve(
+            ProcessManager.startProcess({ serviceName, tagName, command, commandArgs, waitString, useShell: true })
+        );
     });
 };
 
@@ -167,7 +169,15 @@ const restart = function (parameters): Promise<any> {
         const waitString = 'running and waiting for requests';
 
         resolve(
-            ProcessManager.startProcess(serviceName, tagName, command, commandArgs, waitString, true, undefined, true)
+            ProcessManager.startProcess({
+                serviceName,
+                tagName,
+                command,
+                commandArgs,
+                waitString,
+                useShell: true,
+                attemptRestart: true
+            })
         );
     });
 };

--- a/packages/chaire-lib-backend/src/utils/processManagers/ProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/ProcessManager.ts
@@ -60,7 +60,7 @@ const getLoggerName = function (tagName: string, serviceName: string) {
     return `${tagName}Logger_${serviceName}_`;
 };
 
-const setupLogger = function (tagName: string, serviceName: string) {
+const setupLogger = function ({ tagName, serviceName }: { tagName: string; serviceName: string }) {
     const loggerName = getLoggerName(tagName, serviceName);
     serviceLocator.addService(
         loggerName,
@@ -80,16 +80,25 @@ const setupLogger = function (tagName: string, serviceName: string) {
     return loggerName;
 };
 
-const startProcess = async function (
-    serviceName: string,
-    tagName: string,
-    command: string,
-    commandArgs: any,
-    waitString: string,
-    useShell: boolean,
-    cwd?: string,
+const startProcess = async function ({
+    serviceName,
+    tagName,
+    command,
+    commandArgs,
+    waitString,
+    useShell,
+    cwd,
     attemptRestart = false
-): Promise<any> {
+}: {
+    serviceName: string;
+    tagName: string;
+    command: string;
+    commandArgs: any;
+    waitString: string;
+    useShell: boolean;
+    cwd?: string;
+    attemptRestart?: boolean;
+}): Promise<any> {
     return new Promise((resolve) => {
         // Check if we already a process running for that serviceName
         // TODO Should be an await instead of then but need to rework the promise to make it work
@@ -99,7 +108,7 @@ const startProcess = async function (
             const doStart = function () {
                 // If we reached this point, we don't have a process running or it was stopped
 
-                const loggerName = setupLogger(tagName, serviceName);
+                const loggerName = setupLogger({ tagName, serviceName });
 
                 const spawnParams = {
                     shell: useShell,

--- a/packages/chaire-lib-backend/src/utils/processManagers/ProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/ProcessManager.ts
@@ -10,10 +10,9 @@ import { fileManager } from '../filesystem/fileManager';
 import { directoryManager } from '../filesystem/directoryManager';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import ProcessUtils from './ProcessUtils';
+import { DEFAULT_LOG_FILE_COUNT, DEFAULT_LOG_FILE_SIZE_KB } from '../../config/server.config';
 
 const PID_DIRECTORY = 'pids';
-const DEFAULT_LOG_FILE_COUNT = 3; // 3 files
-const DEFAULT_LOG_FILE_SIZE_KB = 5000; // 5MB
 
 directoryManager.createDirectoryIfNotExists(PID_DIRECTORY);
 

--- a/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
@@ -61,16 +61,16 @@ const startTrRoutingProcess = async (
 
     const waitString = 'ready.';
 
-    const processStatus = await ProcessManager.startProcess(
+    const processStatus = await ProcessManager.startProcess({
         serviceName,
         tagName,
         command,
         commandArgs,
         waitString,
-        false,
+        useShell: false,
         cwd,
         attemptRestart
-    );
+    });
     if (processStatus.status === 'error' && processStatus.error.code === 'ENOENT') {
         console.error(
             `trRouting executable does not exist in path ${

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
@@ -8,6 +8,7 @@ var mockSpawn = require('mock-spawn');
 
 var testSpawn = mockSpawn();
 
+import { DEFAULT_LOG_FILE_SIZE_KB } from '../../../config/server.config';
 //TODO maybe use just fs object calls
 import { fileManager } from '../../filesystem/fileManager';
 import ProcessManager from '../ProcessManager';
@@ -91,7 +92,7 @@ describe('Process Manager testing', function() {
         }));
         const logger = createLoggerMock.mock.calls[0][0];
         const fileTransport = (logger as any).transports[0] as winston.transports.FileTransportInstance;
-        expect(fileTransport.maxsize).toEqual(5120000);
+        expect(fileTransport.maxsize).toEqual(DEFAULT_LOG_FILE_SIZE_KB * 1024);
         expect(fileTransport.maxFiles).toEqual(3);
 
         // CHeck isServiceRunning

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
@@ -55,7 +55,14 @@ describe('Process Manager testing', function() {
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
 
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);      
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });      
         expect(result.status).toBe('started');
         expect(testSpawn.calls[0].command).toBe('ls');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
@@ -85,7 +92,14 @@ describe('Process Manager testing', function() {
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
         
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);      
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });      
         expect(result.status).toBe('started');
         expect(testSpawn.calls[0].command).toBe('ls');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
@@ -94,7 +108,15 @@ describe('Process Manager testing', function() {
 
         // Restart serivce
         mockPidRunning.mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(false);
-        var resultRestart = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false, undefined, true);
+        var resultRestart = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false,
+            attemptRestart: true
+        });
         expect(resultRestart.status).toBe('started');
         expect(mockPidRunning).toHaveBeenCalled();
         expect(mockKill).toHaveBeenCalled();
@@ -117,7 +139,14 @@ describe('Process Manager testing', function() {
         testSpawn.sequence.add(testSpawn.simple(0, 'All Not Good!'));
 
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });
         // TODO, the spawn mock simulate a process that exit immediatly, so this is not fully
         // representative of a process that would still run, but don't have the right output. Still
         // covering some of the code path
@@ -131,13 +160,28 @@ describe('Process Manager testing', function() {
         testSpawn.sequence.add(testSpawn.simple(0, 'All Good'));
 
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });
         expect(result.status).toBe('started');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
         
         // Restart service
         mockPidRunning.mockReturnValue(true);
-        var resultRestart = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false, undefined, true);
+        var resultRestart = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false,
+            attemptRestart: true
+        });
         expect(resultRestart.status).toBe('could_not_restart');
         expect(mockPidRunning).toHaveBeenCalled();
         expect(mockKill).toHaveBeenCalled();
@@ -196,14 +240,28 @@ describe('Process Manager testing', function() {
         mockPidRunning.mockReturnValue(true);
         
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });
         expect(result.status).toBe('started');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
         expect(fileManager.readFile("pids/TestService1.pid")).toBe("6");
 
         testSpawn.sequence.add(testSpawn.simple(0, 'All Good'));
         // Start same service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });
         expect(result.status).toBe('already_running');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
         expect(fileManager.readFile("pids/TestService1.pid")).toBe("6");
@@ -223,13 +281,27 @@ describe('Process Manager testing', function() {
         mockPidRunning.mockReturnValue(true);
         
         // Start first service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });
         expect(result.status).toBe('started');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
         expect(fileManager.readFile("pids/TestService1.pid")).toBe("7");
         // Start other service
         
-        var resultOther = await ProcessManager.startProcess("OtherService", "TEST", "cat", ["-l"], "Other Good", false);
+        var resultOther = await ProcessManager.startProcess({
+            serviceName: "OtherService",
+            tagName: "TEST",
+            command: "cat",
+            commandArgs: ["-l"],
+            waitString: "Other Good",
+            useShell: false
+        });
         expect(resultOther.status).toBe('started');
         expect(fileManager.fileExists("pids/OtherService.pid")).toBe(true);
         expect(fileManager.readFile("pids/OtherService.pid")).toBe("8");
@@ -246,7 +318,14 @@ describe('Process Manager testing', function() {
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
 
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false);
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        });
         expect(result.status).toBe('started');
         expect(testSpawn.calls[0].command).toBe('ls');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
@@ -278,7 +357,14 @@ describe('Process Manager testing', function() {
 
         
         // Start service
-        var result = await ProcessManager.startProcess(testServiceName, "TEST", "ls", ["-l"], "All Good", false); 
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "All Good",
+            useShell: false
+        }); 
         expect(result.status).toBe('started');
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
 

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -155,6 +155,31 @@ describe('TrRouting Process Manager: start', () => {
             cwd: undefined,
             attemptRestart: false
         });
+        
+    });
+    test('start process with all parameters set', async () => {
+        const port = 1234;
+        const debug = true;
+        const cacheDirectoryPath = "/tmp/cache";
+        const status = await TrRoutingProcessManager.start({ port, debug, cacheDirectoryPath });
+        expect(status).toEqual({
+            status: 'started',
+            action: 'start',
+            service: 'trRouting',
+            name: `trRouting${port}`
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: `trRouting${port}`,
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false,
+
+        });
     });
     test('start process with deprecated trRoutingCacheAllScenarios configuration option', async () => {
         // Add a port and cacheAllScenarios to the trRouting single config
@@ -240,7 +265,7 @@ describe('TrRouting Process Manager: start', () => {
         });
     });
     test('start batch process with 4 cpus on a custom port', async () => {
-        const status = await TrRoutingProcessManager.startBatch(4, 12345);
+        const status = await TrRoutingProcessManager.startBatch(4, { port: 12345 });
         expect(status).toEqual({
             status: 'started',
             service: 'trRoutingBatch',
@@ -274,6 +299,29 @@ describe('TrRouting Process Manager: start', () => {
             tagName: 'trRouting',
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
+    });
+
+    test('start batch process with all parameters set', async () => {
+        const port = 12345;
+        const debug = true;
+        const cacheDirectoryPath = "/tmp/cache";
+        const status = await TrRoutingProcessManager.startBatch(4, { port, debug, cacheDirectoryPath });
+        expect(status).toEqual({
+            status: 'started',
+            service: 'trRoutingBatch',
+            port: 12345
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting12345',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -70,7 +70,11 @@ describe('TrRouting Process Manager: start', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
 
@@ -92,7 +96,11 @@ describe('TrRouting Process Manager: start', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: __dirname,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start process with a specific port number', async () => {
@@ -113,7 +121,11 @@ describe('TrRouting Process Manager: start', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: __dirname,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start process with a custom cache directory', async () => {
@@ -134,7 +146,11 @@ describe('TrRouting Process Manager: start', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: __dirname,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start process with configured port and cacheAllScenarios for single trRouting', async () => {
@@ -157,7 +173,11 @@ describe('TrRouting Process Manager: start', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
         
     });
@@ -182,7 +202,10 @@ describe('TrRouting Process Manager: start', () => {
             useShell: false,
             cwd: undefined,
             attemptRestart: false,
-
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start process with deprecated trRoutingCacheAllScenarios configuration option', async () => {
@@ -204,7 +227,37 @@ describe('TrRouting Process Manager: start', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
+        });
+    });
+    test('With debug and logFiles in the config', async () => {
+        const logFiles = { maxFileSizeKB: 1500, nbFiles: 5 };
+        setProjectConfiguration({ routing: { transit: { engines: { trRouting: { single: { debug: true, logs: logFiles } } as any } } as any } });
+        const status = await TrRoutingProcessManager.start({});
+        expect(status).toEqual({
+            status: 'started',
+            action: 'start',
+            service: 'trRouting',
+            name: 'trRouting4000'
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting4000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: logFiles.nbFiles,
+                maxFileSizeKB: logFiles.maxFileSizeKB
+            }
         });
     });
 });
@@ -233,7 +286,11 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
 
@@ -255,7 +312,11 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: __dirname,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('with a specific port number', async () => {
@@ -276,7 +337,11 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: __dirname,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('with a custom cache directory', async () => {
@@ -297,7 +362,11 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: __dirname,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start process with configured port and cacheAllScenarios for single trRouting', async () => {
@@ -320,7 +389,11 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
         
     });
@@ -346,7 +419,11 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('doNotStartIfStopped true, process not running', async () => {
@@ -379,7 +456,37 @@ describe('TrRouting Process Manager: restart', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: true
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
+        });
+    });
+    test('With debug and logFiles in the config', async () => {
+        const logFiles = { maxFileSizeKB: 1500, nbFiles: 5 };
+        setProjectConfiguration({ routing: { transit: { engines: { trRouting: { single: { debug: true, logs: logFiles } } as any } } as any } });
+        const status = await TrRoutingProcessManager.restart({});
+        expect(status).toEqual({
+            status: 'started',
+            action: 'start',
+            service: 'trRouting',
+            name: 'trRouting4000'
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting4000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: true,
+            logFiles: {
+                nbLogFiles: logFiles.nbFiles,
+                maxFileSizeKB: logFiles.maxFileSizeKB
+            }
         });
     });
 });
@@ -407,7 +514,11 @@ describe('TrRouting Process Manager: startBatch', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start batch process with 4 cpus', async () => {
@@ -426,7 +537,11 @@ describe('TrRouting Process Manager: startBatch', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start batch process with 4 cpus with 2 limit', async () => {
@@ -449,7 +564,11 @@ describe('TrRouting Process Manager: startBatch', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start batch process with 4 cpus on a custom port', async () => {
@@ -468,7 +587,11 @@ describe('TrRouting Process Manager: startBatch', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
     test('start batch process with 4 cpus with port and cacheAll configuration', async () => {
@@ -490,7 +613,11 @@ describe('TrRouting Process Manager: startBatch', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
         });
     });
 
@@ -513,8 +640,36 @@ describe('TrRouting Process Manager: startBatch', () => {
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
-            attemptRestart: false
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
+        });
+    });
+    test('With debug and logFiles in the config', async () => {
+        const logFiles = { maxFileSizeKB: 1500, nbFiles: 5 };
+        setProjectConfiguration({ routing: { transit: { engines: { trRouting: { batch: { debug: true, logs: logFiles } } as any } } as any } });
+        const status = await TrRoutingProcessManager.startBatch(4);
+        expect(status).toEqual({
+            status: 'started',
+            service: 'trRoutingBatch',
+            port: 14000
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting14000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: logFiles.nbFiles,
+                maxFileSizeKB: logFiles.maxFileSizeKB
+            }
         });
     });
 });
-

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -25,14 +25,7 @@ const getModeMock = osrmService.getMode as jest.MockedFunction<typeof osrmServic
 const walkingOsrmMode = new OSRMMode('walking', 'localhost', 1234, true);
 getModeMock.mockImplementation((mode) => walkingOsrmMode);
 
-startProcessMock.mockImplementation(async (serviceName: string,
-    tagName: string,
-    command: string,
-    commandArgs: any,
-    waitString: string,
-    useShell: boolean,
-    cwd?: string,
-    attemptRestart = false) => ({
+startProcessMock.mockImplementation(async ({ tagName, serviceName }) => ({
     status: 'started',
     action: 'start',
     service: tagName,
@@ -41,8 +34,7 @@ startProcessMock.mockImplementation(async (serviceName: string,
 // Clone the original config to reset it after each test
 let originalTestConfig = _cloneDeep(config);
 beforeEach(function () {
-    startProcessMock.mockClear();
-    stopProcessMock.mockClear();
+    jest.clearAllMocks();
     // Reset the config to default
     setProjectConfiguration(originalTestConfig);
     // Override max parallel setting
@@ -66,16 +58,16 @@ describe('TrRouting Process Manager: start', () => {
             name: 'trRouting4000'
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting4000',
-            'trRouting',
-            'trRouting',
-            ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting4000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
 
     test('start process from TR_ROUTING_PATH environment variable', async () => {
@@ -88,16 +80,16 @@ describe('TrRouting Process Manager: start', () => {
             name: 'trRouting4000'
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting4000',
-            'trRouting',
-            './trRouting',
-            ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
-            'ready.',
-            false,
-            __dirname,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting4000',
+            tagName: 'trRouting',
+            command: './trRouting',
+            commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: __dirname,
+            attemptRestart: false
+        });
     });
     test('start process with a specific port number', async () => {
         process.env.TR_ROUTING_PATH = __dirname;
@@ -109,16 +101,16 @@ describe('TrRouting Process Manager: start', () => {
             name: 'trRouting1234'
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting1234',
-            'trRouting',
-            './trRouting',
-            ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
-            'ready.',
-            false,
-            __dirname,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting1234',
+            tagName: 'trRouting',
+            command: './trRouting',
+            commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: __dirname,
+            attemptRestart: false
+        });
     });
     test('start process with a custom cache directory', async () => {
         process.env.TR_ROUTING_PATH = __dirname;
@@ -130,16 +122,16 @@ describe('TrRouting Process Manager: start', () => {
             name: 'trRouting4000'
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting4000',
-            'trRouting',
-            './trRouting',
-            ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
-            'ready.',
-            false,
-            __dirname,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting4000',
+            tagName: 'trRouting',
+            command: './trRouting',
+            commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: __dirname,
+            attemptRestart: false
+        });
     });
     test('start process with configured port and cacheAllScenarios for single trRouting', async () => {
         // Add a port and cacheAllScenarios to the trRouting single config
@@ -153,16 +145,16 @@ describe('TrRouting Process Manager: start', () => {
             name: `trRouting${port}`
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            `trRouting${port}`,
-            'trRouting',
-            'trRouting',
-            [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: `trRouting${port}`,
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
     test('start process with deprecated trRoutingCacheAllScenarios configuration option', async () => {
         // Add a port and cacheAllScenarios to the trRouting single config
@@ -175,16 +167,16 @@ describe('TrRouting Process Manager: start', () => {
             name: 'trRouting4000'
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting4000',
-            'trRouting',
-            'trRouting',
-            ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting4000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
     test('start batch process with 1 cpu', async () => {
         const status = await TrRoutingProcessManager.startBatch(1);
@@ -194,16 +186,16 @@ describe('TrRouting Process Manager: start', () => {
             port: 14000
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting14000',
-            'trRouting',
-            'trRouting',
-            ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting14000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
     test('start batch process with 4 cpus', async () => {
         const status = await TrRoutingProcessManager.startBatch(4);
@@ -213,16 +205,16 @@ describe('TrRouting Process Manager: start', () => {
             port: 14000
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting14000',
-            'trRouting',
-            'trRouting',
-            ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting14000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
     test('start batch process with 4 cpus with 2 limit', async () => {
         // Override the configuration
@@ -236,16 +228,16 @@ describe('TrRouting Process Manager: start', () => {
             port: 14000
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting14000',
-            'trRouting',
-            'trRouting',
-            ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting14000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
     test('start batch process with 4 cpus on a custom port', async () => {
         const status = await TrRoutingProcessManager.startBatch(4, 12345);
@@ -255,16 +247,16 @@ describe('TrRouting Process Manager: start', () => {
             port: 12345
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            'trRouting12345',
-            'trRouting',
-            'trRouting',
-            ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: 'trRouting12345',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
     test('start batch process with 4 cpus with port and cacheAll configuration', async () => {
         // Add a port and cacheAllScenarios to the trRouting batch config
@@ -277,15 +269,15 @@ describe('TrRouting Process Manager: start', () => {
             port
         });
         expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith(
-            `trRouting${port}`,
-            'trRouting',
-            'trRouting',
-            [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
-            'ready.',
-            false,
-            undefined,
-            false
-        );
+        expect(startProcessMock).toHaveBeenCalledWith({
+            serviceName: `trRouting${port}`,
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
     });
 });

--- a/packages/transition-backend/src/services/simulation/SimulationRun.ts
+++ b/packages/transition-backend/src/services/simulation/SimulationRun.ts
@@ -59,11 +59,10 @@ export default class SimulationRunBackend extends SimulationRun {
 
     async restartTrRoutingInstances() {
         await TrRoutingProcessManager.stopBatch(this.getBatchPort());
-        await TrRoutingProcessManager.startBatch(
-            (this.attributes.options?.numberOfThreads as number) || 1,
-            this.getBatchPort(),
-            this.getProjectRelativeCacheDirectoryPath()
-        );
+        await TrRoutingProcessManager.startBatch((this.attributes.options?.numberOfThreads as number) || 1, {
+            port: this.getBatchPort(),
+            cacheDirectoryPath: this.getProjectRelativeCacheDirectoryPath()
+        });
         this.promiseQueue = new pQueue({ concurrency: (this.attributes.options?.numberOfThreads as number) || 1 });
     }
 

--- a/packages/transition-frontend/webpack.config.js
+++ b/packages/transition-frontend/webpack.config.js
@@ -19,7 +19,10 @@ if (!process.env.NODE_ENV) {
 }
 
 const configuration = require('chaire-lib-backend/lib/config/server.config');
-const config = configuration.default ? configuration.default : configuration;
+// Extract from the config all options that we should not send to the frontend.
+// The `{ ...config }` will be sent to the frontend
+// TODO This won't be necessary once we have frontend and backend configuration separated
+const { trRoutingCacheAllScenarios, routing, ...config } = configuration.default ? configuration.default : configuration;
 
 // Public directory from which files are served
 const publicDirectory = path.join(__dirname, '..', '..', 'public');

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,10 @@
   dependencies:
     "@ucast/mongo2js" "^1.3.0"
 
-"@colors/colors@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
-  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
@@ -3660,6 +3660,11 @@
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
+
+"@types/triple-beam@^1.3.2":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
 
 "@types/uglify-js@*":
   version "3.9.2"
@@ -9084,12 +9089,13 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-logform@^2.3.2, logform@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/logform/-/logform-2.4.0.tgz#131651715a17d50f09c2a2c1a524ff1a4164bcfe"
-  integrity sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==
+logform@^2.6.0, logform@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.6.1.tgz#71403a7d8cae04b2b734147963236205db9b3df0"
+  integrity sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==
   dependencies:
-    "@colors/colors" "1.5.0"
+    "@colors/colors" "1.6.0"
+    "@types/triple-beam" "^1.3.2"
     fecha "^4.2.0"
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
@@ -11595,6 +11601,15 @@ readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~1.0.31:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -13852,30 +13867,31 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-winston-transport@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
-  integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+winston-transport@^4.7.0:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.7.1.tgz#52ff1bcfe452ad89991a0aaff9c3b18e7f392569"
+  integrity sha512-wQCXXVgfv/wUPOfb2x0ruxzwkcZfxcktz6JIMUaPLmcNhO4bZTwA/WtDWK74xV3F2dKu8YadrFv0qhwYjVEwhA==
   dependencies:
-    logform "^2.3.2"
-    readable-stream "^3.6.0"
+    logform "^2.6.1"
+    readable-stream "^3.6.2"
     triple-beam "^1.3.0"
 
-winston@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.7.2.tgz#95b4eeddbec902b3db1424932ac634f887c400b1"
-  integrity sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==
+winston@^3.14.2:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.14.2.tgz#94ce5fd26d374f563c969d12f0cd9c641065adab"
+  integrity sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==
   dependencies:
+    "@colors/colors" "^1.6.0"
     "@dabh/diagnostics" "^2.0.2"
     async "^3.2.3"
     is-stream "^2.0.0"
-    logform "^2.4.0"
+    logform "^2.6.0"
     one-time "^1.0.0"
     readable-stream "^3.4.0"
     safe-stable-stringify "^2.3.1"
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
-    winston-transport "^4.5.0"
+    winston-transport "^4.7.0"
 
 wkt-parser@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
* Use named objects instead of ordinal parameters for the numerous function parameters. This makes a call more readable, make it easier to fine-tune specific parameters while keeping the default values for others, and will make adding yet more parameters simpler.

* Let `ProcessManager` support log file count and size as extra parameter

* Let `TrRoutingProcessManager` support log file count and size as extra parameter. `startBatch` now also supports the `debug` option.

* Add tests for the new functionalities