### PR TITLE
Migrate OSRM settings

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -38,7 +38,79 @@ module.exports = {
     //         }
     //       }
     //     }
-    //   }
+    //   },
+    //   // Configuration for simple routing modes, using OSRM-like engines 
+    //   driving: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { 
+    //         port: 7000, // Port used to access OSRM, either locally or remotely
+    //         host: null, // If set to null, localhost will be used. Ignored if autoStart set to true
+    //         autoStart: true, // If true, a local instance of OSRM will be started
+    //         enabled: true // If true, this mode will be configured, otherwise will be left out
+    //       }
+    //     }
+    //   },
+    //   cycling: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 8000, host: null, autoStart: true, enabled: true }
+    //     }
+    //   },
+    //   walking: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 5001, host: null, autoStart: true, enabled: true }
+    //     }
+    //   },
+    //   bus_suburb: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 7110, host: null, autoStart: true, enabled: true }
+    //     }
+    //   },
+    //   bus_urban: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 7120, host: null, autoStart: true, enabled: true }
+    //     }
+    //   },
+    //   rail: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 9000, host: null, autoStart: false, enabled: false }
+    //     }
+    //   },
+    //   tram: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 9100, host: null, autoStart: false, enabled: false }
+    //     }
+    //   },
+    //   tram_train: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 9200, host: null, autoStart: false, enabled: false }
+    //     }
+    //   },
+    //   metro: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 9300, host: null, autoStart: false, enabled: false }
+    //     }
+    //   },
+    //   monorail: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 9400, host: null, autoStart: false, enabled: false }
+    //     }
+    //   },
+    //   cable_car: {
+    //     defaultEngine: 'osrmRouting',
+    //     engines: {
+    //       osrmRouting: { port: 9500, host: null, autoStart: false, enabled: false }
+    //     }
+    //   },
     // },
   
     mapDefaultCenter: {
@@ -78,77 +150,6 @@ module.exports = {
     },
   
     defaultPreferences: {
-        osrmRouting: {
-            modes: {
-                driving: {
-                    // !!! Be careful: use your own server, since you may be blocked on the osrm demo server after too many queries
-                    port     : 7000, // Port used to access OSRM, either locally or remotely
-                    host     : null, // If set to null, localhost will be used. Ignored if autoStart set to true
-                    autoStart: true, // If true, a local instance of OSRM will be started
-                    enabled  : true  // If true, this mode will be configured, otherwise will be left out 
-                },
-                cycling: {
-                    port     : 8000,
-                    host : null,
-                    autoStart: true,
-                    enabled  : true
-                },
-                walking: {
-                    port     : 5001,
-                    host : null,
-                    autoStart: true,
-                    enabled  : true
-                },
-                bus_suburb: {
-                    port     : 7110,
-                    host : null,
-                    autoStart: true,
-                    enabled  : true
-                },
-                bus_urban: {
-                    port     : 7120,
-                    host : null,
-                    autoStart: true,
-                    enabled  : true
-                },
-                rail: {
-                    port     : 9000,
-                    host : null,
-                    autoStart: false,
-                    enabled  : false
-                },
-                tram: {
-                    port     : 9100,
-                    host : null,
-                    autoStart: false,
-                    enabled  : false
-                },
-                tram_train: {
-                    port     : 9200,
-                    host : null,
-                    autoStart: false,
-                    enabled  : false
-                },
-                metro: {
-                    port     : 9300,
-                    host : null,
-                    autoStart: false,
-                    enabled  : false
-                },
-                monorail: {
-                    port     : 9400,
-                    host : null,
-                    autoStart: false,
-                    enabled  : false
-                },
-                cable_car: {
-                    port     : 9500,
-                    host : null,
-                    autoStart: false,
-                    enabled  : false
-                }
-            }
-      },
       transit: {
         routing: {
           batch: {

--- a/packages/chaire-lib-backend/src/config/ServerConfig.ts
+++ b/packages/chaire-lib-backend/src/config/ServerConfig.ts
@@ -58,6 +58,17 @@ class ServerConfig {
         }
         return engineConfiguration[instance] || { port: 4000, cacheAllScenarios: false };
     };
+
+    getAllModesForEngine = (engine: string): string[] => {
+        const modesForEngine: string[] = [];
+        for (const modeName in config.routing) {
+            if (config.routing[modeName].engines[engine] !== undefined) {
+                modesForEngine.push(modeName);
+            }
+        }
+
+        return modesForEngine;
+    };
 }
 
 const instance = new ServerConfig();

--- a/packages/chaire-lib-backend/src/config/__tests__/ServerConfig.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/ServerConfig.test.ts
@@ -37,7 +37,7 @@ describe('get routing mode and engine configs', () => {
     });
 
     test('getRoutingModeConfig, mode does not exist', () => {
-        expect(ServerConfig.getRoutingModeConfig('walking')).toBeUndefined();
+        expect(ServerConfig.getRoutingModeConfig('walking_way_data_as_name')).toBeUndefined();
     });
 
     test('getRoutingEngineConfigForMode, mode and engine exist', () => {
@@ -52,7 +52,29 @@ describe('get routing mode and engine configs', () => {
     });
 
     test('getRoutingEngineConfigForMode, mode does not exist', () => {
-        expect(ServerConfig.getRoutingEngineConfigForMode('walking', 'osrm')).toBeUndefined();
+        expect(ServerConfig.getRoutingEngineConfigForMode('walking_way_data_as_name', 'osrmRouting')).toBeUndefined();
     });
 
+    test('getAllModesForEngine, at least one mode uses engine', () => {
+        expect(ServerConfig.getAllModesForEngine('trRouting')).toEqual(['transit']);
+        expect(ServerConfig.getAllModesForEngine('osrmRouting')).toEqual([
+            'driving',
+            'driving_congestion',
+            'cycling',
+            'walking',
+            'bus_suburb',
+            'bus_urban',
+            'bus_congestion',
+            'rail',
+            'tram',
+            'tram_train',
+            'metro',
+            'monorail',
+            'cable_car'
+        ]);
+    });
+
+    test('getAllModesForEngine, no mode uses engine', () => {
+        expect(ServerConfig.getAllModesForEngine('valhalla')).toEqual([]);
+    });
 });

--- a/packages/chaire-lib-backend/src/config/__tests__/server.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/__tests__/server.config.test.ts
@@ -16,6 +16,7 @@ test('Expected default with env', () => {
     expect(config.projectDirectory).toEqual(path.normalize(`${__dirname}/../../../../../tests/dir`));
     expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 4000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } });
     expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 }});
