### PR TITLE
batchRoute: Better handle job cancellation and deletion

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -195,12 +195,9 @@ class TrRoutingBatch {
             checkpointTracker.completed();
 
             this.options.progressEmitter.emit('progress', { name: 'BatchRouting', progress: 1.0 });
-            this.options.progressEmitter.emit('progress', { name: 'StoppingRoutingParallelServers', progress: 0.0 });
 
-            const stopStatus = await TrRoutingProcessManager.stopBatch();
-
-            this.options.progressEmitter.emit('progress', { name: 'StoppingRoutingParallelServers', progress: 1.0 });
-            console.log('trRouting multiple stopStatus', stopStatus);
+            // FIXME Should we return here if the job is cancelled? Or we still
+            // generate the results that have been calculated since now?
 
             // Generate the output files
             this.options.progressEmitter.emit('progress', { name: 'GeneratingBatchRoutingResults', progress: 0.0 });
@@ -253,6 +250,14 @@ class TrRoutingBatch {
                 console.error(`Error in batch routing calculation job ${this.options.jobId}: ${error}`);
                 throw error;
             }
+        } finally {
+            // Make sure to stop the trRouting processes, even if an error occurred
+            this.options.progressEmitter.emit('progress', { name: 'StoppingRoutingParallelServers', progress: 0.0 });
+
+            const stopStatus = await TrRoutingProcessManager.stopBatch();
+
+            this.options.progressEmitter.emit('progress', { name: 'StoppingRoutingParallelServers', progress: 1.0 });
+            console.log('trRouting multiple stopStatus', stopStatus);
         }
     };
 


### PR DESCRIPTION
fixes #710

* Cancelled jobs sometimes were not really cancelled if a checkpoint was set after the job status was set to cancelled in the main thread, but before the automatic task refresh every 5 seconds, so we refresh the task before updating it in the checkpoint update.
* Also, refreshing and saving the job would throw an error if the job is deleted from the DB and would kill the running thread, which would cause the trRouting process to be left defunct. So we add a catch when refreshing/updating the job and stopping the trRouting process is done in the finally block, to make sure it is always stopped, even in case of an exception.