### PR TITLE
Add server side errors to /route API request response.

### DIFF
--- a/docs/APIv1/route.yml
+++ b/docs/APIv1/route.yml
@@ -182,6 +182,8 @@ routeUnimodalResultResponse:
       $ref: '#/routeUnimodalResultResponsePaths'
     pathsGeoJson:
       $ref: '#/routeUnimodalResultResponsePathsGeojson'
+    noRoutingReason:
+      $ref: '#/routeResultNoRoutingReason'
 
 routeTransitResultResponse:
   type: object
@@ -193,6 +195,8 @@ routeTransitResultResponse:
       $ref: '#/routeTransitResultResponsePaths'
     pathsGeoJson:
       $ref: '#/routeTransitResultResponsePathsGeojson'
+    noRoutingReason:
+      $ref: '#/routeResultNoRoutingReason'
 
 routeUnimodalResultResponsePaths:
   type: array
@@ -377,6 +381,21 @@ routeTransitResultResponsePathsGeojson:
                   type: number
                   description: The estimated duration of the trip along this section of the route route, in seconds
                   example: 600
+
+routeResultNoRoutingReason:
+  type: object
+  description: An overview of the server side error in case of failure while executing the route request. If there is no error, this will not be included in the response.
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      example: 'cannot calculate transit route with trRouting because of an error on server: MISSING_DATA_AGENCIES'
+    code:
+      type: string
+      enum: [ErrorCodes]
+      example: 'TRROUTING_MISSING_DATA'
 
 singleRouteResponse:
   type: object

--- a/packages/chaire-lib-common/src/utils/TrError.ts
+++ b/packages/chaire-lib-common/src/utils/TrError.ts
@@ -39,7 +39,6 @@ export default class TrError extends Error {
 
     export() {
         return {
-            flash: this.localizedMessage, // deprecated
             localizedMessage: this.localizedMessage,
             error: this.message,
             errorCode: this.code

--- a/packages/transition-backend/src/api/public/RouteAPIResponse.ts
+++ b/packages/transition-backend/src/api/public/RouteAPIResponse.ts
@@ -35,6 +35,10 @@ type RouteAPIUnimodalResultResponse = {
             };
         }>;
     }>;
+    noRoutingReason?: {
+        message: string;
+        code: string;
+    };
 };
 
 type RouteAPITransitResultResponse = {
@@ -52,6 +56,10 @@ type RouteAPITransitResultResponse = {
             };
         }>;
     }>;
+    noRoutingReason?: {
+        message: string;
+        code: string;
+    };
 };
 
 type RouteAPIQueryResponse = {
@@ -178,7 +186,11 @@ export default class RouteAPIResponse extends APIResponseBase<
                         travelTimeSeconds: feature.properties!.travelTimeSeconds
                     }
                 }))
-            }))
+            })),
+            noRoutingReason:
+                transitResultParams.error === undefined
+                    ? undefined
+                    : { message: transitResultParams.error?.error, code: transitResultParams.error?.errorCode }
         };
     }
 
@@ -202,7 +214,11 @@ export default class RouteAPIResponse extends APIResponseBase<
                         travelTimeSeconds: feature.properties!.travelTimeSeconds
                     }
                 }))
-            }))
+            })),
+            noRoutingReason:
+                unimodalResultParams.error === undefined
+                    ? undefined
+                    : { message: unimodalResultParams.error?.error, code: unimodalResultParams.error?.errorCode }
         };
     }
 }

--- a/pyTransition/README.md
+++ b/pyTransition/README.md
@@ -99,7 +99,7 @@ This method allows users to fetch all routing modes which are currently loaded i
 **Raises :**&emsp;**&emsp;**&emsp;***RequestException***\
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;If response code is not 200.
 
-### get_routing_result:
+### request_routing_result:
 This method allows users to send calculation parameters to the Transition server to request a new route. The request can be made for different transit modes. In case of a successful request, the new route is returned in JSON format.\
 **Parameters :**&emsp;***modes*** : *list*\
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;Transit modes for which to calculate the routes.\
@@ -136,7 +136,7 @@ This method allows users to send calculation parameters to the Transition server
 **Raises :**&emsp;***RequestException***\
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;If response code is not 200.
 
-### get_accessibility_map
+### request_accessibility_map
 This method allows users to send accessibility map parameters to the Transition server to request a new accessibility map. In case of a successful request, the accessibility map is returned in JSON format.\
 **Parameters :**&emsp;***coordinates*** : *list*\
 &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;Coordinates of the starting point of the accessibility map. Must be sent as [longitude, latitude]\


### PR DESCRIPTION
In case of a server error while executing a /route request, the error info will be included in the response. Updates the API doc with the new info.

Also removes a deprecated field from an error handling function. 

Also fixes some incorrect function names in the pyTransition readme.
Fix: #1043

Example:
![image](https://github.com/user-attachments/assets/0c73ae8d-dc02-4ccd-9fac-de8be2c3025e)