+    expect(config.routing.driving!.engines.osrmRouting).toEqual({ port: 7000, host: null, autoStart: true, enabled: true });
 });
 
 test('setProjectConfiguration', () => {
@@ -28,6 +29,12 @@ test('setProjectConfiguration', () => {
                 engines: {
                     trRouting: { single: { port: 5000 }, batch: { logs: { maxFileSizeKB: 10000 } } } as any 
                 }
+            },
+            driving: {
+                defaultEngine: 'osrmRouting',
+                engines: {
+                    osrmRouting: { port: 1234, enabled: false } as any
+                }
             }
         }
     });
@@ -37,4 +44,5 @@ test('setProjectConfiguration', () => {
     // Make sure the deep merge works for object configs
     expect(config.routing.transit.engines.trRouting!.single).toEqual({ port: 5000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 5120 } });
     expect(config.routing.transit.engines.trRouting!.batch).toEqual({ port: 14000, cacheAllScenarios: false, debug: false, logs: { nbFiles: 3, maxFileSizeKB: 10000 } });
+    expect(config.routing.driving!.engines.osrmRouting).toEqual({ port: 1234, host: null, autoStart: true, enabled: false });
 });

--- a/packages/chaire-lib-backend/src/config/server.config.ts
+++ b/packages/chaire-lib-backend/src/config/server.config.ts
@@ -50,6 +50,26 @@ export type TrRoutingConfig = {
     // support it in both batch and single calculation
 };
 
