### PR TITLE
trRouting: Move port and cacheAllScenarios to instance specific config

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -11,12 +11,31 @@ module.exports = {
     },
     maxParallelCalculators: 2,
     
-    // Maximum number of parallel calculation
-    // TODO trRouting should support multi-threading so we shouldn't have to start multiple instances
+    // Maximum number of parallel calculation. Used in tasks to start the calculator with this number of threads.
     // maxParallelCalculators: 2,
 
-    // Enable caching of connections for all scenarios in trRouting. Will use more memory
-    trRoutingCacheAllScenarios: false,
+    // @deprecated: Use the cacheAllScenarios in the 'routing.transit.engines.trRouting' configuration instead
+    // trRoutingCacheAllScenarios: false,
+    // Configuration for the trRouting services. Single is for the single calculation instance (from the UI and public API), while batch is for the batch calculation instance, for tasks
+    // routing: {
+    //   transit: {
+    //     defaultEngine: 'trRouting',
+    //     engines: {
+    //       trRouting: {
+    //         single: {
+    //           port: 4000,
+    //           // Enable caching of connections for all scenarios in trRouting. Will use more memory
+    //           cacheAllScenarios: false
+    //         },
+    //         batch: {
+    //           port: 14000,
+    //           // Enable caching of connections for all scenarios in trRouting. Will use more memory and may not be necessary for batch calculations as currently there's only one scenario per task
+    //           cacheAllScenarios: false
+    //         }
+    //       }
+    //     }
+    //   }
+    // },
   
     mapDefaultCenter: {
       lat: 45.5092960,

--- a/packages/chaire-lib-backend/src/config/ServerConfig.ts
+++ b/packages/chaire-lib-backend/src/config/ServerConfig.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import config, { TrRoutingConfig } from './server.config';
+import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+
+/**
+ * Helper class to manage accesses to server configuration
+ */
+class ServerConfig {
+    constructor() {
+        // Nothing to do
+        // TODO Currently, the `server.config` file sets the default value,
+        // because there is not that many we want to set, but as we add more,
+        // this class should be responsible to set them
+    }
+
+    /**
+     * Get the routing mode configuration
+     * @param mode The mode to get the configuration for
+     * @returns the project configuration, or undefined if the mode is not configured
+     */
+    getRoutingModeConfig = (mode: RoutingOrTransitMode) => {
+        if (config.routing[mode] === undefined) {
+            console.error('Configuration for routing mode %s not found', mode);
+        }
+        return config.routing[mode];
+    };
+
+    /**
+     * Get the routing engine configuration for a given mode
+     *
+     * TODO See if we can type the return value better as each engine should
+     * have their own config type
+     *
+     * @param mode The mode to get the configuration for
+     * @param engine The engine to use
+     * @returns
+     */
+    getRoutingEngineConfigForMode = (mode: RoutingOrTransitMode, engine: string) => {
+        if (config.routing[mode] === undefined) {
+            console.error('Configuration for routing mode %s not found', mode);
+        }
+        if (config.routing[mode] !== undefined && config.routing[mode]!.engines[engine] === undefined) {
+            console.error('Configuration for engine %s for routing mode %s not found', engine, mode);
+        }
+        return config.routing[mode]?.engines[engine];
+    };
+
+    getTrRoutingConfig = (instance: 'single' | 'batch'): TrRoutingConfig => {
+        const engineConfiguration = this.getRoutingEngineConfigForMode('transit', 'trRouting');
+        // The configuration should be defined, throw an error if it is not, we have a problem
+        if (engineConfiguration === undefined) {
+            throw new Error('trRouting configuration not found');
+        }
+        return engineConfiguration[instance] || { port: 4000, cacheAllScenarios: false };
+    };
+}
+
+const instance = new ServerConfig();
+export default instance;

--- a/packages/chaire-lib-backend/src/config/__tests__/ServerConfig.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/ServerConfig.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { setProjectConfiguration } from '../server.config';
+import ServerConfig from '../ServerConfig';
+
+
+describe('get routing mode and engine configs', () => {
+
+    beforeEach(() => {
+        setProjectConfiguration({
+            routing: {
+                transit: {
+                    defaultEngine: 'trRouting',
+                    engines: {
+                        trRouting: { single: { port: 5000 } } as any 
+                    }
+                }
+            }
+        });
+    });
+
+    test('getRoutingModeConfig, mode exists', () => {
+        expect(ServerConfig.getRoutingModeConfig('transit')).toEqual({
+            defaultEngine: 'trRouting',
+            engines: {
+                trRouting: { single: { port: 5000, cacheAllScenarios: false }, batch: { port: 14000, cacheAllScenarios: false } }
+            }
+        });
+    });
+
+    test('getRoutingModeConfig, mode does not exist', () => {
+        expect(ServerConfig.getRoutingModeConfig('walking')).toBeUndefined();
+    });
+
+    test('getRoutingEngineConfigForMode, mode and engine exist', () => {
+        expect(ServerConfig.getRoutingEngineConfigForMode('transit', 'trRouting')).toEqual({
+            single: { port: 5000, cacheAllScenarios: false }, 
+            batch: { port: 14000, cacheAllScenarios: false }
+        });
+    });
+
+    test('getRoutingEngineConfigForMode, engine does not exist', () => {
+        expect(ServerConfig.getRoutingEngineConfigForMode('transit', 'valhalla')).toBeUndefined();
+    });
+
+    test('getRoutingEngineConfigForMode, mode does not exist', () => {
+        expect(ServerConfig.getRoutingEngineConfigForMode('walking', 'osrm')).toBeUndefined();
+    });
+
+});

--- a/packages/chaire-lib-backend/src/config/__tests__/server.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/server.config.test.ts
@@ -1,5 +1,11 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
 process.env.PROJECT_CONFIG = `${__dirname}/../../../../../tests/config2_test.js`;
-import config from '../server.config';
+import config, { setProjectConfiguration } from '../server.config';
 import path from 'path';
 
 test('Expected default with env', () => {
@@ -8,4 +14,27 @@ test('Expected default with env', () => {
     expect(config.projectShortname).toEqual('unitTest');
     expect(config.maxParallelCalculators).toEqual(1);
     expect(config.projectDirectory).toEqual(path.normalize(`${__dirname}/../../../../../tests/dir`));
+    expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 4000, cacheAllScenarios: false });
+    expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false });
+});
+
+test('setProjectConfiguration', () => {
+    setProjectConfiguration({
+        projectShortname: 'newProject',
+        mapDefaultCenter: { lon: -73, lat: 45 },
+        routing: {
+            transit: {
+                defaultEngine: 'trRouting',
+                engines: {
+                    trRouting: { single: { port: 5000 } } as any 
+                }
+            }
+        }
+    });
+    expect(config.mapDefaultCenter).toEqual({ lon: -73, lat: 45 });
+    expect(config.separateAdminLoginPage).toEqual(false);
+    expect(config.projectShortname).toEqual('newProject');
+    // Make sure the deep merge works for object configs
+    expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 5000, cacheAllScenarios: false });
+    expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false });
 });