+export type OsrmRoutingConfig = {
+    /**
+     * Port used to access OSRM, either locally or remotely.
+     */
+    port: number | null;
+    /**
+     * If set to null, localhost will be used. Ignored if autoStart set to true.
+     * Do not prefix with the protocol (ex: 'some.osrm.site.com')
+     */
+    host: string | null;
+    /**
+     * If true, a local instance of OSRM will be started when launching transition (client).
+     */
+    autoStart: boolean;
+    /**
+     * If true, this mode will be configured, otherwise it will be left out. Usable when routing paths.
+     */
+    enabled: boolean;
+};
+
 // TODO Some project config option depend on the application, so should not be
 // typed in chaire-lib. Each app (transition , evolution, etc) should add types
 // to the config and should have a project.config file which imports this one
@@ -87,8 +107,7 @@ export type ServerSideProjectConfiguration = {
         [key in RoutingMode]?: {
             defaultEngine: string;
             engines: {
-                // TODO Type and intialize these configuration for routing modes
-                [key: string]: any;
+                osrmRouting?: OsrmRoutingConfig;
             };
         };
     };
@@ -165,6 +184,149 @@ setProjectConfigurationCommon<ServerSideProjectConfiguration>({
                     }
                 }
             }
+        },
+        driving: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 7000,
+                    host: null,
+                    autoStart: true,
+                    enabled: true
+                }
+            }
+        },
+        driving_congestion: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 7500,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        cycling: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 8000,
+                    host: null,
+                    autoStart: true,
+                    enabled: true
+                }
+            }
+        },
+        walking: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 5000,
+                    host: null,
+                    autoStart: true,
+                    enabled: true
+                }
+            }
+        },
+        bus_suburb: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 7200,
+                    host: null,
+                    autoStart: true,
+                    enabled: true
+                }
+            }
+        },
+        bus_urban: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 7300,
+                    host: null,
+                    autoStart: true,
+                    enabled: true
+                }
+            }
+        },
+        bus_congestion: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 7400,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        rail: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 9000,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        tram: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 9100,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        tram_train: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 9200,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        metro: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 9300,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        monorail: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 9400,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
+        },
+        cable_car: {
+            defaultEngine: 'osrmRouting',
+            engines: {
+                osrmRouting: {
+                    port: 9500,
+                    host: null,
+                    autoStart: false,
+                    enabled: false
+                }
+            }
         }
     }
 });
@@ -191,6 +353,35 @@ export const setProjectConfiguration = (newConfig: Partial<ProjectConfiguration<
             }
         });
     }