--- a/packages/chaire-lib-backend/src/config/auth/__tests__/directToken.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/auth/__tests__/directToken.config.test.ts
@@ -103,7 +103,7 @@ each([
 test('Complete flow with valid token', async() => {
     config.auth = {
         directToken: {
-            tokenFormat: undefined
+            tokenFormat: undefined as any
         }
     };
     directTokenLogin(passport, userAuthModel)

--- a/packages/chaire-lib-backend/src/config/auth/directToken.config.ts
+++ b/packages/chaire-lib-backend/src/config/auth/directToken.config.ts
@@ -17,7 +17,7 @@ const isTokenValid = (token: string): boolean => {
     // TODO The token regex format could be validated at the start instead of
     // in this method. But this is called only for new users and it is easier to
     // unit test as it is now, so we keep this here.
-    const tokenFormat = config.auth?.directToken?.tokenFormat;
+    const tokenFormat = (config.auth?.directToken as any)?.tokenFormat;
     let tokenFormatRegex: RegExp | boolean = true;
     try {
         tokenFormatRegex = tokenFormat !== undefined ? new RegExp(tokenFormat) : true;

--- a/packages/chaire-lib-backend/src/config/auth/index.ts
+++ b/packages/chaire-lib-backend/src/config/auth/index.ts
@@ -101,7 +101,7 @@ export default <U extends IUserModel>(authModel: IAuthModel<U>): PassportStatic 
         const directTokenConfig = require('./directToken.config');
         // FIXME It used to work without the next line, not anymore... probably some compilation issue
         const directToken = directTokenConfig.default ? directTokenConfig.default : directTokenConfig;
-        directToken(passport, authModel, config.auth.directTokenFormat);
+        directToken(passport, authModel);
     }
 
     // TODO user is Express.User type and does not have an id type

--- a/packages/chaire-lib-backend/src/config/server.config.ts
+++ b/packages/chaire-lib-backend/src/config/server.config.ts
@@ -6,9 +6,78 @@
  */
 import path from 'path';
 import os from 'os';
+import _merge from 'lodash/merge';
 
-import config, { setProjectConfiguration } from 'chaire-lib-common/lib/config/shared/project.config';
+import config, {
+    ProjectConfiguration,
+    setProjectConfiguration as setProjectConfigurationCommon
+} from 'chaire-lib-common/lib/config/shared/project.config';
 import fs from 'fs';
+import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
+
+export type TrRoutingConfig = {
+    /**
+     * Port to use for this trRouting instance
+     */
+    port: number;
+    /**
+     * If set to `true`, enable caching of connections for all scenarios in
+     * trRouting. Will use more memory
+     */
+    cacheAllScenarios: boolean;
+    // FIXME Do we need to configure a host here? If so, we need to properly
+    // support it in both batch and single calculation
+};
+
+// TODO Some project config option depend on the application, so should not be
+// typed in chaire-lib. Each app (transition , evolution, etc) should add types
+// to the config and should have a project.config file which imports this one
+// for common options.
+export type ServerSideProjectConfiguration = {
+    /** @deprecated Use `routing.transit.engines.trRouting.*.cacheAllScenarios instead */
+    trRoutingCacheAllScenarios?: boolean;
+
+    /**
+     * Configuration for the various engines used for the routing modes
+     *
+     * TODO Actually use this configuration in the various calculators, once we
+     * support more than a single engine per mode
+     */
+    routing: {
+        transit: {
+            defaultEngine: string;
+            engines: {
+                /**
+                 * Configuration for the trRouting engine
+                 */
+                trRouting?: {
+                    /**
+                     * Configuration for the single calculation trRouting service
+                     */
+                    single: TrRoutingConfig;
+                    /**
+                     * Configuration for the batch calculation trRouting service
+                     */
+                    batch: TrRoutingConfig;
+                };
+            };
+        };
+    } & {
+        [key in RoutingMode]?: {
+            defaultEngine: string;
+            engines: {
+                // TODO Type and intialize these configuration for routing modes
+                [key: string]: any;
+            };
+        };
+    };
+
+    /**
+     * The number of days that a token is valid for. After this time, the token
+     * will expire
+     */
+    tokenLifespanDays: number;
+};
 
 const etcConfigFile = '/etc/transition/config.js';
 const homeDirConfigFileRelative = '.config/transition/config.js';
@@ -47,10 +116,52 @@ const getConfigFilePath = (): string => {
 const configFileNormalized = getConfigFilePath();
 
 // Initialize default server side configuration
-setProjectConfiguration({
+setProjectConfigurationCommon<ServerSideProjectConfiguration>({
     // Initialize runtime directory at the root of the repo
-    projectDirectory: path.normalize(`${__dirname}/../../../../runtime/`)
+    projectDirectory: path.normalize(`${__dirname}/../../../../runtime/`),
+    routing: {
+        transit: {
+            defaultEngine: 'trRouting',
+            engines: {
+                trRouting: {
+                    single: {
+                        port: 4000,
+                        cacheAllScenarios: false
+                    },
+                    batch: {
+                        port: 14000,
+                        cacheAllScenarios: false
+                    }
+                }
+            }
+        }
+    }
 });
+
+/**
+ * Set the project configuration. This method handles deprecated values
+ * @param newConfig The additional configuration to set
+ */
+export const setProjectConfiguration = (newConfig: Partial<ProjectConfiguration<ServerSideProjectConfiguration>>) => {
+    // If the configuration file has a `trRoutingCacheAllScenarios` option, but the engine configuration does not have a `cacheAllScenarios` option, set it
+    // FIXME Remove once the trRoutingCacheAllScenarios is fully deprecated
+    if (
+        newConfig.trRoutingCacheAllScenarios !== undefined &&
+        newConfig.routing?.transit?.engines?.trRouting?.single?.cacheAllScenarios === undefined
+    ) {
+        console.warn(
+            'The `trRoutingCacheAllScenarios` configuration is deprecated and will be removed in the future. Please use `routing.transit.engines.trRouting.single.cacheAllScenarios` instead.'
+        );
+        _merge(newConfig, {
+            routing: {
+                transit: {
+                    engines: { trRouting: { single: { cacheAllScenarios: newConfig.trRoutingCacheAllScenarios } } }
+                }
+            }
+        });
+    }
+    setProjectConfigurationCommon(newConfig);
+};
 
 try {
     const configFromFile = require(configFileNormalized);
@@ -67,4 +178,4 @@ try {
 }
 
 /** Application configuration, does not include the server configuration */
-export default config;
+export default config as ProjectConfiguration<ServerSideProjectConfiguration>;

--- a/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
+++ b/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
@@ -8,9 +8,8 @@ import _get from 'lodash/get';
 //TODO replace this fetch-retry library with one compatible with TS
 const fetch = require('@zeit/fetch-retry')(require('node-fetch'));
 
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import ServerConfig from '../../config/ServerConfig';
 import * as TrRoutingApi from 'chaire-lib-common/lib/api/TrRouting';
-import TrRoutingProcessManager from '../processManagers/TrRoutingProcessManager';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 /**
@@ -191,9 +190,11 @@ class TrRoutingServiceBackend {
         port: string | number | undefined,
         customRequestPath: string
     ): string {
-        const trRoutingConfig = Preferences.get('trRouting');
+        // FIXME We should not get the port from here, as we assume here it is for the single instance and not the batch.
+        const trRoutingConfig = ServerConfig.getTrRoutingConfig('single');
         if (host === undefined) {
-            host = process.env.TR_ROUTING_HOST_URL || trRoutingConfig.host || 'http://localhost';
+            // There used to be a host in the config, but we do not support it, it either comes from the environment or is localhost
+            host = process.env.TR_ROUTING_HOST_URL || 'http://localhost';
         }
         if (port === undefined) {
             port = process.env.TR_ROUTING_HOST_PORT || trRoutingConfig.port;

--- a/packages/chaire-lib-common/src/api/TrRouting/index.ts
+++ b/packages/chaire-lib-common/src/api/TrRouting/index.ts
@@ -26,7 +26,6 @@ export class TrRoutingConstants {
      * @memberof TrRoutingConstants
      */
     static readonly ROUTE = 'service.trRouting.route';
-    static readonly UPDATE_CACHE = 'service.trRouting.updateCache';
     /**
      * Socket route name to call a batch routing calculation. It takes
      * parameter of type {@link TransitBatchRoutingDemandAttributes}. It returns a

--- a/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
+++ b/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
@@ -173,10 +173,6 @@ const defaultPreferences: PreferencesModel = {
     showAggregatedOdTripsLayer: true,
     socketUploadChunkSize: 10240000,
     defaultWalkingSpeedMetersPerSeconds: 5 / 3.6,
-    trRouting: {
-        port: 4000,
-        autoStart: false
-    },
     geoNames: {
         host: 'http://api.geonames.org/findNearestIntersectionOSMJSON'
     },

--- a/packages/chaire-lib-common/src/config/shared/__tests__/project.config.test.ts
+++ b/packages/chaire-lib-common/src/config/shared/__tests__/project.config.test.ts
@@ -1,4 +1,10 @@
-import projectConfig, { setProjectConfiguration } from '../project.config'
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import projectConfig, { setProjectConfiguration } from '../project.config';
 
 test('Expected default', () => {
     expect(projectConfig.userDiskQuota).toEqual('1gb');
@@ -6,10 +12,14 @@ test('Expected default', () => {
     expect(projectConfig.mapDefaultCenter).toEqual({ lon: -73.6131, lat: 45.5041 });
     expect(projectConfig.separateAdminLoginPage).toEqual(false);
     expect(projectConfig.projectShortname).toEqual('default');
+    
 });
 
 test('setProjectConfiguration', () => {
-    setProjectConfiguration({ projectShortname: 'newProject', mapDefaultCenter: { lon: -73, lat: 45 } })
+    setProjectConfiguration({
+        projectShortname: 'newProject',
+        mapDefaultCenter: { lon: -73, lat: 45 },
+    });
     expect(projectConfig.mapDefaultCenter).toEqual({ lon: -73, lat: 45 });
     expect(projectConfig.separateAdminLoginPage).toEqual(false);
     expect(projectConfig.projectShortname).toEqual('newProject');

--- a/packages/chaire-lib-common/src/config/shared/project.config.ts
+++ b/packages/chaire-lib-common/src/config/shared/project.config.ts
@@ -4,6 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import _merge from 'lodash/merge';
+
 // TODO Some project config option depend on the application, so should not be
 // typed in chaire-lib. Each app (transition , evolution, etc) should add types
 // to the config and should have a project.config file which imports this one
@@ -91,6 +93,10 @@ const projectConfig: ProjectConfiguration<any> = {
  * @returns
  */
 export const setProjectConfiguration = <AdditionalConfig>(config: Partial<ProjectConfiguration<AdditionalConfig>>) =>
-    Object.keys(config).forEach((configKey) => (projectConfig[configKey] = config[configKey]));
+    Object.keys(config).forEach((configKey) =>
+        typeof projectConfig[configKey] === 'object'
+            ? _merge(projectConfig[configKey], config[configKey])
+            : (projectConfig[configKey] = config[configKey])
+    );
 
 export default projectConfig;

--- a/packages/transition-backend/src/api/services.socketRoutes.ts
+++ b/packages/transition-backend/src/api/services.socketRoutes.ts
@@ -12,10 +12,8 @@ import osrm from 'osrm';
 import { isSocketIo } from './socketUtils';
 import serverConfig from 'chaire-lib-backend/lib/config/server.config';
 import trRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
-import trRoutingService from 'chaire-lib-backend/lib/utils/trRouting/TrRoutingServiceBackend';
 import osrmProcessManager from 'chaire-lib-backend/lib/utils/processManagers/OSRMProcessManager';
 import osrmService from 'chaire-lib-backend/lib/utils/osrm/OSRMService';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { TrRoutingConstants } from 'chaire-lib-common/lib/api/TrRouting';
 import { transitionRouteOptions, transitionMatchOptions } from 'chaire-lib-common/lib/api/OSRMRouting';
 import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
@@ -128,25 +126,6 @@ export default function (socket: EventEmitter, userId?: number) {
             console.error(error);
             callback(Status.createError(TrError.isTrError(error) ? error.message : error));
         }
-    });
-
-    socket.on(TrRoutingConstants.UPDATE_CACHE, (parameters, callback) => {
-        trRoutingService
-            .updateCache(
-                parameters,
-                parameters.host || 'http://localhost',
-                parameters.port || Preferences.get('trRouting.port')
-            )
-            .then((response) => {
-                callback(response);
-            })
-            .catch((error) => {
-                console.error(error);
-                callback({
-                    status: 'error',
-                    error
-                });
-            });
     });
 
     socket.on(

--- a/packages/transition-backend/src/services/simulation/SimulationRun.ts
+++ b/packages/transition-backend/src/services/simulation/SimulationRun.ts
@@ -10,8 +10,8 @@ import pQueue from 'p-queue';
 import _cloneDeep from 'lodash/cloneDeep';
 import Scenario from 'transition-common/lib/services/scenario/Scenario';
 import trRoutingService from 'chaire-lib-backend/lib/utils/trRouting/TrRoutingServiceBackend';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import config from 'chaire-lib-backend/lib/config/server.config';
+import ServerConfig from 'chaire-lib-backend/lib/config/ServerConfig';
 
 import Simulation, { SimulationDataAttributes } from 'transition-common/lib/services/simulation/Simulation';
 import SimulationRun, {
@@ -132,7 +132,7 @@ export default class SimulationRunBackend extends SimulationRun {
     }
 
     public getBatchPort(): number {
-        return this.attributes.options.trRoutingStartingPort || Preferences.get('trRouting.batchPortStart', 14000);
+        return this.attributes.options.trRoutingStartingPort || ServerConfig.getTrRoutingConfig('batch').port;
     }
 
     public getCacheDirectoryPath(): string {


### PR DESCRIPTION
This adds the `trRouting` property to the config type. This property contains data for the `single` instance for individual calculations (UI and public API) and `batch` instance (for tasks). For each instance, the `port` and `cacheAllScenarios` properties can be set.

The configuration objects replace the `trRouting` preference that contained the `port` and `batchPortStart` and the current `trRoutingCacheAllScenarios` configuration option.

Port management when starting or querying trRouting is updated to match the new configuration options.