+
+    // If osrmRouting is configured using the old defaultPreferences format and not the new one in server.config, set it to the new format
+    // FIXME Remove once the old osrmRouting format is fully deprecated. See issue #1137
+    const osrmModesInDeprecatedFormat = (newConfig as any)?.defaultPreferences?.osrmRouting?.modes;
+    if (osrmModesInDeprecatedFormat !== undefined) {
+        console.warn(
+            'The `osrmRouting` configuration in defaultPreferences is deprecated and will be removed in the future. Please insert the orsm configs in `routing.*.engines.osrmRouting` in server.config.ts, using a similar format as `routing.transit` instead.'
+        );
+        for (const osrmMode in osrmModesInDeprecatedFormat) {
+            if (newConfig.routing?.[osrmMode] === undefined) {
+                _merge(newConfig, {
+                    routing: {
+                        [osrmMode]: {
+                            defaultEngine: 'osrmRouting',
+                            engines: {
+                                osrmRouting: {
+                                    port: osrmModesInDeprecatedFormat[osrmMode].port,
+                                    host: osrmModesInDeprecatedFormat[osrmMode].host || osrmModesInDeprecatedFormat[osrmMode].osrmPath,
+                                    autoStart: osrmModesInDeprecatedFormat[osrmMode].autoStart,
+                                    enabled: osrmModesInDeprecatedFormat[osrmMode].enabled
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
+
     setProjectConfigurationCommon(newConfig);
 };
 

--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMServicePath.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMServicePath.ts
@@ -11,7 +11,8 @@ import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
 
 const defaultDirectoryPrefix = process.env.OSRM_DIRECTORY_PREFIX
     ? process.env.OSRM_DIRECTORY_PREFIX
-    : Preferences.get('osrmRouting.directoryPrefix', '');
+    : // TODO: Migrate this value from preferences to config like the osrm modes. See issue #1140
+    Preferences.get('osrmRouting.directoryPrefix', '');
 
 const getDirectoryPrefix = function (directoryPrefix = defaultDirectoryPrefix) {
     return !_isBlank(directoryPrefix) ? directoryPrefix + '_' : '';

--- a/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
+++ b/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
@@ -44,11 +44,13 @@ test('Test current match attributes', () => {
 
 test('Test initialize PreferencesClass with custom attributes', () => {
     const preferences = new PreferencesClass({ data: { foo: 'bar' }, osrmRouting: { directoryPrefix: 'newPrefix' } });
+    // TODO: Migrate this value from preferences to config like the osrm modes. See issue #1140
     expect(preferences.get('osrmRouting.directoryPrefix')).toBe('newPrefix');
     expect(preferences.getData('foo')).toBe('bar');
 });
 
 test('Test get preferences', () => {
+    // TODO: Migrate this value from preferences to config like the osrm modes. See issue #1140
     expect(Preferences.get('osrmRouting.directoryPrefix')).toBe('test');
 });
 

--- a/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
+++ b/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
@@ -200,93 +200,10 @@ const defaultPreferences: PreferencesModel = {
         // Keep empty for none (will only use the mode name):
         // If empty, directories will be projects/{PROJECT_SHORTNAME}/osrm/{MODE}
         // If not empty, directories will be projects/{PROJECT_SHORTNAME}/osrm/directoryPrefix_{MODE}
+        // TODO: Move these params to chaire-lib-backend with server.config. See issue #1140
         directoryPrefix: '',
         maxDistanceFromNearestNetworkNodeMeters: 300,
-        useContinueStraightForMapMatching: false, // use only if using the forked version of osrm-backend with support for continue-straight in match query
-        modes: {
-            driving: {
-                // set host to null when you want node to start osrm locally with the provided osrmPath and port
-                // !!! Be careful: use your own server, since you may be blocked on the osrm demo server after too many queries
-                port: 7000, // set to null when using remote osrm server
-                osrmPath: null, // set to null when using a remote osrm server
-                autoStart: true, // autostart osrm server for this mode when lauching transition (client)
-                enabled: true // usable when routing paths
-            },
-            driving_congestion: {
-                // set host to null when you want node to start osrm locally with the provided osrmPath and port
-                // !!! Be careful: use your own server, since you may be blocked on the osrm demo server after too many queries
-                port: 7500, // set to null when using remote osrm server
-                osrmPath: null, // set to null when using a remote osrm server
-                autoStart: false, // autostart osrm server for this mode when lauching transition (client)
-                enabled: false // usable when routing paths
-            },
-            cycling: {
-                port: 8000,
-                osrmPath: null,
-                autoStart: true,
-                enabled: true
-            },
-            walking: {
-                port: 5000,
-                osrmPath: null,
-                autoStart: true,
-                enabled: true
-            },
-            bus_suburb: {
-                port: 7200,
-                osrmPath: null,
-                autoStart: true,
-                enabled: true
-            },
-            bus_urban: {
-                port: 7300,
-                osrmPath: null,
-                autoStart: true,
-                enabled: true
-            },
-            bus_congestion: {
-                port: 7400,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            },
-            rail: {
-                port: 9000,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            },
-            tram: {
-                port: 9100,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            },
-            tram_train: {
-                port: 9200,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            },
-            metro: {
-                port: 9300,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            },
-            monorail: {
-                port: 9400,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            },
-            cable_car: {
-                port: 9500,
-                osrmPath: null,
-                autoStart: false,
-                enabled: false
-            }
-        }
+        useContinueStraightForMapMatching: false // use only if using the forked version of osrm-backend with support for continue-straight in match query
     },
     colorPicker: {
         colors: [

--- a/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
@@ -88,6 +88,7 @@ export default class OSRMRoutingService extends RoutingService.default {
             const origin = waypoints[0];
             const destination = waypoints[waypoints.length - 1];
 
+            // TODO: Migrate this value from preferences to config like the osrm modes. See issue #1140
             const maxDistance = Preferences.get('osrmRouting.maxDistanceFromNearestNetworkNodeMeters');
 
             if (origin.distance > maxDistance || destination.distance > maxDistance) {
@@ -190,6 +191,7 @@ export default class OSRMRoutingService extends RoutingService.default {
             annotations: _isBlank(params.annotations) ? true : params.annotations,
             // gaps      : 'ignore',
             continue_straight:
+                // TODO: Migrate this value from preferences to config like the osrm modes. See issue #1140
                 Preferences.current.osrmRouting.useContinueStraightForMapMatching === true ? true : undefined // see comment in chaire-lib-common/lib/config/defaultPreferences.config.js
         });
         return this.processRoutingResult(routingResult);

--- a/tests/config_test.js
+++ b/tests/config_test.js
@@ -44,86 +44,87 @@ module.exports = {
   
     defaultPreferences: {
       defaultSection: "test",
+      // Change to the new osrm config. See issue #1137
       osrmRouting: {
           directoryPrefix: 'test',
           modes: {
             driving: {
-                // set host to null when you want node to start osrm locally with the provided osrmPath and port
+                // set host to null when you want node to start osrm locally with the provided port
                 // !!! Be careful: use your own server, since you may be blocked on the osrm demo server after too many queries
                 port     : 7999, // set to null when using remote osrm server
-                osrmPath : null, // set to null when using a remote osrm server
+                host : null, // set to null when using a remote osrm server
                 autoStart: true,
                 enabled  : true
             },
             cycling: {
                 port     : 8999,
-                osrmPath : null,
+                host : null,
                 autoStart: true,
                 enabled  : false
             },
             walking: {
                 port     : 5999,
-                osrmPath : null,
+                host : null,
                 autoStart: true,
                 enabled  : false
             },
             driving_congestion: {
                 port     : 8899,
-                osrmPath : null,
+                host : null,
                 autoStart: true,
                 enabled  : false
             },
             bus_suburb: {
                 port     : 7889,
-                osrmPath : null,
+                host : null,
                 autoStart: true,
                 enabled  : true
             },
             bus_urban: {
                 port     : 7879,
-                osrmPath : null,
+                host : null,
                 autoStart: true,
                 enabled  : true
             },
             bus_congestion: {
                 port     : 7869,
-                osrmPath : null,
+                host : null,
                 autoStart: true,
                 enabled  : false
             },
             rail: {
                 port     : 9999,
-                osrmPath : null,
+                host : null,
                 autoStart: false,
                 enabled  : false
             },
             tram: {
                 port     : 9199,
-                osrmPath : null,
+                host : null,
                 autoStart: false,
                 enabled  : false
             },
             tram_train: {
                 port     : 9299,
-                osrmPath : null,
+                host : null,
                 autoStart: false,
                 enabled  : false
             },
             metro: {
                 port     : 9399,
-                osrmPath : null,
+                host : null,
                 autoStart: false,
                 enabled  : false
             },
             monorail: {
                 port     : 9499,
-                osrmPath : null,
+                host : null,
                 autoStart: false,
                 enabled  : false
             },
             cable_car: {
                 port     : 9599,
-                osrmPath : null,
+                host : null,
                 autoStart: false,
                 enabled  : false
             }


### PR DESCRIPTION
Migrate OSRM settings from the defaultPreferences.config.ts file in chaire-lib-common to server.config,ts file in chaire-lib-backend
Also adds some todos as a reminder to rework some settings that can't be moved at the moment.
Fix: #1084