### PR TITLE
Add documentation popups

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -964,5 +964,14 @@
             "LocationColor": "Location color",
             "PolygonColor": "Accessibility polygon default color"
         }
+    },
+    "documentationTooltip": {
+        "Symbol": "Symbol",
+        "Unit": "Unit",
+        "Expression": "Expression",
+        "Description": "Description",
+        "errors": {
+            "DefinitionNotFound": "An error occured while searching for this symbol's information on the server."
+        }
     }
 }

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -964,5 +964,14 @@
             "LocationColor": "Couleur du lieu",
             "PolygonColor": "Couleur par défaut du polygone d'accessibilité"
         }
+    },
+    "documentationTooltip": {
+        "Symbol": "Symbole",
+        "Unit": "Unité",
+        "Expression": "Expression",
+        "Description": "Description",
+        "errors": {
+            "DefinitionNotFound": "Une erreur s'est produite lors de la recherche de l'information de ce symbole sur le serveur."
+        }
     }
 }

--- a/packages/transition-backend/file/definitions/README.md
+++ b/packages/transition-backend/file/definitions/README.md
@@ -1,0 +1,12 @@
+# Latex documentation files
+These tex files are copied from the Overleaf project maintained by [Pierre-Leo Bourbonnais](https://github.com/kaligrafy), found here: https://www.overleaf.com/read/dtxfhttxgjrx#d70683.
+
+At the moment, the files on Overleaf are considered the primary version, and if they are updated in Overleaf, the changes should be manually copied and pasted to the files in this repo, then commited and pushed. Eventually, we will move them entirely to the Transition repo and add a script to compile them into a pdf.
+
+When adding or modifying information on these files, they must follow the already present row structure:
+```
+\label{label}
+\makecell[r]{Title} & \[Symbol\] & \[Unit\] & \[Expression\] & Description \\
+\hline
+```
+Each row is starts with a label that allows for it to be located by the tooltip component and ends with `\hline`. Each cell is separated with `&`, and starts and ends with a space. The unit and expression can be empty, in which case they must be represented by a single hyphen (`-`). The symbol, unit, and expression are mathematical expressions, and must be start `\[` and end with `\]`, unless they are empty. Finally, any change must be translated and added to both the French and English file.

--- a/packages/transition-backend/file/definitions/definitions-en.tex
+++ b/packages/transition-backend/file/definitions/definitions-en.tex
@@ -1,0 +1,1387 @@
+\documentclass{article}
+\usepackage[colorlinks = true,
+            linkcolor = blue,
+            urlcolor  = blue,
+            citecolor = blue,
+            anchorcolor = blue]{hyperref}
+
+\usepackage{longtable}
+\usepackage{tabulary}
+\usepackage{multirow}
+\usepackage{amsmath}
+\usepackage[none]{hyphenat}
+\usepackage[utf8]{inputenc}
+\usepackage{array}
+\usepackage{mathtools}
+\usepackage{amsmath}
+\usepackage{tabularx}
+\usepackage{makecell}
+\usepackage[legalpaper, landscape, top=0.5in, left=0.5in, right=0.7in, bottom=0.2in, includefoot]{geometry}
+
+\begin{document}
+
+\newcolumntype{C}[1]{>{\centering\arraybackslash}m{#1}}   %% centered
+\newcolumntype{R}[1]{>{\raggedleft\arraybackslash}m{#1}}  %% right aligned
+\newcolumntype{L}[1]{>{\raggedright\arraybackslash}m{#1}}  %% left aligned
+\setlength\LTleft{0pt}
+\setlength\LTright{0pt}
+\setlength\LTcapwidth{\textwidth}
+\setlength{\abovedisplayskip}{0.1pt}
+\setlength{\belowdisplayskip}{0.1pt}
+\renewcommand{\arraystretch}{1.2}
+\newdimen\NetTableWidth
+
+\title{Public transit • Definitions and symbols }
+
+\author{Pierre-Léo Bourbonnais and students of the course CIV6708}
+
+\section*{Public transit: Definitions and symbols (still being translated from french to english)}
+
+\subsection*{Stops, stop nodes, stations and segments}
+
+\noindent
+  \NetTableWidth=\dimexpr
+    \linewidth
+    - 8\tabcolsep
+    - 5\arrayrulewidth % if package array is loaded
+  \relax
+
+\begin{longtable}{%
+    R{.15\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    L{.65\NetTableWidth}%
+}
+\hline
+\makecell[r]{Object} & \makecell[c]{Symbol} & \makecell[c]{Unit} & \makecell[c]{Expression} & \makecell[l]{Definition} \\ 
+\hline
+\hline
+\endhead
+\label{node}
+\makecell[r]{Stop node} & \[q\] & - & - & Group of stop signs and/or transit platforms for boarding and alighting in the vicinity of each other and considered a potential transfer location when multiple lines serve the node. By instance, when multiple stop signs are located at each corner of an intersection, they are grouped in a single stop node. \\
+\hline
+\label{stop}
+\makecell[r]{Stop} & \[s\] & - & - & Precise location of the platform centroid or stop sign allowing boarding and alighting of passengers for a unit in service on a line. Is part of a stop node. \\
+\hline
+\label{station}
+\makecell[r]{Station} & \[S\] & - & - & Building making it easy to transfer between multiple stops. When more than one transit modes are served at a station, we call it an intermodal station. \\
+\hline
+\makecell[r]{Segment} & \[l\] & - & - & Line path segment between two consecutive stops/stop nodes, represented by a specific route on the road or rail network. \\
+\hline
+\makecell[r]{Unique stop node} & \[q_u\] & - & - & Stop node served by a single line (one-way or bi-directional). \\
+\hline
+\makecell[r]{Multiple stop node} & \[q_m\] & - & - & Stop node served by more than one line. \\
+\hline
+\makecell[r]{Unique stop} & \[s_u\] & - & - & Stop sign or platform served by a single line (one-way or bi-directional). \\
+\hline
+\makecell[r]{Multiple stop} & \[s_m\] & - & - & Stop sign or platform served by more than one line. \\
+\hline
+\makecell[r]{Unique segment} & \[l_u\] & - & - & Segment served by a single line (one-way or bi-directional). \\
+\hline
+\makecell[r]{Multiple segment} & \[l_m\] & - & - & Segment served by multiple lines. \\
+\hline
+\label{terminal}
+\makecell[r]{Terminal} & \[s_T\] or \[q_T\]  & - & - & First or last stop/stop node for a line. Usually allows at least one transit unit to park during layover time. \\
+\hline
+\label{outbound_terminal}
+\makecell[r]{Departure/Outbound terminal} & \[{s^{\prime}_T}\] or \[q^{\prime}_T\] & - & - & First stop/stop node on a line path. \\
+\hline
+\label{inbound_terminal}
+\makecell[r]{Arrival/Inbound terminal} & \[{s^{\prime\prime}_T}\] or \[{q^{\prime\prime}_T}\] & - & - & Last stop/stop node on a line path. \\
+\hline
+\label{stop_time}
+\makecell[r]{Stop-time} & \[s_t\] or \[q_t\] & - & - & Passage of a transit unit in service on a line at a particular stop/stop node, in a given direction and at a specific time (scheduled). Includes an arrival time when the unit arrives at the stop and a departure time when the unit leaves the stop.\\
+\hline
+\label{stop_sequence}
+\makecell[r]{Stop-sequence} & \[s_{seq}\] or \[q_{seq}\] & - & - & A combination of a stop/stop node and a sequence number on a line path in one direction. A path includes a stop-sequence for each stop/stop node served. An outbound path with 4 stops (A, B, C and D) will have 4 stop-sequences: stop A at sequence 1, stop B at sequence 2, stop C at sequence 3 and stop D at sequence 4. The inbound path will have reversed stop sequences: stop D at sequence 1, stop C at sequence 2, stop B at sequence 3 and stop A at sequence 4.\\
+\hline
+\label{connection}
+\makecell[r]{Connection} & \[c\] & - & - & Traveling of a transit unit on a particular path segment between two consecutive stop/stop nodes and according to a schedule. Includes a departure time from the previous stop and an arrival time at the next stop. \\
+\hline
+\end{longtable} 
+
+\pagebreak
+\subsection*{Véhicules, unités et garages • \textit{Vehicles, units and depots}}
+
+\begin{longtable}{%
+    R{.25\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.1\NetTableWidth}%
+    L{.5\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{transit_unit}
+\makecell[r]{Unité de transport collectif \\ \textit{Transit unit (Unit)}} & \[u\] & - & - & Ensemble de voitures, de wagons ou de remorques couplés constituant un train. Un bus régulier ou articulé représente une seule unité. \\
+\hline
+\label{vehicle}
+\makecell[r]{Véhicule (wagon/voiture) \\ \textit{Vehicle (trailer/car)}} & \[y\] & - & - & Voiture, wagon ou remorque faisant partie d'une unité. \\
+\hline
+\label{depot}
+\makecell[r]{Garage/dépôt \\ \textit{Depot}} & \[G\] & - & - & Garage pour bus ou dépôt ferroviaire où sont entreposés les unités et véhicules et où on effectue leur maintenance. Habituellement, le garage constitue également le lieu de départ et d'arrivée des véhicules et chauffeurs assignés aux services en début et en fin de tournée. \\
+\hline
+\label{depot_unit_capacity}
+\makecell[r]{Capacité d'unités du garage \\ \textit{Depot units capacity}} & \[{N_u}_G\] & unités & - & Nombre d'unités pouvant être stationnées simultanément dans le garage ou le dépôt. Attention de bien spécifier si cette capacité comprend les emplacements réservés aux véhicules en maintenance. \\
+\hline
+\label{fleet_size}
+\makecell[r]{Taille de la flotte \\ \textit{Fleet size} } & \[F\] & unités & - & Flotte totale (nombre d'unités) incluant les unités en service, en réserve et en maintenance. \\
+\hline
+\label{reserve_fleet_size}
+\makecell[r]{Taille de la flotte en réserve \\ \textit{Reserve fleet size}} & \[F_r\] & unités & - & Nombre d'unités réservées pour remplacer les unités devant être retirées de la circulation (incidents) et ajouter du service lors d'événements spéciaux ou de congestion sévère ralentissant le service planifié. \\
+\hline
+\label{maintenance_fleet_size}
+\makecell[r]{Taille de la flotte en maintenance \\ \textit{Maintenance fleet size}} & \[F_m\] & unités & - & Nombre d'unités en réparation ou en maintenance préventive. Ces unités ne peuvent être utilisées pour effectuer du service. \\
+\hline
+\label{service_fleet_size}
+\makecell[r]{Taille de la flotte en service \\ \textit{Service fleet size}} & \[F_s\] & unités & \[F - F_m - F_r\] & Nombre d'unités pouvant être utilisées pour effectuer le service planifié pendant la période de pointe maximale. \\
+\hline
+\label{fleet_use_ratio}
+\makecell[r]{Ratio d'utilisation de la flotte \\ \textit{Fleet use ratio}} & \[\mu_{F_u}\] & - & \[\frac{F_s + F_r}{F}\] & - \\
+\hline
+\label{reserve_fleet_ratio}
+\makecell[r]{Ratio de la flotte en réserve \\ \textit{Reserve fleet ratio}} & \[\mu_{F_r}\] & - & \[\frac{F_r}{F}\] & - \\
+\hline
+\label{maintenance_fleet_ratio}
+\makecell[r]{Ratio de la flotte en maintenance \\ \textit{Maintenance fleet ratio}} & \[\mu_{F_m}\] & - & \[\frac{F_m}{F}\] & - \\
+\hline
+\label{service_fleet_ratio}
+\makecell[r]{Ratio de la flotte en service \\ \textit{Service fleet ratio}} & \[\mu_{F_s}\] & - & \[\frac{F_s}{F}\] & - \\
+\hline
+\label{vehicles_per_unit}
+\makecell[r]{Nombre de véhicules par unité \\ \textit{Number of vehicles per unit}} & \[n_y\] & véhicules & - & Nombre de voitures, de wagons ou de remorques couplés constituant l'unité. \\
+\hline
+\label{required_units}
+\makecell[r]{Nombre d'unités requises \\ \textit{Required number of units}} & \[n_u\] & unités & - & Nombre d'unités requises pour effectuer un service pour une période données (habituellement sur une ligne en particulier). \\
+\hline
+\label{maximum_acceleration}
+\makecell[r]{Accélération maximale \\ \textit{Maximum acceleration}} & \[a_{max}\] & \[m/s^2\] & - & Accélération maximale d'une unité. \\
+\hline
+\label{programmed_acceleration}
+\makecell[r]{Accélération programmée \\ \textit{Programmed acceleration}} & \[a\] & \[m/s^2\] & - & Accélération utilisée en service. Cette accélération doit être le meilleur équilibre entre le confort des passagers, l'efficacité énergétique et l'optimisation du service. \\
+\hline
+\label{maximum_deceleration}
+\makecell[r]{Décélération maximale \\ \textit{Maximum deceleration}} & \[b_{max}\] & \[m/s^2\] & - & Décélération maximale d'une unité lors d'un freinage d'urgence. Utiliser en valeur absolue (positive). \\
+\hline
+\label{programmed_deceleration}
+\makecell[r]{Décélération programmée \\ \textit{Programmed deceleration}} & \[b\] & \[m/s^2\] & - & Décélération utilisée en service. Cette décélération/freinage doit être le meilleur équilibre entre le confort des passagers et l'optimisation du service. Utiliser en valeur absolue (positive). \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+    R{.31\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.11\NetTableWidth}%
+    C{.2\NetTableWidth}%
+    L{.3\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{floor_area_per_standee}
+\makecell[r]{Superficie au sol par place debout \\ \textit{Floor area per standee}} & \[e\] & \[m^2\] & - & Superficie prévue pour chaque place debout (empreinte au sol). Confortable, circulation convenable: \(0.25 m^2\); Inconfortable, circulation difficile: \(0.15 m^2\) \\
+\hline
+\label{vehicle_capacity}
+\makecell[r]{Capacité de véhicule \\ \textit{Vehicle capacity}} & \[C_y\] & places & \[C_{y_{se}} + C_{y_{st}}\] & Nombre de places assises et debout dans le véhicule. \\
+\hline
+\label{unit_capacity}
+\makecell[r]{Capacité d'unité \\ \textit{Unit capacity}} & \[C_{u}\] & places & \[C_{{u}_{se}} + C_{{u}_{st}}\] & Nombre de places assises et debout dans l'unité. \\
+\hline
+\label{vehicle_seated_capacity}
+\makecell[r]{Capacité de sièges par véhicule \\ \textit{Vehicle seated capacity}} & \[C_{y_{se}}\] & places & - & - \\
+\hline
+\label{vehicle_standees_capacity}
+\makecell[r]{Capacité de passagers debout par véhicule \\ \textit{Vehicle standees capacity}} & \[C_{y_{st}}\] & places & - & Attention de bien préciser l'espace disponible par place debout \(e\) entre \(0.15m^2\) (inconfortable) et \(0.25m^2\) (confortable). \\
+\hline
+\label{unit_seated_capacity}
+\makecell[r]{Capacité de sièges par unité \\ \textit{Unit seated capacity}} & \[C_{u_{se}}\] & places & \[n_y C_{{y}_{se}}\] si toutes les voitures de l'unité ont la même capacité de sièges. & - \\
+\hline
+\label{unit_standees_capacity}
+\makecell[r]{Capacité de passagers debout par unité \\ \textit{Unit standees capacity}} & \[C_{u_{st}}\] & places & \[n_y C_{{y}_{st}}\] si toutes les voitures de l'unité ont la même capacité de places debout. & - \\
+\hline
+\label{vehicle_boarding_door_channels}
+\makecell[r]{Nombre de voies d'embarquement par véhicule \\ \textit{Number of boarding door channels per vehicle}} & \[{n_{Bch}}_y\] & voies d'embarquement & - & Nombre de voies permettant l'embarquement d'une personne à la fois dans le véhicule. \\
+\hline
+\label{vehicle_alighting_door_channels}
+\makecell[r]{Nombre de voies de débarquement par véhicule \\ \textit{Number of alighting door channels per vehicle}} & \[{n_{Ach}}_y\] & voies de débarquement & - & Nombre de voies permettant le débarquement d'une personne à la fois dans le véhicule. \\
+\hline
+\label{vehicle_mixed_door_channels}
+\makecell[r]{Nombre de voies d'accès mixtes par véhicule \\ \textit{Number of mixed door channels per vehicle}} & \[{n_{ABch}}_{y}\] & voies mixtes & - & Nombre de voies permettant l'embarquement ou le débarquement d'une personne à la fois dans le véhicule. \\
+\hline
+\label{vehicle_door_channels}
+\makecell[r]{Nombre total de voies d'accès par véhicule \\ \textit{Number of door channels per vehicle}} & \[{n_{ch}}_y\] & voies d'accès & \[{n_{Ach}}_{y} + {n_{Bch}}_{y} + {n_{ABch}}_{y}\] & Nombre de voies d'accès permettant l'embarquement, le débarquement ou les deux dans le véhicule. \\
+\hline
+\label{unit_boarding_door_channels}
+\makecell[r]{Nombre de voies d'embarquement par unité \\ \textit{Number of boarding door channels per unit}} & \[{n_{Bch}}_{u}\] & voies d'embarquement & - & Nombre de voies permettant l'embarquement d'une personne à la fois dans l'ensemble des véhicules de l'unité. \\
+\hline
+\label{unit_alighting_door_channels}
+\makecell[r]{Nombre de voies de débarquement par unité \\ \textit{Number of alighting door channels per unit}} & \[{n_{Ach}}_{u}\] & voies de débarquement & - & Nombre de voies permettant le débarquement d'une personne à la fois dans l'ensemble des véhicules de l'unité. \\
+\hline
+\label{unit_mixed_door_channels}
+\makecell[r]{Nombre de voies d'accès mixtes par unité \\ \textit{Number of mixed door channels per unit}} & \[{n_{ABch}}_{u}\] & voies mixtes & - & Nombre de voies permettant l'embarquement ou le débarquement d'une personne à la fois dans l'ensemble des véhicules de l'unité. \\
+\hline
+\label{unit_door_channels}
+\makecell[r]{Nombre total de voies d'accès par unité \\ \textit{Number of door channels per unit}} & \[{n_{ch}}_{u}\] & voies d'accès & \[{n_{Ach}}_{u} + {n_{Bch}}_{u} + {n_{ABch}}_{u}\] & Nombre de voies d'accès permettant l'embarquement, le débarquement ou les deux dans l'ensemble des véhicules de l'unité. \\
+\hline
+\end{longtable}
+
+
+\pagebreak
+\subsection*{Lignes et parcours • \textit{Lines and paths}}
+
+\begin{longtable}{%
+    R{.18\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    L{.56\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{line}
+\makecell[r]{Ligne \\ \textit{Line}} & \[L\] & - & - & Ligne de transport collectif comprenant un ou plusieurs parcours distincts mais désignée de manière unique et possédant un identifiant (numéro ou lettre) et un nom (le nom peut changer en fonction de la direction desservie). Une ligne peut être bidirectionnelle, en boucle bidirectionnelle ou en boucle à sens unique, avec possiblement des parcours réduits (ligne courte) ou allongés pour certaines périodes de la journée ou pour desservir des clientèles particulières. \\
+\hline
+\label{path}
+\makecell[r]{Parcours \\ \textit{Path}} & \[p\] & - & - & Parcours unique dans une direction déterminée sur une ligne. Un parcours est défini pour chaque séquence d'arrêts distincte desservie par la ligne. Un parcours comprend un ensemble d'arrêts-séquences et un parcours géographique sur le réseau (routier, ferroviaire ou autre). \\
+\hline
+\label{path_outbound}
+\makecell[r]{Parcours aller \\ \textit{Outbound path}} & \[p_{out}\] ou \[{p^{\prime}}\] & - & - & Parcours effectué dans la première direction (aller) pour une ligne bidirectionnelle ou la seule direction pour une ligne en boucle à sens unique. Le choix de la direction aller est arbitraire. Habituellement, le parcours aller est la direction empruntée lors du premier départ de la première tournée de la journeé sur la ligne. \\
+\hline
+\label{path_inbound}
+\makecell[r]{Parcours retour \\ \textit{Inbound path}} & \[p_{in}\] ou \[{p^{\prime\prime}}\] & - & - & Parcours effectué en sens contraire (retour) pour une ligne bidirectionnelle ou la deuxième direction spécifiée sur la ligne lorsque le parcours de retour n'est pas l'inverse exact du parcours aller. \\
+\hline
+\label{trip}
+\makecell[r]{Voyage \\ \textit{Trip}} & \[o\] & - & - & Un voyage est le déplacement en service d'une unité sur un parcours d'une ligne selon un horaire. \\
+\hline
+\label{schedule}
+\makecell[r]{Horaire \\ \textit{Schedule}} & \[O\] & - & - & Un horaire est un ensemble de voyages effectués pour un même service (calendrier) pour une ligne donnée. \\
+\hline
+\label{run}
+\makecell[r]{Tournée \\ \textit{Run}} & \[r\] & - & - & Une tournée est un ensemble de voyages desservis par une même unité ou un même chauffeur. Une tournée peut desservir plusieurs parcours et plusieurs lignes (interlignage). Habituellement, une tournée débute et se termine à un garage. \\
+\hline
+\label{block}
+\makecell[r]{Bloc \\ \textit{Block}} & \[r_b\] & - & - & Un bloc est un ensemble de voyages consécutifs desservis par une même unité et à l'intérieur duquel les passagers peuvent demeurer dans le véhicule pour un transfert instantané et/ou garanti. \\
+\hline
+\label{spatial_directivity}
+\makecell[r]{Directivité spatiale \\ \textit{Spatial directivity}} & \[\delta\] & - & \[\frac{d_e}{d_o}\] & Ratio représentant le caractère direct d'un parcours par rapport au parcours direct à vol d'oiseau (distance euclidienne). Inverse de la tortuosité (aussi appelée directitude). \\
+\hline
+\label{spatial_tortuosity}
+\makecell[r]{Tortuosité spatiale \\ \textit{Tortuosity}} & \[\tau\] & - & \[\frac{d_o}{d_e}\] & Ratio représentant le caractère tortueux du parcours par rapport au parcours direct à vol d'oiseau (distance euclidienne). Inverse de la directivité. \\
+\hline
+\label{spatial_network_directivity}
+\makecell[r]{Directivité spatiale réseau \\ \textit{Spatial network directivity}} & \[\delta_n\] & - & \[\frac{d_n}{d_o}\] & Ratio représentant le caractère direct d'un parcours par rapport au parcours le plus court en distance sur le réseau entre les deux terminus (habituellement le parcours le plus court en voiture). Inverse de la tortuosité réseau. \\
+\hline
+\label{spatial_network_tortuosity}
+\makecell[r]{Tortuosité spatiale réseau \\ \textit{Spatial network tortuosity}} & \[\tau_n\] & - & \[\frac{d_o}{d_n}\] & Ratio représentant le caractère tortueux du parcours par rapport au parcours le plus court en distance sur le réseau entre les deux terminus (habituellement le parcours le plus court en voiture). Inverse de la directivité réseau. \\
+\hline
+\label{temporal_directivity}
+\makecell[r]{Directivité temporelle \\ \textit{Temporal Directivity}} & \[\delta_t\] & - & \[\frac{t_n}{t_o}\] & Ratio représentant le caractère direct d'un parcours par rapport au parcours le plus rapide en temps sur le réseau entre les deux terminus (habituellement le parcours le plus rapide en voiture). Inverse de la tortuosité temporelle. \\
+\hline
+\label{temporal_tortuosity}
+\makecell[r]{Tortuosité temporelle \\ \textit{Temporal tortuosity}} & \[\tau_t\] & - & \[\frac{t_o}{t_n}\] & Ratio représentant le caractère tortueux du parcours par rapport au parcours le plus rapide en temps sur le réseau entre les deux terminus (habituellement le parcours le plus direct en voiture). Inverse de la directivité temporelle. \\
+\hline
+\end{longtable} 
+
+\begin{longtable}{%
+    R{.29\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.12\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    L{.43\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{number_of_paths_on_line}
+\makecell[r]{Nombre de parcours sur la ligne \\ \textit{Number of path on line}} & \[n_p\] & parcours & - & Nombre de parcours desservis sur une ligne. \\
+\hline
+\label{number_of_segments_on_path}
+\makecell[r]{Nombre de segments sur le parcours \\ \textit{Number of segments on path}} & \[n_l\] & segments & - & Nombre total de segments desservis par le parcours. \\
+\hline
+\label{number_of_segments_on_path_outbound}
+\makecell[r]{Nombre de segments aller \\ \textit{Number of outbound segments}} & \[{n_l}^{\prime}\] & segments & - & Nombre total de segments desservis par le parcours. \\
+\hline
+\label{number_of_segments_on_path_inbound}
+\makecell[r]{Nombre de segments retour \\ \textit{Number of inbound segments}} & \[{n_l}^{\prime\prime}\] & segments & - & Nombre total de segments desservis par le parcours. \\
+\hline
+\label{number_of_stops_on_path}
+\makecell[r]{Nombre d'arrêts sur le parcours \\ \textit{Number of stops on path}} & \[n_q\] ou \[n_s\] & noeuds d'arrêts ou arrêts & - & Nombre total de noeuds d'arrêts desservis par le parcours. \\
+\hline
+\label{number_of_stops_on_path_outbound}
+\makecell[r]{Nombre d'arrêts aller \\ \textit{Number of outbound stops}} & \[{n_q}^{\prime}\] ou \[{n_s}^{\prime}\] & noeuds d'arrêts ou arrêts & - & Nombre total de noeuds d'arrêts desservis par le parcours aller. \\
+\hline
+\label{number_of_stops_on_path_inbound}
+\makecell[r]{Nombre d'arrêts retour \\ \textit{Number of inbound stops}} & \[{n_q}^{\prime\prime}\] ou \[{n_s}^{\prime\prime}\] & noeuds d'arrêts ou arrêts & - & Nombre total de noeuds d'arrêts desservis par le parcours retour. \\
+\hline
+\label{stop_nodes_linear_density}
+\makecell[r]{Densité linéaire de noeuds d'arrêts \\ \textit{Stop nodes linear density}} & \[{\rho}_{q_L}\] & \[\frac{\textnormal{noeuds d'arrêts}}{km}\] & \[\frac{n_q}{d}\] & Densité linéaire de noeuds d'arrêts sur une ligne ou un tronc de lignes. \\
+\hline
+\label{stop_nodes_area_density}
+\makecell[r]{Densité surfacique de noeuds d'arrêts \\ \textit{Stop nodes area density}} & \[{\rho}_{q_A}\] & \[\frac{\textnormal{noeuds d'arrêts}}{{km}^2}\] & \[\frac{N_q}{\textnormal{A}}\] & Densité surfacique de noeuds d'arrêts dans une région, un territoire donné. \\
+\hline
+\label{number_of_outbound_inbound_trips}
+\makecell[r]{Nombre de voyages aller-retour \\ \textit{Number of outbound-inbound trips}} & \[N_o\] ou \[k\] & voyages & - & Nombre total de voyages effectués dans les deux directions pour une période donnée pour une ligne bidirectionnelle ou dans la seule direction pour une ligne en boucle à sens unique. Attention aux ambiguïtés lorsque plusieurs parcours distincts sont utilisés pendant une période sur la ligne. \\
+\hline
+\end{longtable}
+
+
+\pagebreak
+\subsection*{Distances et longueurs • \textit{Distances and lengths}}
+
+\begin{longtable}{%
+    R{.3\NetTableWidth}%
+    C{.06\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.14\NetTableWidth}%
+    L{.4\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{acceleration_distance}
+\makecell[r]{Distance d'accélération \\ \textit{Acceleration distance}} & \[d_a\] & \[m\] & \[\frac{{v_p}^2}{2 a}\] & Distance parcourue lors de la phase d'accélération après avoir quitté l'arrêt précédent. \\
+\hline
+\label{deceleration_distance}
+\makecell[r]{Distance de décélération \\ \textit{Deceleration distance}} & \[d_b\] & \[m\] & \[\frac{{v_p}^2}{2 b}\] & Distance parcourue lors de la phase de décélération/freinage avant d'atteindre le prochain arrêt. \\
+\hline
+\label{distance_at_programmed_speed}
+\makecell[r]{Distance à vitesse programmée \\ \textit{Distance at programmed speed}} & \[d_{v_p}\] & \[m\] & \[d_l - d_a - d_b\] (catégorie A ou B seulement) & Distance entre la fin de l'accélération et le début de la décélération entre arrêts. \\
+\hline
+\label{interstop_distance}
+\makecell[r]{Distance inter-arrêt (longueur de segment) \\ \textit{Interstop distance (segment length)}} & \[d_l\] & \[m\] & - & Distance totale parcourue entre deux arrêts consécutifs sur le parcours. \\
+\hline
+\label{average_interstop_distance}
+\makecell[r]{Distance inter-arrêt moyenne de parcours \\ \textit{Average path interstop distance}} & \[\overline{d_l}\] & \[m\] & \[\frac{\sum_{i=1}^{n_l} {d_l}_i} {n_l}\] & Moyenne des distances inter-arrêts du parcours. \\
+\hline
+\label{median_interstop_distance}
+\makecell[r]{Distance inter-arrêt médiane de parcours \\ \textit{Median path interstop distance}} & \[\widetilde{d_l}\] & \[m\] & - & Médiane des distances inter-arrêts du parcours. \\
+\hline
+\label{minimum_interstop_distance}
+\makecell[r]{Distance inter-arrêt minimale de parcours \\ \textit{Minimum path interstop distance}} & \[{d_l}_{min}\] & \[m\] & - & Longueur du segment inter-arrêts le plus court du parcours. \\
+\hline
+\label{maximum_interstop_distance}
+\makecell[r]{Distance inter-arrêt maximale de parcours \\ \textit{Maximum path interstop distance}} & \[{d_l}_{max}\] & \[m\] & - & Longueur du segment inter-arrêts le plus long du parcours. \\
+\hline
+\label{average_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt moyenne de ligne \\ \textit{Average line interstop distance}} & \[\overline{{d_l}_L}\] & \[m\] & \[\frac{\sum_{j=1}^{n_p} {(\sum_{i=1}^{{n_l}_j} {d_l}_i})} {\sum_{j=1}^{n_p} {{n_l}_j}}\] & Distance moyenne des segments inter-arrêts d'une ligne dans les deux directions. \\
+\hline
+\label{median_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt médiane de ligne \\ \textit{Median path interstop distance}} & \[\widetilde{{d_l}_L}\] & \[m\] & - & Médiane des distances inter-arrêts de la ligne. \\
+\hline
+\label{minimum_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt minimale de ligne \\ \textit{Minimum path interstop distance}} & \[{{d_l}_L}_{min}\] & \[m\] & - & Longueur du segment inter-arrêts le plus court de la ligne. \\
+\hline
+\label{maximum_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt maximale de ligne \\ \textit{Maximum path interstop distance}} & \[{{d_l}_L}_{max}\] & \[m\] & - & Longueur du segment inter-arrêts le plus long de la ligne. \\
+\hline
+\label{path_length}
+\makecell[r]{Longueur de parcours \\ \textit{Path length}} & \[d_p\] & \[m\] & \[\sum_{i=1}^{n_l} {d_l}_i\] & Longueur totale du parcours. \\
+\hline
+\label{path_outbound_length}
+\makecell[r]{Longueur de parcours aller \\ \textit{Outbound path length}} & \[d^{\prime}\] & \[m\] & \[\sum_{i=1}^{{n_l}_{p^{\prime}}} {d_l}_i\] & Longueur totale du parcours en direction aller. \\
+\hline
+\label{path_inbound_length}
+\makecell[r]{Longueur de parcours retour \\ \textit{Inbound path length}} & \[d^{\prime\prime}\] & \[m\] & \[\sum_{i=1}^{{n_l}_{p^{\prime\prime}}} {d_l}_i\] & Longueur totale du parcours en direction retour. \\
+\hline
+\label{line_length}
+\makecell[r]{Longueur de ligne \\ \textit{Line length}} & \[d_L\] & \[m\] & \[\sum_{i=1}^{{N_l}_L} {d_l}_i\] & Longueur totale du parcours dans une seule direction. Valable seulement pour les lignes unidirectionnelles, en boucle ou bidirectionnelles symétriques. \\
+\hline
+\label{network_length}
+\makecell[r]{Longueur de réseau \\ \textit{Network length}} & \[D_{net}\] & \[km\] & \[\sum_{i=1}^{N_{l_u}} {{d_l}_i} + \sum_{i=1}^{N_{l_{m}}} {{d_l}_i}\] & Longueur totale de tous les segments uniques de lignes (dans une direction). Ne compter qu'une seule fois les segments superposés (sur lesquels passent plusieurs parcours). \\
+\hline
+\label{lines_length}
+\makecell[r]{Longueur de lignes \\ \textit{Lines lengths}} & \[D_{L_{tot}}\] & \[km\] & \[\sum_{i=1}^{N_L} {{d_L}_i}\] & Longueur totale de l'ensemble des lignes (dans une direction). Additionner les segments superposés. \\
+\hline
+\label{vehicle_length}
+\makecell[r]{Longueur de véhicule \\ \textit{Vehicle length}} & \[l_y\] & \[m\] & - & Longueur d'un véhicule. \\
+\hline
+\label{unit_length}
+\makecell[r]{Longueur d'unité \\ \textit{Unit length}} & \[l_u\] & \[m\] & \[\sum_{i=1}^{n_y} {l_y}_i\] & Longueur d'une unité. \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+    R{.3\NetTableWidth}%
+    C{.06\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.14\NetTableWidth}%
+    L{.46\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{network_direct_distance}
+\makecell[r]{Distance réseau directe \\ \textit{Direct network distance}} & \[d_n\] & \[m\] & - & Distance sur le réseau routier, ferroviaire ou autre qui minimise la distance totale entre les deux terminus, sans avoir à s'arrêter en chemnin (ne tient pas compte des arrêts en route). \\
+\hline
+\label{euclidean_distance}
+\makecell[r]{Distance euclidienne \\ \textit{Euclidian distance}} & \[d_e\] & \[m\] & - & Distance à vol d'oiseau entre les deux terminus. \\
+\hline
+\label{access_distance}
+\makecell[r]{Distance d'accès à l'origine \\ \textit{Access distance}} & \[{d_e}_O\] & \[m\] & - & Distance parcourue par l'usager de l'origine du déplacement au premier arrêt de son parcours de transport collectif. \\
+\hline
+\label{egress_distance}
+\makecell[r]{Distance d'accès à destination \\ \textit{Egress distance}} & \[{d_e}_D\] & \[m\] & - & Distance parcourue par l'usager du dernier arrêt de son parcours de transport collectif à la destination du déplacement. \\
+\hline
+\label{access_egress_distance}
+\makecell[r]{Distance d'accès à l'origine et à destination \\ \textit{Access/egress distance}} & \[{d_e}_{OD}\] & \[m\] & \[{d_e}_O + {d_e}_D\] & Distance parcourue par l'usager de l'origine au premier arrêt et du dernier arrêt à la destination de son parcours de transport collectif. \\
+\hline
+\label{transfer_distance}
+\makecell[r]{Distance de transfert \\ \textit{Transfer distance}} & \[d_{tr}\] & \[m\] & - & Distance parcourue pour se déplacer d'un arrêt à l'autre lors d'un transfert particulier. \\
+\hline
+\label{total_transfer_distance}
+\makecell[r]{Distance totale de transfert \\ \textit{Total transfer distance}} & \[{d_{tr}}_{tot}\] & \[m\] & \[\sum_{i=1}^{n_{tr}} {d_{tr}}_i\] & Distance totale parcourue pour se déplacer d'un arrêt à l'autre lors de tous les transferts effectués pendant le parcours. N'inclut pas les distances d'accès à l'origine et à destination. \\
+\hline
+\label{total_access_egress_transfer_distance}
+\makecell[r]{Distance totale d'accès et de transfert \\ \textit{Total access/sgress and transfer distance}} & \[d_{e_{tot}}\] & \[m\] & \[{d_e}_{OD} + {d_{tr}}_{tot}\]& Somme des distances d'accès de l'origine du déplacement au premier arrêt et du dernier arrêt de son parcours de transport collectif à la destination du déplacement, et de la distance totale de transfert. Cette distance représente la distance totale parcourue à pied, à vélo ou en voiture pour accéder au service de transport collectif à l'origine et à destination et pour se déplacer entre les arrêts de transfert. \\
+\hline
+\label{in_vehicle_distance}
+\makecell[r]{Distance en véhicule \\ \textit{In-vehicle distance}} & \[d_{veh}\] & \[m\] & - & Distance parcourue en véhicule sur une ligne entre l'embarquement à un arrêt et le débarquement à un arrêt subséquent sur la ligne. \\
+\hline
+\label{total_in_vehicle_distance}
+\makecell[r]{Distance totale en véhicule \\ \textit{Total in-vehicle distance}} & \[d_{{veh}_{tot}}\] & \[m\] & \[\sum_{i=1}^{n_{tr}+1} d_{{veh}_i}\] & Distance totale parcourue en véhicule lors du parcours de transport collectif complet, incluant les distances de tous les segments de ligne empruntés. \\
+\hline
+\label{total_od_distance}
+\makecell[r]{Distance totale OD \\ \textit{Total OD distance}} & \[d_{OD}\] & \[m\] & \[d_{e_{tot}} + d_{{veh}_{tot}}\] & Distance totale parcourue lors d'un déplacement de transport collectif, incluant l'accès et les transferts. \\
+\hline
+\label{total_od_transit_distance}
+\makecell[r]{Distance totale OD transport collectif \\ \textit{Total OD transit distance}} & \[d_{transit}\] ou \[d_{TC}\] & \[m\] & \[d_{OD}\] & Distance totale calculée en transport collectif. Permet de comparer la compétitivité des modes entre eux. \\
+\hline
+\label{total_od_driving_distance}
+\makecell[r]{Distance totale OD voiture \\ \textit{Total OD driving distance}} & \[d_{car}\] ou \[d_{driving}\]  & \[m\] & - & Distance totale du chemin le plus rapide calculé en voiture. Attention de bien spécifier si le parcours optimal a été calculé en tenant compte de la congestion. \\
+\hline
+\label{total_od_cycling_distance}
+\makecell[r]{Distance totale OD vélo \\ \textit{Total OD cycling distance}} & \[d_{bicycle}\] ou \[d_{cycling}\] & \[m\] & - & Distance totale du chemin le plus rapide calculé à vélo. \\
+\hline
+\label{total_od_walking_distance}
+\makecell[r]{Distance totale OD marche \\ \textit{Total OD walking distance}} & \[d_{foot}\] ou \[d_{walking}\] & \[m\] & - & Distance totale du chemin le plus rapide calculé à pied. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Temps et durées • \textit{Time and durations}}
+
+\begin{longtable}{%
+    R{.28\NetTableWidth}%
+    C{.07\NetTableWidth}%
+    C{.03\NetTableWidth}%
+    C{.22\NetTableWidth}%
+    L{.40\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{acceleration_time}
+\makecell[r]{Temps d'accélération \\ \textit{Acceleration time}} & \[t_a\] & \[s\] & \[\frac{v_p}{a}\] & Temps requis pour accélérer de l'arrêt complet à la vitesse programmée. \\
+\hline
+\label{deceleration_time}
+\makecell[r]{Temps de décélération \\ \textit{Deceleration time}} & \[t_b\] & \[s\] & \[\frac{v_p}{b}\] & Temps requis pour ralentir et freiner de la vitesse programmée à l'arrêt complet. \\
+\hline
+\label{travel_time_at_programmed_speed}
+\makecell[r]{Temps à vitesse programmée \\ \textit{Travel time at programmed speed}} & \[t_{v_p}\] & \[s\] & \[\frac{d_{v_p}}{v_p}\] (catégorie A ou B seulement) & Temps entre la fin de l'accélération et le début de la décélération d'un segment entre arrêts. \\
+\hline
+\label{segment_interstop_travel_time}
+\makecell[r]{Temps de parcours de segment/inter-arrêts \\ \textit{Segment/Interstop travel time}} & \[t_l\] & \[s\] & \[t_a + t_{v_p} + t_b\] ou \[\sqrt[]{\frac{2(a + b){d}_l}{a b}}\] si la distance inter-arrêt ne permet pas d'atteindre la vitesse programmée & Temps de parcours entre deux arrêts consécutifs qui n'inclut pas les temps d'arrêt, mais qui inclut les temps d'accélération et de décélération, ainsi que les temps d'arrêt aux feux de circulation ou en congestion. Les expressions ne sont valables que pour les catégories A ou B (aucune congestion ou feux de circulation). \\
+\hline
+\label{average_interstop_travel_time}
+\makecell[r]{Temps de parcours de segment moyen \\ \textit{Average interstop travel time}} & \[\overline{t_l}\] & \[s\] & \[\frac{\sum_{i=1}^{n_l} {t_l}_i}{n_l}\] & Moyenne des temps de parcours inter-arrêt d'un parcours ou des parcours aller et retour d'une ligne bidirectionnelle. \\
+\hline
+\label{median_interstop_travel_time}
+\makecell[r]{Temps de parcours de segment médian \\ \textit{Median interstop travel time}} & \[\widetilde{t_l}\] & \[s\] & & Médiane des temps de parcours inter-arrêt d'un parcours ou des parcours aller et retour d'une ligne bidirectionnelle. \\
+\hline
+\label{door_opening_time}
+\makecell[r]{Temps d'ouverture des portes \\ \textit{Door opening time}} & \[t_{do}\] & \[s\] & - & Temps requis pour l'ouverture de toutes les portes d'une unité pour le débarquement et/ou l'embarquement des passagers. \\
+\hline
+\label{door_closing_time}
+\makecell[r]{Temps de fermeture des portes \\ \textit{Door closing time}} & \[t_{dc}\] & \[s\] & - & Temps requis pour la fermeture de toutes les portes d'une unité pour le débarquement et/ou l'embarquement des passagers. \\
+\hline
+\label{dwell_time}
+\makecell[r]{Temps d'arrêt \\ \textit{Dwell time}} & \[t_q\] ou \[t_s\] & \[s\] & $\begin{gathered}[t] \max{\Big(\frac{n_B}{n_{{Bch}_{u}}} \overline{t_B}\ ,\ \frac{n_A}{n_{{Ach}_{u}}} \overline{t_A}\Big)} \\ + t_{do} + t_{dc} \end{gathered}$ & Temps pendant lequel l'unité en service sur un parcours est à l'arrêt complet, permettant l'embarquement et le débarquement des passagers au quai ou vis-à-vis le panneau d'arrêt. \\
+\hline
+\label{average_dwell_time}
+\makecell[r]{Temps d'arrêt moyen \\ \textit{Average dwell time}} & \[\overline{t_q}\] & \[s\] & \[\frac{\sum_{i=1}^{n_q} {t_q}_i}{n_q}\] & Moyenne des temps d'arrêt d'un parcours. \\
+\hline
+\label{median_dwell_time}
+\makecell[r]{Temps d'arrêt median \\ \textit{Median dwell time}} & \[\widetilde{t_q}\] & \[s\] & & Médiane des temps d'arrêt d'un parcours. \\
+\hline
+\label{stop_to_stop_time}
+\makecell[r]{Temps arrêt à arrêt \\ \textit{Stop to stop time}} & \[t_{\Delta s}\] & \[s\] & \[t_q + t_l\] & Temps total entre le départ de l'arrêt précédent et le départ de l'arrêt suivant. Comprend le temps de parcours inter-arrêts et le temps d'arrêt. \\
+\hline
+\label{line_average_dwell_time}
+\makecell[r]{Temps d'arrêt moyen de ligne \\ \textit{Line average dwell time }} & \[\overline{t_q}_L\] & \[s\] & \[\frac{\sum_{j=1}^{n_p} {(\sum_{i=1}^{{n_q}_j} {{t_q}_j}_i})} {\sum_{j=1}^{n_p} {n_q}_j}\] & Moyenne des temps d'arrêt d'une ligne. Attention aux ambiguïtés lorsque la ligne possède plusieurs parcours, notamment des parcours bidirectionnels non symétriques avec des temps d'arrêt non semblables. \\
+\hline
+\label{maximum_dwell_time}
+\makecell[r]{Temps d'arrêt maximal \\ \textit{Maximum dwell time}} & \[{t_q}_{max}\] & \[s\] & \[\max_{i=1}^{n_q} {{t_q}_i}\] & Temps d'arrêt à l'arrêt le plus achalandé et/ou demandant le plus de temps d'embarquement et de débarquement sur l'ensemble du parcours. \\
+\hline
+\label{line_maximum_dwell_time}
+\makecell[r]{Temps d'arrêt maximal de ligne \\ \textit{Line maximum dwell time}} & \[{{t_q}_L}_{max}\] & \[s\] & \[\max_{i=1}^{{n_q}_L} {{t_q}_i}\] & Temps d'arrêt à l'arrêt le plus achalandé et/ou demandant le plus de temps d'embarquement et de débarquement sur la ligne. Attention aux ambiguïtés lorsque la ligne possède plusieurs parcours, notamment des parcours bidirectionnels non symétriques avec des temps d'arrêt non semblables. \\
+\hline
+\label{reaction_time}
+\makecell[r]{Temps de réaction \\ \textit{Reaction time}} & \[t_r\] & \[s\] & - & Temps de réaction du conducteur ou du système autonome entre le début de la consigne ou de la demande de freinage ou d'accélération et le début du freinage ou de l'accélération. \\
+\hline
+\label{operating_time}
+\makecell[r]{Temps d'opération \\ \textit{Operating time}} & \[T_o\] & \[s\] & \[\sum_{i=1}^{n_l} {t_l}_i + \sum_{i=1}^{n_q - 1} {t_q}_i = \frac{d_L}{V_o}\]& Temps total entre le départ du terminus de départ et l'arrivée au terminus d'arrivée. Habituellement, on compte un temps d'arrêt de moins que le nombre d'arrêts sur le parcours (le temps au premier arrêt est inclus dans le battement). \\
+\hline
+\label{operating_time_outbound}
+\makecell[r]{Temps d'opération aller \\ \textit{Outbound operating time}} & \[{T_o}^\prime\] & \[s\] & \[\sum_{i=1}^{{n_l}_p} {t_l}_i + \sum_{i=1}^{n_q - 1} {t_q}_i \] où p est le parcours aller & Temps total entre le départ du terminus de départ et l'arrivée au terminus d'arrivée du parcours aller. Habituellement, on compte un temps d'arrêt de moins que le nombre d'arrêts sur le parcours (le temps au premier arrêt est inclus dans le battement). \\
+\hline
+\label{operating_time_return}
+\makecell[r]{Temps d'opération retour \\ \textit{Inbound operating time}} & \[{T_o}^{\prime\prime}\] & \[s\] & \[\sum_{i=1}^{{n_l}_p} {t_l}_i + \sum_{i=1}^{n_q - 1} {t_q}_i \] où p est le parcours retour & Temps total entre le départ du terminus de départ et l'arrivée au terminus d'arrivée du parcours retour. Habituellement, on compte un temps d'arrêt de moins que le nombre d'arrêts sur le parcours (le temps au premier arrêt est inclus dans le battement). \\
+\hline
+\label{layover_time}
+\makecell[r]{Temps de battement \\ \textit{Layover time}} & \[{t_t}\] & \[s\] & - & Temps requis pour débarquer les passagers au dernier arrêt, pour permettre à l'unité de se remettre en disponibilité pour le parcours suivant, pour rattraper les retards accumulés et pour embarquer les passagers pour le prochain départ en direction inverse. Habituellement, le battement n'inclut que le temps d'arrêt au départ du terminus, mais pas à l'arrivée (inclus dans le temps d'opération). \\
+\hline
+\label{minimum_layover_time}
+\makecell[r]{Temps de battement minimum \\ \textit{Minimum layover time}} & \[{t_t}_{min}\] & \[s\] & - & Temps de  battement minimum requis, peu importe le temps d'opération prévu. \\
+\hline
+\label{path_layover_time}
+\makecell[r]{Temps de battement de parcours \\ \textit{Path layover time}} & \[{t_t}_p\] & \[s\] & \[\max \Big( {t_t}_{min}\ ,\  {\gamma_t} {T_o} \Big)\] & Temps de battement au terminus d'arrivée du parcours. \\
+\hline
+\label{outbound_layover_time}
+\makecell[r]{Temps de battement aller \\ \textit{Outbound layover time}} & \[{t_t}^\prime\] & \[s\] & \[\max \Big( {t_t}_{min}\ ,\  {\gamma_t}^\prime {T_o}^{\prime} \Big)\] & Temps de battement au terminus 1 (à la fin du parcours aller). \\
+\hline
+\label{inbound_layover_time}
+\makecell[r]{Temps de battement retour \\ \textit{Inbound layover time}} & \[{t_t}^{\prime\prime}\] & \[s\] & \[\max \Big( {t_t}_{min}\ ,\  {\gamma_t}^{\prime\prime} {T_o}^{\prime\prime} \Big)\] & Temps de battement au terminus 2 (à la fin du parcours retour) \\
+\hline
+\label{total_layover_time}
+\makecell[r]{Temps de battement total \\ \textit{Total layover time}} & \[t_t\] & \[s\] & \[\max \Big( 2{t_t}_{min}\ ,\  {\gamma_t}^\prime {T_o}^\prime + {\gamma_t}^{\prime\prime} {T_o}^{\prime\prime} \Big)\] ou \[ \max \Big( 2{t_t}_{min}\ ,\  2 \gamma_t T_o \Big)\] pour une ligne symétrique & Temps de battement total à l'ensemble des terminus d'une ligne bidirectionnelle ou d'une ligne en boucle. Attention aux ambiguïtés si la ligne possède plusieurs parcours distincts. Le temps de battement inclut les temps d'embarquement et de débarquement des passagers aux terminus. \\
+\hline
+\label{layover_coefficient}
+\makecell[r]{Coefficient de battement \\ \textit{Layover coefficient}} & \[\gamma_t\] & - & \[\frac{t_t} {T_o}\] & Pourcentage du temps d'opération utilisé pour les battements. Le temps de battement est ajouté au temps d'opération pour obtenir le temps de cycle. Utilisé pour les lignes symétriques. \\
+\hline
+\label{outbound_layover_coefficient}
+\makecell[r]{Coefficient de battement aller \\ \textit{Outbound layover coefficient}} & \[{\gamma_t}^\prime\] & - & \[\frac{{t_t}^\prime}{{T_o}^\prime}\] & Pourcentage du temps d'opération du parcours aller utilisé pour le battement aller. \\
+\hline
+\label{inbound_layover_coefficient}
+\makecell[r]{Coefficient de battement retour \\ \textit{Inbound layover coefficient}} & \[{\gamma_t}^{\prime\prime}\] & - & \[\frac{{t_t}^{\prime\prime}}{{T_o}^{\prime\prime}}\] & Pourcentage du temps d'opération du parcours retour utilisé pour le battement retour. \\
+\hline
+\label{total_layover_coefficient}
+\makecell[r]{Coefficient de battement total \\ \textit{Total layover coefficient}} & \[\gamma_t\] & - & \[\frac{{t_t}^{\prime} + {t_t}^{\prime\prime}} {{T_o}^{\prime} + {T_o}^{\prime\prime}}\] & Pourcentage du temps d'opération total utilisé pour les battements. \\
+\hline
+\label{non_productive_tts_layover_time}
+\makecell[r]{Temps improductif de battement cadencé \\ \textit{Non-productive TTS layover time}} & \[{t_t}_{h_p}\] & \[s\] & \[T_c - {T_c}_{min}\] & Temps devant être ajouté au temps de cycle minimum d'une ligne pour pouvoir obtenir un horaire cadencé.\\
+\hline
+\label{total_non_productive_ttslayover_time}
+\makecell[r]{Temps improductif total de battement cadencé \\ \textit{Total non-productive TTS layover time}} & \[{t_t}_{{h_p}_{total}}\] & \[s\] & \[\sum_{i=1}^{n_L} {t_t}_{{h_p}_i} {{n_u}_i}\] où \(n_L\) est le nombre de lignes affectées par le cadencement & Temps total devant être ajouté aux temps de cycle minimum des lignes pour pouvoir obtenir un horaire cadencé.\\
+\hline
+\label{half_cycle_time}
+\makecell[r]{Temps de demi-cycle \\ \textit{Half-cycle time}} & \[{T_c}_p\] & \[s\] & \[{T_o} + {t_t} \] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée. \\
+\hline
+\label{outbound_half_cycle_time}
+\makecell[r]{Temps de demi-cycle aller \\ \textit{Outbound half-cycle time}} & \[{{T_c}_p}^{\prime}\] & \[s\] & \[{T_o}^{\prime} + {t_t}^{\prime} \] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée du parcours aller. \\
+\hline
+\label{inbound_half_cycle_time}
+\makecell[r]{Temps de demi-cycle retour \\ \textit{Inbound half-cycle time}} & \[{{T_c}_p}^{\prime\prime}\] & \[s\] & \[{T_o}^{\prime\prime} + {t_t}^{\prime\prime} \] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée du parcours retour. \\
+\hline
+\label{cycle_time}
+\makecell[r]{Temps de cycle \\ \textit{Cycle time}} & \[T_c\] & \[s\] & \[{T_o}^\prime + {t_t}^{\prime} +  {T_o}^{\prime\prime} + {t_t}^{\prime\prime}\] & Le temps de cycle (ou temps de remise en disponibilité) inclut le temps d'opération dans les deux directions et le temps de battement à tous les terminus des parcours aller et retour ou du terminus dans le cas d'une ligne en boucle. Ce temps représente le temps de remise en disponibilité de l'unité pour un prochain voyage. \\
+\hline
+\end{longtable}
+
+
+\begin{longtable}{%
+    R{.3\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.14\NetTableWidth}%
+    L{.44\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{direct_network_travel_time}
+\makecell[r]{Temps de parcours réseau direct \\ \textit{Direct network travel time}} & \[t_n\] & \[s\] & - & Temps de parcours calculé sur le réseau routier, ferroviaire ou autre le plus rapide entre les deux terminus, sans passer nécessairement par les arrêts du parcours. \\
+\hline
+\label{deadhead_time}
+\makecell[r]{Temps haut-le-pied \\ \textit{Deadhead time}} & \[t_d\] & \[s\] & - & Somme des temps de parcours entre le garage et le premier terminus en début de tournée, entre le dernier terminus et le garage en fin de tournée, des temps de parcours requis lors des parcours de repositionnement au départ des terminus et les temps de parcours d'interlignage si la tournée effectue du service sur plusieurs lignes. \\
+\hline
+\label{platform_time}
+\makecell[r]{Temps plateforme \\ \textit{Platform time}} & \[T_p\] & \[s\] & \[k T_c + t_d\] où \[k\] est le nombre de voyages aller-retour effectués pendant la tournée & Temps total pendant lequel une unité est en opération sur une tournée complète, en service productif et en haut-le-pied. Attention aux ambiguïtés lorsque les tournées comprennent des parcours d'interlignage. \\
+\hline
+\label{access_egress_time}
+\makecell[r]{Temps d'accès \\ \textit{Access/egress time}} & \[t_{e}\] & \[s\] & - & Temps de parcours à pied, à vélo ou en voiture permettant d'atteindre un arrêt. \\
+\hline
+\label{access_time}
+\makecell[r]{Temps d'accès à l'origine \\ \textit{Access time}} & \[{t_e}_O\] & \[s\] & \[v_e {d_e}_O\] & Temps d'accès de l'usager entre l'origine du déplacement et le premier arrêt de son parcours de transport collectif. Un calculateur de chemin réseau pour le mode d'accès (marche, vélo, voiture ou autre) peut permettre d'obtenir un temps d'accès calibré et tenant compte des obstacles et des feux de circulation. \\
+\hline
+\label{egress_time}
+\makecell[r]{Temps d'accès à destination \\ \textit{Egress time}} & \[{t_e}_D\] & \[s\] & \[v_e {d_e}_D\] & Temps d'accès de l'usager entre le dernier arrêt de son parcours de transport collectif et la destination du déplacement. \\
+\hline
+\label{access_egress_time_od}
+\makecell[r]{Temps total d'accès à l'origine et à destination \\ \textit{Access/egress time}} & \[{t_e}_{OD}\] & \[s\] & \[{t_e}_O + {t_e}_D\]& Temps total d'accès de l'usager de l'origine du déplacement au premier arrêt et du dernier arrêt de son parcours de transport collectif à la destination du déplacement. N'inclut pas le temps total d'accès de transfert. \\
+\hline
+\label{transfer_time}
+\makecell[r]{Temps de transfert \\ \textit{Transfer time}} & \[t_{tr}\] & \[s\] & - & Temps de parcours permettant de passer d'un arrêt à l'autre lors d'un transfer. N'inclut pas le temps d'attente lors du transfert. \\
+\hline
+\label{total_transfer_time}
+\makecell[r]{Temps total de transfert \\ \textit{Total transfer time}} & \[{t_{tr}}_{tot}\] & \[s\] & \[\sum_{i=1}^{n_{tr}} d_{tr}\] & Temps total de parcours permettant de passer d'un arrêt à l'autre lors de tous les transferts effectués pendant le parcours. N'inclut pas les temps d'accès à l'origine et à destination ni le temps d'attente lors du transfert. \\
+\hline
+\label{total_access_egress_transfer_time}
+\makecell[r]{Temps total d'accès et de transfert \\ \textit{Total access/egress and transfer time}} & \[{t_e}_{tot}\] & \[s\] & \[{t_e}_{OD} + {t_{tr}}_{tot}\] & Somme des temps d'accès de l'usager de l'origine du déplacement au premier arrêt et du dernier arrêt de son parcours de transport collectif à la destination du déplacement, et du temps total d'accès de transfert. Ce temps représente le total du temps de parcours effectué à pied, à vélo ou en voiture pour accéder au service de transport collectif à l'origine et à destination et pour se déplacer entre les arrêts de transfert. \\
+\hline
+\label{waiting_time}
+\makecell[r]{Temps d'attente \\ \textit{Waiting time}} & \[t_w\] & \[s\] & - & Temps d'attente avant l'embarquement à un arrêt. \\
+\hline
+\label{origin_waiting_time}
+\makecell[r]{Temps d'attente à l'origine \\ \textit{Origin waiting time}} & \[{t_w}_O\] & \[s\] & - & Temps d'attente au premier arrêt d'embarquement du parcours. \\
+\hline
+\label{transfer_waiting_time}
+\makecell[r]{Temps d'attente de transfert \\ \textit{Transfer waiting time}} & \[{t_w}_{tr}\] & \[s\] & - & Temps d'attente avant l'embarquement à un arrêt lors d'un transfert. \\
+\hline
+\label{minimum_waiting_time}
+\makecell[r]{Temps minimum d'attente \\ \textit{Minimum waiting time}} & \[{t_w}_{min}\] & \[s\] & - & Temps minimum de sécurité (d'arrivée à l'avance) avant l'embarquement à un arrêt pour tenir compte des retards possibles de la ligne précédente lors d'un transfert, des incertitudes sur les temps d'accès et de la possibilité que l'unité parte en avance sur l'horaire planifié à l'arrêt d'embarquement. Utilisé pour les calculs de chemin transport collectif. \\
+\hline
+\label{total_transfer_waiting_time}
+\makecell[r]{Temps total d'attente de transfert \\ \textit{Total transfer waiting time}} & \[{{t_w}_{tr}}_{tot}\] & \[s\] & \[\sum_{i=1}^{n_{tr}} {{t_w}_i}\] & Temps total d'attente lors des transferts. N'inclut ni le temps d'attente à l'origine, ni les temps d'accès aux transferts. \\
+\hline
+\label{total_waiting_time}
+\makecell[r]{Temps total d'attente \\ \textit{Total waiting time}} & \[{t_w}_{tot}\] & \[s\] & \[{t_w}_O + {{t_w}_{tr}}_{tot}\] & Temps total d'attente, incluant le temps d'attente à l'origine et les temps d'attente de transfert. \\
+\hline
+\label{in_vehicle_time}
+\makecell[r]{Temps en véhicule \\ \textit{In-vehicle time}} & \[t_{veh}\] & \[s\] & - & Temps passé en véhicule sur une ligne entre l'embarquement à un arrêt et le débarquement à un arrêt subséquent sur la ligne. \\
+\hline
+\label{total_in_vehicle_time}
+\makecell[r]{Temps total en véhicule \\ \textit{Total in-vehicle time}} & \[{t_{veh}}_{tot}\] & \[s\] & \[\sum_{i=1}^{n_{tr}+1} t_{{veh}_i}\] & Temps total passé en véhicule lors du parcours de transport collectif complet, incluant les temps de parcours de tous les segments de ligne empruntés et les temps d'arrêt en route. \\
+\hline
+\label{total_od_time}
+\makecell[r]{Temps total OD \\ \textit{Total OD time}} & \[T_{OD}\] & \[s\] & \[ {t_e}_{tot} + {t_w}_{tot} + {t_{veh}}_{tot}\] & Temps total entre l'origine et la destination. \\
+\hline
+\label{average_single_boarding_time}
+\makecell[r]{Temps moyen d'embarquement par passager \\ \textit{Average single boarding time}} & \[\overline{t_B}\] & \[s\] & - & \\
+\hline
+\label{average_single_alighting_time}
+\makecell[r]{Temps moyen de débarquement par passager \\ \textit{Average single alighting time}} & \[\overline{t_A}\] & \[s\] & - & \\
+\hline
+\label{reported_total_time}
+\makecell[r]{Temps total rapporté \\ \textit{Reported total time}} & \[T_{rep}\] \[{T_{rep}}_L\] & \[s\] & - & Temps total déclaré comme ayant été travaillé par les employés. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{total_paid_time}
+\makecell[r]{Temps total payé \\ \textit{Total paid time}} & \[T_{paid}\] \[{T_{paid}}_L\] & \[s\] & - & Temps total payé aux employés. Inclut les temps déclarés travaillés et les absences, retards, congés, etc. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{total_service_time}
+\makecell[r]{Temps total travaillé en service \\ \textit{Total service time}} & \[T_{serv}\] \[{T_{serv}}_L\] & \[s\] & - & Temps total pour lequel du travail en service a été effectué par les employés. Ce temps n'inclut pas les temps haut-le-pied et les temps de battement. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{personnel_attendence_coefficient}
+\makecell[r]{Coefficient d'efficacité de présence \\ \textit{Personnel attendence coefficient}} & \[\eta_a\] \[{\eta_a}_L\] & - & \[\frac{T_{rep}}{T_{paid}}\] \[\frac{{T_{rep}}_L}{{T_{paid}}_L}\] & Permet d'évaluer le ratio entre les heures rapportées travaillées et les heures payées qui comprennent les absences, retards, congés, etc. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{run_cutting_and_schedule_efficiency_coefficient}
+\makecell[r]{Coefficient d'efficacité d'habillage \\ \textit{Run-cutting and schedule efficiency coefficient}} & \[\eta_s\] \[{\eta_s}_L\] & - & \[\frac{T_{serv}}{T_{rep}}\] \[\frac{{T_{serv}}_L}{{T_{rep}}_L}\] & Permet d'évaluer le ratio entre les heures travaillées pour offrir un service aux usagers et les heures rapportées travaillées, qui incluent les réunions, les pauses, les vérifications avant départ, les temps haut-le-pied, les temps en terminus, etc. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{terminal_efficiency_coefficient}
+\makecell[r]{Coefficient d'efficacité en terminus \\ \textit{Terminal efficiency coefficient}} & \[\eta_t\] \[{\eta_t}_L\] & - & \[\frac{{T_o}^\prime + {T_o}^{\prime\prime}}{T_c}\] lorsque les lignes sont bidirectionnelles et symétriques & Représente le ratio entre le temps total d'opération aller-retour et le temps de cycle qui inclut les battements en terminus. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{global_efficiency_coefficient}
+\makecell[r]{Coefficient d'efficacité globale \\ \textit{Global operating efficiency coefficient}} & \[\eta\] \[{\eta}_L\] & - & \[\eta_a \eta_s \eta_t\] \[{\eta_a}_L {\eta_s}_L {\eta_t}_L\] & Représente l'efficacité globale d'une ligne ou d'un réseau. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{total_transit_od_time}
+\makecell[r]{Temps total OD en transport collectif \\ \textit{Total transit OD travel time}} & \[T_{transit}\] ou \[T_{TC}\] & \[s\] & \[T_{OD}\] & Temps calculé en transport collectif. Permet de comparer la compétitivité des modes entre eux. \\
+\hline
+\label{total_driving_od_time}
+\makecell[r]{Temps total OD en voiture \\ \textit{Total driving OD travel time}} & \[T_{car}\] ou \[T_{driving}\] & \[s\] & - & Temps de parcours du chemin le plus rapide calculé en voiture. Attention de bien spécifier si ce temps et le parcours emprunté tient compte de la congestion. \\
+\hline
+\label{total_bicycle_od_time}
+\makecell[r]{Temps total OD à vélo \\ \textit{Total cycling OD travel time}} & \[T_{bicycle}\] ou \[T_{cycling}\] & \[s\] & - & Temps de parcours du chemin le plus rapide calculé à vélo. \\
+\hline
+\label{total_walking_od_time}
+\makecell[r]{Temps total OD à pied \\ \textit{Total walking OD travel time}} & \[T_{foot}\] ou \[T_{walking}\] & \[s\] & - & Temps de parcours du chemin le plus rapide calculé à pied. \\
+\hline
+\label{transit_driving_competitivity_coefficient}
+\makecell[r]{Coefficient de compétitivité TC/voiture \\ \textit{Transit/driving competitivity coefficient}} & \[\mu_{car}\] ou \[\mu_{driving}\] & - & \[\frac{T_{transit}}{T_{car}}\] & Une valeur \(> 1\) indique que le transport collectif est plus lent. \\
+\hline
+\label{transit_cycling_competitivity_coefficient}
+\makecell[r]{Coefficient de compétitivité du TC/vélo \\ \textit{Transit/cycling competitivity coefficient}} & \[\mu_{bicycle}\] ou \[\mu_{cycling}\] & - & \[\frac{T_{transit}}{T_{bicycle}}\] & Une valeur \(> 1\) indique que le transport collectif est plus lent. \\
+\hline
+\label{transit_walking_competitivity_coefficient}
+\makecell[r]{Coefficient de compétitivité TC/marche \\ \textit{Transit/walking competitivity coefficient}} & \[\mu_{foot}\] ou \[\mu_{walking}\] & - & \[\frac{T_{transit}}{T_{foot}}\] & Une valeur \(> 1\) indique que le transport collectif est plus lent. \\
+\hline
+\end{longtable} 
+
+
+
+
+\pagebreak
+\subsection*{Vitesses • \textit{Speeds and velocities}}
+
+\begin{longtable}{%
+  R{.26\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.04\NetTableWidth}%
+  C{.18\NetTableWidth}%
+  L{.44\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{unit_maximum_speed}
+\makecell[r]{Vitesse maximale de l'unité \\ \textit{Unit maximum speed}} & \[v_{max}\] & \[{km}/h\] & - & Vitesse que l'unité peut atteindre à puissance maximale. \\
+\hline
+\label{design_speed}
+\makecell[r]{Vitesse de conception \\ \textit{Design speed}} & \[v_d\] & \[{km}/h\] & - & Vitesse maximale possible sur un tronçon. Tient compte des contraintes de confort et de sécurité. \\
+\hline
+\label{legal_speed}
+\makecell[r]{Vitesse légale \\ \textit{Legal speed}} & \[v_{reg}\] & \[{km}/h\] & - & Vitesse légale permise sur le tronçon. \\
+\hline
+\label{programmed_speed}
+\makecell[r]{Vitesse programmée \\ \textit{Programmed speed}} & \[v_p\] & \[{km}/h\] & - & Vitesse programmée en service sur un tronçon ou un segment. Habituellement, cette vitesse est déterminée de manière à optimiser, dans le meilleur équilibre, l'efficacité énergétique et la minimisation des temps de parcours inter-arrêts. \(v_p \leq v_{reg} \leq v_d\) \\
+\hline
+\label{operating_speed}
+\makecell[r]{Vitesse d'opération \\ \textit{Operating speed}} & \[V_o\] & \[{km}/h\] & \[\frac{d_p}{T_o}\] & Vitesse commerciale perçue par l'usager sur un parcours, qui inclut les temps d'arrêt. \\
+\hline
+\label{outbound_operating_speed}
+\makecell[r]{Vitesse d'opération aller \\ \textit{Outbound operating speed}} & \[{V_o}^\prime\] & \[{km}/h\] & \[\frac{d^{\prime}}{{T_o}^{\prime}}\] & Vitesse commerciale pour le parcours aller. \\
+\hline
+\label{inbound_operating_speed}
+\makecell[r]{Vitesse d'opération retour \\ \textit{Inbound operating speed}} & \[{V_o}^{\prime\prime}\] & \[{km}/h\] & \[\frac{d^{\prime\prime}}{{T_o}^{\prime\prime}}\] & Vitesse commerciale pour le parcours retour. \\
+\hline
+\label{line_operating_speed}
+\makecell[r]{Vitesse d'opération de ligne \\ \textit{Line operating speed}} & \[{V_o}_L\] & \[{km}/h\] & \[\frac{d^{\prime} + d^{\prime\prime}}{{T_o}^{\prime} + {T_o}^{\prime\prime}}\] & Vitesse commerciale sur la ligne. Attention aux ambiguïtés lorsque la ligne n'est pas bidirectionnelle symétrique ou en boucle. \\
+\hline
+\label{half_cycle_speed}
+\makecell[r]{Vitesse de demi-cycle \\ \textit{Half-cycle speed}} & \[V_{1/2c}\] & \[{km}/h\] & \[\frac{d_p}{T_{1/2c}}\] & Vitesse moyenne pendant un demi-cycle (parcours) \\
+\hline
+\label{outbound_half_cycle_speed}
+\makecell[r]{Vitesse de demi-cycle aller \\ \textit{Outbound half-cycle speed}} & \[{V_{1/2c}}^{\prime}\] & \[{km}/h\] & \[\frac{d^{\prime}}{{T_{1/2c}}^{\prime}}\] & Vitesse moyenne pendant le demi-temps de cycle aller. \\
+\hline
+\label{inbound_half_cycle_speed}
+\makecell[r]{Vitesse de demi-cycle retour \\ \textit{Inbound half-cycle speed}} & \[{V_{1/2c}}^{\prime\prime}\] & \[{km}/h\] & \[\frac{d^{\prime\prime}}{{T_{1/2c}}^{\prime\prime}}\] & Vitesse moyenne pendant le demi-temps de cycle retour. \\
+\hline
+\label{cycle_speed}
+\makecell[r]{Vitesse de cycle \\ \textit{Cycle speed}} & \[V_c\] & \[{km}/h\] & \[\frac{d^{\prime} + d^{\prime\prime}}{T_c}\] & Vitesse moyenne aller-retour pendant le temps de cycle. \\
+\hline
+\label{platform_speed}
+\makecell[r]{Vitesse plateforme \\ \textit{Platform speed}} & \[V_p\] & \[{km}/h\] & \[\frac{k(d^{\prime} + d^{\prime\prime})}{T_p}\] où \[k\] est le nombre de voyages aller-retour effectués pendant la tournée & Vitesse moyenne pendant le temps pour lequel une unité est en opération sur une tournée complète, en service productif et en haut-le-pied. Attention aux ambiguïtés lorsque les tournées comprennent des parcours d'interlignage. \\
+\hline
+\label{segment_speed}
+\makecell[r]{Vitesse de segment/inter-arrêt \\ \textit{Segment/interstop speed}} & \[v_l\] & \[{km}/h\] & \[\frac{d_l}{t_l}\] & Vitesse moyenne entre le départ de l'arrêt précédent et l'arrivée à l'arrêt suivant (segment). N'inclut pas le temps d'arrêt. \\
+\hline
+\label{stop_to_stop_speed}
+\makecell[r]{Vitesse arrêt à arrêt \\ \textit{Stop to stop speed}} & \[v_{\Delta s}\] ou \[v_{\Delta q}\] & \[{km}/h\] & \[\frac{d_l}{t_l + t_q}\] & Vitesse moyenne entre le départ de l'arrêt précédent et le départ de l'arrêt suivant. Inclut le temps d'arrêt. \\
+\hline
+\label{average_segment_speed}
+\makecell[r]{Vitesse moyenne de segment/inter-arrêt \\ \textit{Average segment/interstop speed}} & \[\overline{v_l}\] & \[{km}/h\] & \[\frac{ \sum_{i=1}^{n_l} {\frac{{d_l}_i}{{t_l}_i}}} {n_l} \] & Moyenne des vitesses inter-arrêt des segments d'un parcours ou d'une ligne. \\
+\hline
+\label{average_in_vehicle_speed}
+\makecell[r]{Vitesse moyenne en véhicule \\ \textit{Average in-vehicle speed}} & \[v_{veh}\] & \[{km}/h\] & - & Vitesse moyenne d'opération des segments de la ligne ou des lignes utilisées lors du déplacement. \\
+\hline
+\label{access_egress_speed}
+\makecell[r]{Vitesse d'accès \\ \textit{Access/egress speed}} & \[v_e\] & \[{km}/h\] & - & Vitesse de marche, à vélo ou en voiture pour accéder aux arrêts à l'origine et à destination et lors des transferts. Un calcul de chemin bien calibré permet d'obtenir des vitesses plus réalistes, en tenant compte notamment des feux de circulation, de la congestion et des obstacles. \\
+\hline
+\label{od_speed}
+\makecell[r]{Vitesse OD \\ \textit{OD speed}} & \[V_{OD}\] & \[{km}/h\] & \[\frac{d_{OD}}{T_{OD}}\] & Vitesse moyenne globale d'un parcours de l'origine à la destination, en tenant compte des accès, des transferts, de tous les segments en véhicule, ainsi que de tous les temps d'arrêt et d'attente. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Fréquences et intervalles • \textit{Frequencies and periods}}
+
+\begin{longtable}{%
+  R{.29\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.05\NetTableWidth}%
+  C{.15\NetTableWidth}%
+  L{.43\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{frequency}
+\makecell[r]{Fréquence \\ \textit{Frequency}} & \[f\] & \[\text{unités}/h\] & \[\frac{60}{h}=\frac{n_u}{T_c}\] & Nombre de passages d'une unité par heure sur un parcours ou une ligne (\(T_c\) est en heures). \\
+\hline
+\label{minimum_frequency}
+\makecell[r]{Fréquence minimale \\ \textit{Minimum frequency}} & \[f_{min}\] & \[\text{unités}/h\] & \[\frac{60}{h_{max}}\] & Fréquence de service minimale selon contraintes et réglementations nationales, régionales ou locales. Cette fréquence peut être différente selon la période de service (matin, pointe du matin, journée, pointe du soir, soir, nuit, fin de semaine, etc.) \\
+\hline
+\label{minimum_peak_frequency}
+\makecell[r]{Fréquence minimale de pointe \\ \textit{Minimum peak frequency}} & \[{f_{peak}}_{min}\] & \[\text{unités}/h\] & \[\frac{60}{{h_{peak}}_{max}}\] & Fréquence de service minimale de pointe selon contraintes et réglementations nationales, régionales ou locales. \\
+\hline
+\label{minimum_off_peak_frequency}
+\makecell[r]{Fréquence minimale hors-pointe \\ \textit{Minimum off-peak frequency}} & \[{f_{off}}_{min}\] & \[\text{unités}/h\] & \[\frac{60}{{h_{off}}_{max}}\] & Fréquence de service minimale hors-pointe selon contraintes et réglementations nationales, régionales ou locales. Habituellement valable entre les pointes du matin et de l'après-midi et en soirée. \\
+\hline
+\label{way_constrained_maximum_frequency}
+\makecell[r]{Fréquence maximale contrainte de voie \\ \textit{Way constrained maximum frequency}} & \[{f_l}_{max}\] & \[\text{unités}/h\] & \[\frac{60}{{h_l}_{min}}\] & Fréquence maximale de service possible en tenant compte de la voie dans laquelle se déplace les unités affectées au parcours ou à la ligne. Cette fréquence tient compte des vitesses maximales permises, des critères de sécurité et des obstacles sur la voie (aiguillages, congestion, virages, etc.) \\
+\hline
+\label{dwell_constrained_maximum_frequency}
+\makecell[r]{Fréquence maximale contrainte d'arrêt \\ \textit{Dwell constrained maximum frequency}} & \[{f_s}_{max}\] & \[\text{unités}/h\] & \[\frac{60}{{h_s}_{min}}\] & Fréquence maximale de service possible en tenant compte de l'arrêt limitant sur le parcours ou la ligne. Tient compte de l'espace disponible aux arrêts, du nombre d'unités pouvant s'y arrêter, des temps d'arrêts prévus et des critères de sécurité. La plupart du temps, \({f_s}_{max} \ll {{f_l}_{max}}\) \\
+\hline
+\label{maximum_frequency}
+\makecell[r]{Fréquence maximale \\ \textit{Maximum frequency}} & \[f_{max}\] & \[\text{unités}/h\] & \[\min \Big({{f_s}_{max}}\ ,\ {{f_l}_{max}}\Big)\] & Fréquence maximale de service possible en tenant compte des contraintes de voie et d'arrêt. \\
+\hline
+\label{peak_frequency}
+\makecell[r]{Fréquence de pointe \\ \textit{Peak frequency}} & \[f_{peak}\] & \[\text{unités}/h\] & \[\frac{60}{h_{peak}}\] & Fréquence pendant la période de pointe maximale (fréquence maximale offerte) sur un parcours ou une ligne. \\
+\hline
+\label{ultra_peak_frequency}
+\makecell[r]{Fréquence d'ultra-pointe \\ \textit{Ultra-peak frequency}} & \[f_{up}\] & \[\text{unités}/h\] & \[\frac{60}{h_{up}}\] & Fréquence requise pendant le 15 minutes le plus achalandé de la période de pointe maximale (fréquence maximale requise) sur un parcours ou une ligne. \\
+\hline
+\label{off_peak_frequency}
+\makecell[r]{Fréquence hors-pointe \\ \textit{Off-peak frequency}} & \[f_{off}\] & \[\text{unités}/h\] & \[\frac{60}{h_{off}}\] & Fréquence pendant la période hors-pointe (fréquence offerte) sur un parcours ou une ligne. \\
+\hline
+\label{average_frequency}
+\makecell[r]{Fréquence moyenne \\ \textit{Average frequency}} & \[\overline{f}\] & \[\text{unités}/h\] & \[\frac{\sum_{i=1}^{n_\text{périodes}} {f_i}}{n_\text{périodes}}\] & Fréquence moyenne d'un ensemble de périodes de service sur un parcours ou une ligne. \\
+\hline
+\label{stop_weighted_peak_frequency}
+\makecell[r]{Fréquence de pointe pondérée par arrêt \\ \textit{Stop weighted peak frequency}} & \[{f_{peak}}_s\] ou \[{f_{peak}}_q\] & \[\text{unités}/h\] & \[\frac{\sum_{i=1}^{n_q} {f_i}}{n_q}\] & Attention de spécifier si la fréquence à chaque arrêt est la fréquence de la ligne avec la meilleure fréquence qui dessert l'arrêt ou la fréquence moyenne de toutes les lignes qui desservent l'arrêt. \\
+\hline
+\label{headway_or_period}
+\makecell[r]{Intervalle ou période \\ \textit{Headway or period}} & \[h\] & \[min\] & \[\frac{60}{f}=\frac{T_c}{n_u}\] & Intervalle de temps entre le passage consécutif de deux unités sur un parcours ou une ligne (\(T_c\) est en minutes). \\
+\hline
+\label{maximum_headway}
+\makecell[r]{Intervalle maximum \\ \textit{Maximum headway}} & \[h_{max}\] & \[min\] & \[\frac{60}{f_{min}}\] & Intervalle de service maximum selon contraintes et réglementations nationales, régionales ou locales. Cet intervalle peut être différente selon la période de service (matin, pointe du matin, journée, pointe du soir, soir, nuit, fin de semaine, etc.) \\
+\hline
+\label{maximum_peak_headway}
+\makecell[r]{Intervalle maximum de pointe \\ \textit{Maximum peak headway}} & \[{f_{peak}}_{max}\] & \[\text{unités}/h\] & \[\frac{60}{{h_{peak}}_{min}}\] & Intervalle maximum de pointe selon contraintes et réglementations nationales, régionales ou locales. \\
+\hline
+\label{maximum_off_peak_headway}
+\makecell[r]{Intervalle maximum hors-pointe \\ \textit{Maximum off-peak headway}} & \[{h_{off}}_{max}\] & \[\text{min}\] & \[\frac{60}{{f_{off}}_{min}}\] & Intervalle maximum hors-pointe selon contraintes et réglementations nationales, régionales ou locales. Habituellement valable entre les pointes du matin et de l'après-midi et en soirée. \\
+\hline
+\label{way_constrained_minimum_headway}
+\makecell[r]{Intervalle minimum selon contrainte de voie \\ \textit{Way constrained minimum headway}} & \[{h_l}_{min}\] & \[min\] & \[\frac{60}{{f_l}_{max}}\] & Intervalle minimum de service possible en tenant compte de la voie dans laquelle se déplace les unités affectées au parcours ou à la ligne. Cet intervalle tient compte des vitesses maximales permises, des critères de sécurité et des obstacles sur la voie (aiguillages, congestion, virages, etc.) \\
+\hline
+\label{dwell_constrained_minimum_headway}
+\makecell[r]{Intervalle minimum selon contrainte d'arrêt \\ \textit{Dwell constrained minimum headway}} & \[{h_s}_{min}\] & \[min\] & \[\frac{60}{{f_s}_{max}}\] & Intervalle minimum de service possible en tenant compte de l'arrêt limitant sur le parcours ou la ligne. Tient compte de l'espace disponible aux arrêts, du nombre d'unités pouvant s'y arrêter, des temps d'arrêts prévus et des critères de sécurité. La plupart du temps, \({h_s}_{min} \gg {{h_l}_{min}}\) \\
+\hline
+\label{minimum_headway}
+\makecell[r]{Intervalle minimum \\ \textit{Minimum headway}} & \[h_{min}\] & \[min\] & \[\max \Big({{h_s}_{min}}\ ,\ {{h_l}_{min}}\Big)\] & Fréquence maximale de service possible en tenant compte des contraintes de voie et d'arrêt. \\
+\hline
+\label{peak_headway}
+\makecell[r]{Intervalle de pointe \\ \textit{Peak headway}} & \[h_{peak}\] & \[min\] & \[\frac{60}{f_{peak}}\] & Intervalle pendant la période de pointe maximale (intervalle minimum offert) sur un parcours ou une ligne. \\
+\hline
+\label{ultra_peak_headway}
+\makecell[r]{Intervalle d'ultra-pointe \\ \textit{Ultra-peak headway}} & \[h_{up}\] & \[min\] & \[\frac{60}{f_{up}}\] & Intervalle requis pendant le 15 minutes le plus achalandé de la période de pointe maximale (intervalle minimum requis) sur un parcours ou une ligne. \\
+\hline
+\label{off_peak_headway}
+\makecell[r]{Intervalle hors-pointe \\ \textit{Off-peak headway}} & \[h_{off}\] & \[min\] & \[\frac{60}{f_{off}}\] & Intervalle pendant la période hors-pointe (fréquence offerte) sur un parcours ou une ligne. \\
+\hline
+\label{average_headway}
+\makecell[r]{Intervalle moyen \\ \textit{Average headway}} & \[\overline{h}\] & \[min\] & \[\frac{\sum_{i=1}^{n_\text{périodes}} {h_i}}{n_\text{périodes}}\] & Intervalle moyen d'un ensemble de périodes de service sur un parcours ou une ligne. \\
+\hline
+\label{stop_weighted_peak_headway}
+\makecell[r]{Intervalle de pointe pondéré par arrêt \\ \textit{Stop weighted peak headway}} & \[{h_{peak}}_s\] ou \[{h_{peak}}_q\] & \[min\] & \[\frac{\sum_{i=1}^{n_q} {h_i}}{n_q}\] & Attention de spécifier si l'intervalle à chaque arrêt est l'intervalle de la ligne avec le plus petit intervalle qui dessert l'arrêt ou l'intervalle moyen de toutes les lignes qui desservent l'arrêt. \\
+\hline
+\label{pulsation_headway_or_tts_headway}
+\makecell[r]{Intervalle de pulsation ou intervalle cadencé \\ \textit{Pulsation headway or TTS headway}} & \[h_p\] & \[min\] & - & Intervalle permettant de synchroniser plusieurs lignes entre elles aux points focaux (horaires cadencés ou \textit{Timed-Transfer-System - TTS}). Habituellement: 10, 15 ou 20 minutes en réseaux urbains et 30 ou 60 minutes en réseaux interurbains/régionaux. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Volumes et demande • \textit{Volumes and demand}}
+
+\begin{longtable}{%
+  R{.35\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.06\NetTableWidth}%
+  C{.1\NetTableWidth}%
+  L{.41\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{volume}
+\makecell[r]{Volume/Demande \\ \textit{Volume/Demand}} & \[P\] & \[pass/h\] & - & Nombre de passagers par heure sur un parcours, une ligne, à un arrêt, un noeud d'arrêt ou une station. \\
+\hline
+\label{number_of_boardings_at_stop}
+\makecell[r]{Nombre d'embarquements à un arrêt \\ \textit{Number of boardings at stop}} & \[n_B\] & \[pass\] & - & - \\
+\hline
+\label{number_of_alightings_at_stop}
+\makecell[r]{Nombre de débarquements à un arrêt \\ \textit{Number of alightings at stop}} & \[n_A\] & \[pass\] & - & - \\
+\hline
+\label{total_number_of_boardings}
+\makecell[r]{Nombre total d'embarquements \\ \textit{Total number of boardings}} & \[N_B\] & \[pass\] & \[\sum_{i=1}^{n_q} {{n_B}_i}\] & Nombre total d'embarquements sur un voyage d'une ligne, dans une direction. \\
+\hline
+\label{total_number_of_alightings}
+\makecell[r]{Nombre total de débarquements \\ \textit{Total number of alightings}} & \[N_A\] & \[pass\] & \[\sum_{i=1}^{n_q} {{n_A}_i}\] & Nombre total de débarquements sur un voyage d'une ligne, dans une direction. \\
+\hline
+\label{maximum_number_of_boardings_in_channel}
+\makecell[r]{Nombre d'embarquements maximum en voie d'accès \\ \textit{Maximum number of boardings in channel}} & \[{n_B}_{max}\] & \[pass\] & \[\overline{n_B} \xi_B\] & Nombre total d'embarquements à la voie d'embarquement la plus achalandée. \\
+\hline
+\label{maximum_number_of_alightings_in_channel}
+\makecell[r]{Nombre de débarquements maximum en voie d'accès \\ \textit{Maximum number of alightings in channel}} & \[{n_A}_{max}\] & \[pass\] & \[\overline{n_A} \xi_A\] & Nombre total de débarquements à la voie de débarquement la plus achalandée. \\
+\hline
+\label{average_number_of_boardings_per_channel}
+\makecell[r]{Nombre moyen d'embarquements par voie d'accès \\ \textit{Average number of boardings per channel}} & \[\overline{n_B}\] & \[pass\] & \[\frac{n_B} {{n_{Bch}}_u}\] & Nombre moyen d'embarquements par voie d'embarquement. \\
+\hline
+\label{average_number_of_alightings_per_channel}
+\makecell[r]{Nombre moyen de débarquements par voie d'accès \\ \textit{Average number of alightings per channel}} & \[\overline{n_A}\] & \[pass\] & \[\frac{n_A} {{n_{Ach}}_u}\] & Nombre moyen de débarquements par voie de débarquement. \\
+\hline
+\label{boarding_distribution_coefficient}
+\makecell[r]{Coefficient de distribution des embarquements \\ \textit{Boarding distribution coefficient}} & \[\xi_B\] & - & \[\frac{{n_B}_{max}} {\overline{n_B}}\] & Facteur permettant de déterminer la distribution des embarquements sur l'ensemble des voies d'embarquement. \\
+\hline
+\label{alighting_distribution_coefficient}
+\makecell[r]{Coefficient de distribution des débarquements \\ \textit{Alighting distribution coefficient}} & \[\xi_A\] & - & \[\frac{{n_A}_{max}} {\overline{n_A}}\] & Facteur permettant de déterminer la distribution des débarquements sur l'ensemble des voies de débarquement. \\
+\hline
+\label{maximum_volume}
+\makecell[r]{Volume maximum (horaire) \\ \textit{Maximum volume (hourly)}} & \[P_{max}\] & \[pass/h\] & - & Nombre total de passagers ayant voyagé sur le segment le plus achalandé d'une ligne, dans la direction la plus achalandée, pendant l'heure de pointe maximale. \\
+\hline
+\label{segment_volume}
+\makecell[r]{Volume de segment \\ \textit{Segment volume}} & \[P_l\] & \[pass/h\] & - & Nombre total de passagers ayant voyagé sur le segment, par heure. \\
+\hline
+\label{average_path_volume}
+\makecell[r]{Volume moyen de parcours \\ \textit{Average path volume}} & \[\overline{P_p}\] & \[pass/h\] & \[\frac{\sum_{i=1}^{{n_l}} {P_l}_i}{{n_l}}\] & Nombre moyen de passagers par segment du parcours par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{average_outbound_volume}
+\makecell[r]{Volume moyen aller \\ \textit{Average outbound volume}} & \[\overline{{P_p}^{\prime}}\] & \[pass/h\] & \[\frac{\sum_{i=1}^{{n_l}^{\prime}} {P_l}_i}{{n_l}^{\prime}}\] & Nombre moyen de passagers par segment du parcours aller par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{average_inbound_volume}
+\makecell[r]{Volume moyen retour \\ \textit{Average inbound volume}} & \[\overline{{P_p}^{\prime\prime}}\] & \[pass/h\] & \[\frac{\sum_{i=1}^{{n_l}^{\prime\prime}} {P_l}_i}{{n_l}^{\prime\prime}}\] & Nombre moyen de passagers par segment du parcours retour par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{average_line_volume}
+\makecell[r]{Volume moyen de ligne \\ \textit{Average line volume}} & \[\overline{P_L}\] & \[pass/h\] & \[\frac{\overline{{P_p}^{\prime}} + \overline{{P_p}^{\prime\prime}}}{2}\] & Nombre moyen de passagers par segment de la ligne par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{maximum_load_segment}
+\makecell[r]{Segment à volume maximal \\ \textit{Maximum load segment (MLS)}} & \[l_{P_{max}}\] & - & - & Segment le plus achalandé d'une ligne, dans la direction la plus achalandée, pendant l'heure de pointe maximale. \\
+\hline
+\label{maximum_volume_stop}
+\makecell[r]{Arrêt à volume maximal \\ \textit{Maximum volume stop}} & \[s_{P_{max}}\] & - & - & Arrêt comportant le plus grand nombre d'embarquements et de débarquements pendant l'heure de pointe maximale (panneau ou plateforme unique). \\
+\hline
+\label{maximum_volume_stop_node}
+\makecell[r]{Noeud d'arrêt à volume maximal \\ \textit{Maximum volume stop node}} & \[q_{P_{max}}\] & - & - & Noeud d'arrêt comportant le plus grand nombre d'embarquements et de débarquements pendant l'heure de pointe maximale. \\
+\hline
+\label{maximum_volume_station}
+\makecell[r]{Station à volume maximal \\ \textit{Maximum volume station}} & \[S_{P_{max}}\] & - & - & Station comportant le plus grand nombre d'embarquements et de débarquements sur tous ses arrêts desservis pendant l'heure de pointe maximale. \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+  R{.25\NetTableWidth}%
+  C{.06\NetTableWidth}%
+  C{.07\NetTableWidth}%
+  C{.21\NetTableWidth}%
+  L{.41\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{ultra_peak_15_minutes_volume}
+\makecell[r]{Volume d'ultra-pointe sur 15 minutes \\ \textit{Ultra-peak 15 minutes volume}} & \[P_{up15}\] & \[pass/{{15}\ min}\] & - & Nombre total de passagers ayant voyagé sur le segment le plus achalandé d'une ligne, dans la direction la plus achalandée, pendant le 15 minute de pointe maximale. Permet d'obtenir la pointe de volume la plus précise possible. \\
+\hline
+\label{ultra_peak_volume}
+\makecell[r]{Volume d'ultra-pointe (horaire) \\ \textit{Ultra-peak volume (hourly)}} & \[P_{up}\] & \[pass/h\] & \[4 P_{up15}\] & Volume maximum sur 15 minutes extrapolé sur une heure. \\
+\hline
+\label{peak_hour_factor}
+\makecell[r]{Facteur d'heure de pointe \\ \textit{Peak-hour factor (PHF)}} & \[\gamma_{PHF}\] & - & \[\frac{P_{max}}{P_{up}} = \frac{1}{\gamma_{PHC}}\] & Facteur permettant de tenir compte du volume maximum sur 15 minutes. \(0.25 \leq \gamma_{PHF} \leq 1\). \\
+\hline
+\label{peak_hour_coefficient}
+\makecell[r]{Coefficient d'heure de pointe \\ \textit{Peak-hour coefficient (PHC)}} & \[\gamma_{PHC}\] & - & \[\frac{P_{up}}{P_{max}} = \frac{1}{\gamma_{PHF}}\] & Coefficient permettant de tenir compte du volume maximum sur 15 minutes. \(1 \leq \gamma_{PHC} \leq 4\). \\
+\hline
+\label{design_volume}
+\makecell[r]{Volume de conception \\ \textit{Design volume}} & \[P_d\] & \[pass/h\] & \[\gamma_{PHC} P_{max} = P_{up}\] & Volume utilisé pour déterminer les capacités requises sur la ligne ou le coefficient d'utilisation de la capacité offerte. \\
+\hline
+\label{daily_path_volume}
+\makecell[r]{Volume quotidien de parcours \\ \textit{Daily path volume}} & \[{{P_p}_{day}}\] & \[pass/jour\] & \[\sum_{i=0}^{23} {P_i}\] où \(P_i\) représente le volume de passagers entre l'heure \(i\) et l'heure \(i+1\) sur le parcours & Nombre de passagers par jour transportés sur le parcours, dans une direction. \\
+\hline
+\label{daily_line_volume}
+\makecell[r]{Volume quotidien de ligne \\ \textit{Daily line volume}} & \[{{P_L}_{day}}\] & \[pass/jour\] & \[\sum_{i=0}^{23} {P_i}\] où \(P_i\) représente le volume de passagers entre l'heure \(i\) et l'heure \(i+1\) & Nombre de passagers par jour transportés sur tous les voyages de la ligne. \\
+\hline
+\label{potential_demand}
+\makecell[r]{Demande potentielle \\ \textit{Potential demand}} & \[P_{pot}\] & \[pass/h\] & \[P_{lat} + P_{obs}\] & Volume de passagers qui existerait si le service et la tarification étaient optimaux. \\
+\hline
+\label{latent_demand}
+\makecell[r]{Demande latente \\ \textit{Latent demand}} & \[P_{lat}\] & \[pass/h\] & \[P_{pot} - P_{obs}\] & Demande non desservie ou non satisfaite. \\
+\hline
+\label{observed_volume}
+\makecell[r]{Volume observé \\ \textit{Observed volume}} & \[P_{obs}\] & \[pass/h\] & \[P_{pot} - P_{lat}\] & Volume de passagers observé dans le réseau ou la ligne. \\
+\hline
+\end{longtable}
+
+
+
+
+\pagebreak
+\subsection*{Capacités, travail et productivité • \textit{Capacities, work and productivity}}
+
+\begin{longtable}{%
+  R{.25\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.12\NetTableWidth}%
+  C{.15\NetTableWidth}%
+  L{.40\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{capacity}
+\makecell[r]{Capacité \\ \textit{Capacity}} & \[C\] & \[places/h\] & - & Capacité d'une ligne, dans une direction, par heure. \\
+\hline
+\label{unit_capacity}
+\makecell[r]{Capacité de l'unité \\ \textit{Unit capacity}} & \[c_u\] & \[places\] & - & Capacité d'une unité. \\
+\hline
+\label{seated_unit_capacity}
+\makecell[r]{Capacité de sièges de l'unité \\ \textit{Seated unit capacity}} & \[c_{u_{seat}}\] & \[places\] & - & Capacité de sièges d'une unité. \\
+\hline
+\label{standee_unit_capacity}
+\makecell[r]{Capacité debout de l'unité \\ \textit{Standee unit capacity}} & \[c_{u_{stand}}\] & \[places\] & - & Capacité de passagers debouts d'une unité. \\
+\hline
+\label{vehicle_capacity}
+\makecell[r]{Capacité du véhicule \\ \textit{Vehicle capacity}} & \[c_y\] & \[places\] & - & Capacité d'un véhicule. \\
+\hline
+\label{seated_vehicle_capacity}
+\makecell[r]{Capacité de sièges du véhicule \\ \textit{Seated vehicle capacity}} & \[c_{y_{seat}}\] & \[places\] & - & Capacité de sièges d'un véhicule. \\
+\hline
+\label{standee_vehicle_capacity}
+\makecell[r]{Capacité debout du véhicule \\ \textit{Standee vehcile capacity}} & \[c_{y_{stand}}\] & \[places\] & - & Capacité de passagers debouts d'un véhicule. \\
+\hline
+\label{line_capacity}
+\makecell[r]{Capacité de ligne \\ \textit{Line capacity}} & \[C_L\] & \[places/h\] & \[c_u f_{up} = \frac{60 c_u}{h_{up}} = \frac{P_d}{\alpha_c}\] & Capacité maximale offerte sur une ligne en pointe, dans une direction, en tenant compte du coefficient de confort. Cette capacité est \(\leq\) à la capacité théorique maximale qui ne tient pas compte du niveau de confort souhaité. \\
+\hline
+\label{comfort_coefficient}
+\makecell[r]{Coefficient de confort \\ \textit{Comfort coefficient/Load factor}} & \[\alpha_c\] & - & - & Coefficient permettant de déterminer le niveau de confort requis lors de la conception et du choix de la capacité offerte. Si on veut éviter les passagers debout: \(\alpha_c = c_{{u}_{seat}} / c_{u}\). Relativement confortable: \(\alpha_c = 0.7\) \\
+\hline
+\label{network_maximum_line_capacity}
+\makecell[r]{Capacité de ligne maximale de réseau \\ \textit{Network maximum line capacity}} & \[{C_L}_{max}\] & \[places/h\] & - & Capacité de la ligne qui offre la plus grande capacité dans le réseau, en pointe, dans une direction. \\
+\hline
+\label{programmed_capacity}
+\makecell[r]{Capacité programmée \\ \textit{Programmed capacity}} & \[C_p\] & \[places/h\] & - & Capacité de ligne pour une période donnée (pas nécessairement la pointe), dans une direction. \\
+\hline
+\label{line_capacity_coefficient}
+\makecell[r]{Coefficient de capacité de ligne \\ \textit{Line capacity coefficient}} & \[\delta_p\] & - & \[\frac{C_p}{C_L}\] & Ratio entre la capacité programmée pour la période donnée et la capacité de ligne en pointe. \\
+\hline
+\label{used_capacity_coefficient}
+\makecell[r]{Coefficient d'utilisation de la capacité \\ \textit{Used capacity coefficient}} & \[\alpha_u\] & - & \[\frac{\sum_{i=1}^{n_l} {P_{l_i}}}{{C_L}{n_l}}\] & Coefficient permettant d'évaluer le pourcentage d'utilisation de la capacité offerte sur une ligne, par heure. \\
+\hline
+\label{station_capacity}
+\makecell[r]{Capacité de station \\ \textit{Station capacity}} & \[C_S\] & \[places/h\] & - & Nombre de places pouvant s'arrêter à une station, par heure (toutes lignes et directions passant par la station). \\
+\hline
+\label{node_capacity}
+\makecell[r]{Capacité de noeud d'arrêt \\ \textit{Stop node capacity}} & \[C_q\] & \[places/h\] & - & Nombre de places pouvant s'arrêter à un noeud d'arrêt, par heure (toutes lignes et directions passant par le noeud). \\
+\hline
+\label{stop_capacity}
+\makecell[r]{Capacité d'arrêt \\ \textit{Stop capacity}} & \[C_s\] & \[places/h\] & - & Nombre de places pouvant s'arrêter à un arrêt (panneau ou un quai/plateforme), par heure (toutes lignes et directions passant par l'arrêt). \\
+\hline
+\label{offered_work}
+\makecell[r]{Travail offert \\ \textit{Offered work}} & \[w_o\] & \[places-km/h\] & \[C_L d_L\] & Travail offert sur la ligne dans une direction, pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{outbound_offered_work}
+\makecell[r]{Travail offert aller \\ \textit{Outbound offered work}} & \[{w_o}^{\prime}\] & \[places-km/h\] & \[C_L d^{\prime}\] & Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{inbound_offered_work}
+\makecell[r]{Travail offert retour \\ \textit{Inbound offered work}} & \[{w_o}^{\prime\prime}\] & \[places-km/h\] & \[C_L d^{\prime\prime}\] & Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{cycle_offered_work}
+\makecell[r]{Travail offert de cycle \\ \textit{Cycle offered work}} & \[{w_{o_c}}\] & \[places-km/h\] & \[{w_o}^{\prime} + {w_o}^{\prime\prime}\] & Travail total offert aller-retour (cycle complet), pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{used_work}
+\makecell[r]{Travail utilisé \\ \textit{Used work}} & \[w_u\] & \[pass-km/h\] & \[\sum_{i=1}^{n_l} {{P_l}_i {d_l}_i}\] & Travail comprenant le volume de passagers qui a utilisé les différents segments de la ligne, dans une direction. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{outbound_used_work}
+\makecell[r]{Travail utilisé aller \\ \textit{Outbound used work}} & \[{w_u}^{\prime}\] & \[pass-km/h\] & \[\sum_{i=1}^{n_l} {{P_l}_i {d_l}_i}\] où \(l_i\) sont les segments du parcours aller & Travail comprenant le volume de passagers qui a utilisé les différents segments de la ligne, en direction aller, pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{inbound_used_work}
+\makecell[r]{Travail utilisé retour \\ \textit{Inbound used work}} & \[{w_u}^{\prime\prime}\] & \[pass-km/h\] & \[\sum_{i=1}^{n_l} {{P_l}_i {d_l}_i}\] où \(l_i\) sont les segments du parcours retour & Travail comprenant le volume de passagers qui a utilisé les différents segments de la ligne, en direction retour, pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{cycle_used_work}
+\makecell[r]{Travail utilisé de cycle \\ \textit{Cycle used work}} & \[{w_{u_c}}\] & \[pass-km/h\] & \[{w_o}^{\prime} + {w_o}^{\prime\prime}\] & Travail total utilisé aller-retour (cycle complet), pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{line_daily_offered_work}
+\makecell[r]{Travail offert quotidien de ligne \\ \textit{Line daily offered work}} & \[W_o\] & \[places-km/jour\] & \[\sum_{i=1}^{N_o} {w_{o_i}}\] où \(w_{o_i}\) est le travail offert par un voyage aller-retour & Travail total offert sur une ligne pendant une journée complète de service. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{line_daily_used_work}
+\makecell[r]{Travail utilisé quotidien de ligne \\ \textit{Line daily used work}} & \[W_u\] & \[pass-km/jour\] & \[\sum_{i=0}^{23} {w_{u_i}}\] où \(w_{u_i}\) est le travail utilisé sur un voyage aller-retour & Travail total utilisé par des passagers sur une ligne pendant une journée complète de service. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{network_daily_offered_work}
+\makecell[r]{Travail offert quotidien de réseau \\ \textit{Daily network offered work}} & \[W_{o_{net}}\] & \[places-km/jour\] & \[\sum_{i=1}^{N_L} {W_{o_i}}\] & Travail offert par jour sur l'ensemble des lignes du réseau. \\
+\hline
+\label{network_daily_used_work}
+\makecell[r]{Travail utilisé quotidien dans le réseau \\ \textit{Daily network used work}} & \[W_{u_{net}}\] &\[pass-km/jour\] & \[\sum_{i=1}^{N_L} {W_{u_i}}\] & Travail utilisé par jour sur l'ensemble des lignes du réseau. \\
+\hline
+\label{productive_capacity}
+\makecell[r]{Capacité productive \\ \textit{Productive capacity}} & \[Q\] & \[places-km/h^2\] & \[C_L {V_o}_L\] & Mesure de performance la plus utile, puisqu'elle tient compte autant de la capacité d'une ligne que de la vitesse d'opération offerte. La capacité productive est par heure, par direction. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{unit_daily_productivity}
+\makecell[r]{Productivité d'unité quotidienne \\ \textit{Unit daily productivity}} & \[w_{u}\] & \[\textit{unité}-{km}\] & \[N_o (d^{\prime} + d^{\prime\prime})\] où \(N_o\) est le nombre de voyages aller-retour par jour & Nombre de km offerts par une unité par jour. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{total_unit_daily_productivity}
+\makecell[r]{Productivité d'unités quotidienne totale \\ \textit{Total unit daily productivity}} & \[W_{u}\] & \[\textit{unités}-{km}\] & \[\sum_{i=1}^{N_{u}} {w_{{u}_i}}\] & Nombre total d'unités-km offerts par jour. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{productive_volume}
+\makecell[r]{Volume productif \\ \textit{Productive volume}} & \[Q_u\] & \[pass-km/h^2\] & \[\overline{P_L} {V_o}_L\] & Tient compte du volume de passagers moyen sur la ligne. La capacité productive utilisée est par heure, par direction. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+  R{.35\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.05\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  L{.44\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{used_work_coefficient}
+\makecell[r]{Coefficient d'utilisation du travail \\ \textit{Used work coefficient}} & \[\alpha_w\] & - & \[\frac{w_{u_c}}{w_{o_c}}\] & Permet d'évaluer le pourcentage du travail offert, par heure, qui a été utilisé par des passagers. \\
+\hline
+\label{daily_line_used_work_coefficient}
+\makecell[r]{Coefficient d'utilisation du travail quotidien de ligne \\ \textit{Daily line used work coefficient}} & \[\alpha_W\] & - & \[\frac{W_u}{W_o}\] & Permet d'évaluer le pourcentage du travail offert quotidien qui a été utilisé par des passagers. \\
+\hline
+\label{daily_network_used_work_coefficient}
+\makecell[r]{Coefficient d'utilisation du travail quotidien de réseau \\ \textit{Daily network used work coefficient}} & \[\alpha_{W_{net}}\] & - & \[\frac{W_{u_{net}}}{W_{o_{net}}}\] & Permet d'évaluer le pourcentage du travail offert quotidien qui a été utilisé par des passagers sur l'ensemble du réseau. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Coûts • \textit{Costs}}
+
+\begin{longtable}{%
+  R{.23\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.04\NetTableWidth}%
+  C{.2\NetTableWidth}%
+  L{.45\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{operating_cost_per_unit_hour}
+\makecell[r]{Coût d'opération par unité-heure \\ \textit{Operating cost per unit-hour}} & \[c_{t_o}\] & \[\$/h\] & - & Coût d'opération d'une unité par heure de fonctionnement. Attention d'inclure les temps haut-le-pied et les battements. \\
+\hline
+\label{operating_cost_per_unit_km}
+\makecell[r]{Coût d'opération par unité-km \\ \textit{Operating cost per unit-km}} & \[c_{d_o}\] & \[\$/km\] & & Coût d'opération d'une unité par km. Attention d'inclure les distances des parcours haut-le-pied. \\
+\hline
+\label{total_operating_cost}
+\makecell[r]{Coût total d'opération \\ \textit{Total operating cost}} & \[C_o\] & \[\$\] & \[\sum_{i=1}^{N_{u}} {c_{t_o} t_i}\] ou \[\sum_{i=1}^{N_{u}} {c_{d_o} d_i}\] où \(N_u\) est le nombre d'unités en service pendant la période visée. & Coût d'opération total. Attention de bien indiquer la période de service pour le calcul de \(t\) et \(d\) (heure, jour, semaine, année, etc.). \\
+\hline
+\label{total_hourly_operating_cost}
+\makecell[r]{Coût d'opération horaire total \\ \textit{Total hourly operating cost}} & \[C_{t_o}\] & \[\$\] & \[\sum_{i=1}^{N_{u}} {c_{t_o}}\] où \(N_u\) est le nombre d'unités en service pendant la période visée. & Coût d'opération moyen par heure. Habituellement calculé en pointe, hors-pointe ou sur 24h. \\
+\hline
+\label{user_hourly_cost}
+\makecell[r]{Coût usager horaire \\ \textit{User hourly cost}} & \[c_{t_u}\] & \[\$/h\] & - & Coût horaire associé aux déplacements des usagers (valeur du temps). Peut varier selon la socio-démographie et les caractéristiques de l'usager. \\
+\hline
+\label{total_user_cost}
+\makecell[r]{Coût usager total \\ \textit{Total user cost}} & \[C_u\] & \[\$\] & \[\sum_{i=1}^{N_{OD}} {c_{t_u} T_{OD}}\] & Coût usager total représentant la somme des coûts de chaque déplacement complété. Attention de bien indiquer la période de service pour le calcul de \(t\) et \({\Delta s}\) (heure, jour, semaine, année, etc.). \\
+\hline
+\label{total_hourly_user_cost}
+\makecell[r]{Coût usager horaire total \\ \textit{Total hourly user cost}} & \[C_{t_u}\] & \[\$/h\] & \[\frac{\sum_{i=1}^{N_{OD}} {c_{t_u} T_{OD}}}{\Delta t}\] où \(\Delta t\) est la durée en heures de la période visée. & Coût usager horaire total représentant la somme des coûts de chaque déplacement complété, ramenée sur une heure. Habituellement calculé en pointe, hors-pointe ou sur 24h. \\
+\hline
+\label{total_cost}
+\makecell[r]{Coût total \\ \textit{Total cost}} & \[C\] & \[\$\] & \[C_o + C_u\] & Coût total incluant les coûts d'opération et la valeur du temps pour les usagers. \\
+\hline
+\label{total_hourly_cost}
+\makecell[r]{Coût horaire total \\ \textit{Total hourly cost}} & \[C_h\] & \[\$/h\] & \[C_{t_o} + C_{t_u}\] & Coût total horaire incluant les coûts d'opération et les coûts usager. \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+  R{.3\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.04\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  L{.5\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{minimum_transfer_penalty}
+\makecell[r]{Pénalité de transfert minimum \\ \textit{Minimum transfer penalty}} & \[c_t\] & \[\$\] & - & Pénalité (valeur du temps augmentée) pour chaque transfert effectué. Représente la pénibilité de transfert. \\
+\hline
+\label{transfer_access_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'accès de transfert \\ \textit{Transfer access time penalty factor}} & \[\mu_{tr}\] & - & - & Facteur par lequel on multiplie le temps d'accès de transfert. Varie en fonction de la perception de pénibilité associée aux temps d'accès entre arrêts de transfert. \\
+\hline
+\label{waiting_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'attente \\ \textit{Waiting time penalty factor}} & \[\mu_w\] & - & - & Facteur par lequel on multiplie le temps d'attente. Varie en fonction de la perception de pénibilité associée aux temps d'attente. \\
+\hline
+\label{access_egress_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'accès OD \\ \textit{Access/egress time penalty factor}} & \[\mu_{e_{OD}}\] & - & - & Facteur par lequel on multiplie le temps d'accès à l'origine et à destination. Varie en fonction de la perception de pénibilité associée aux temps d'accès à l'origine et à destination. \\
+\hline
+\label{total_access_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'accès total \\ \textit{Total access time penalty factor}} & \[\mu_e\] & - & - & Facteur par lequel on multiplie le temps d'accès total. Varie en fonction de la perception de pénibilité associée aux temps d'accès total (à l'origine, à destination et lors des transferts). \\
+\hline
+\label{in_vehicle_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps en véhicule \\ \textit{In-vehicle time penalty factor}} & \[\mu_{veh}\] & - & - & Facteur par lequel on multiplie le temps en véhicule. Varie en fonction de la perception de pénibilité associée aux temps en véhicule. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Agences, réseaux, services, horaires, déplacements et indicateurs globaux • \textit{Agencies, networks, services, schedules, user trips and global indicators}}
+
+\begin{longtable}{%
+  R{.28\NetTableWidth}%
+  C{.05\NetTableWidth}%
+  C{.15\NetTableWidth}%
+  C{.16\NetTableWidth}%
+  L{.37\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{agency}
+\makecell[r]{Agence \\ \textit{Agency}} & \[A^G\] & - & - & Agence possédant un réseau de transport collectif \\
+\hline
+\label{network}
+\makecell[r]{Réseau \\ \textit{Network}} & \[N^T\] & - & - & Réseau de transport collectif comprenant des lignes et des services/horaires pour une ou plusieurs agences \\
+\hline
+\label{service}
+\makecell[r]{Service \\ \textit{Service}} & \[H\] &  &  & Ensemble d'horaires associés pour une période ou un type de service donné (service de semaine, de fin de semaine, de nuit, service spécial, etc.). \\
+\hline
+\label{scenario}
+\makecell[r]{Scénario \\ \textit{Scenario}} & \[H_S\] &  &  & Ensemble de services utilisé pour des fins de design, de comparaison et de simulation. \\
+\hline
+\label{user_trip}
+\makecell[r]{Déplacement \\ \textit{User trip}} & \[OD\] & - & - & Déplacement de transport collectif effectué par un usager \\
+\hline
+\label{total_number_of_user_trips}
+\makecell[r]{Nombre total de déplacements \\ \textit{Total number of user trips}} & \[N_{OD}\] & dépl. & - & Nombre total de déplacements de transport collectif effectués par l'ensemble des usagers. Préciser s'il s'agit de l'ensemble du réseau, d'une ligne ou d'un parcours, et si la période est une heure, une journée, une semaine, un an, etc. \\
+\hline
+\label{direct_user_trips}
+\makecell[r]{Nombre total de déplacements directs \\ \textit{Total number of direct user trips}} & \[N_{{OD}_d}\] & dépl. & - & Nombre total de déplacements de transport collectif effectués par l'ensemble des usagers sans transfert. Préciser s'il s'agit de l'ensemble du réseau, d'une ligne ou d'un parcours, et si la période est une heure, une journée, une semaine, un an, etc. \\
+\hline
+\label{direct_user_trips_coefficient}
+\makecell[r]{Coefficient de directivité des déplacements \\ \textit{Direct user trips coefficient}} & \[\delta_{{OD}_d}\] & - & \[\frac{N_{{OD}_d}}{N_{OD}}\] & Pourcentage des déplacements qui sont faits directement, sans transfert. \\
+\hline
+\label{urban_population}
+\makecell[r]{Population urbaine \\ \textit{Urban population}} & \[P_{urb}\] & pers. & - & Population de la région urbaine dans laquelle le réseau offre son service. \\
+\hline
+\label{number_of_transfers}
+\makecell[r]{Nombre de transferts \\ \textit{Number of transfers}} & \[n_{tr}\] & transferts & - & Nombre de transferts effectués par l'usager lors d'un parcours de transport collectif. \\
+\hline
+\label{total_number_of_transfers}
+\makecell[r]{Nombre total de transferts \\ \textit{Total number of transfers}} & \[N_{tr}\] & transferts & \[\sum_{i=1}^{} {n_{tr}}_i\] & Nombre total de transferts effectués par l'ensemble des usagers. Préciser s'il s'agit de l'ensemble du réseau, d'une ligne ou d'un parcours, et si la période est une heure, une journée, une semaine, un an, etc. \\
+\hline
+\label{urban_area}
+\makecell[r]{Superficie urbaine \\ \textit{Urban area}} & \[A_{urb}\] & \[km^2\] & - & Superficie de la région urbaine dans laquelle le réseau offre son service. \\
+\hline
+\label{transit_usage_habit}
+\makecell[r]{Habitude d'utilisation du transport collectif \\ \textit{Transit usage habit}} & \[\overline{n_{OD}}\] & \[dep\] & - & Nombre moyen de déplacements transport collectif par personne par année, incluant les non-utilisateurs du transport collectif. Cet indicateur est très souvent utillisé dans les comparaisons entre villes, mais ne tient pas compte des particularités locales, du nombre de déplacements moyen total par personne (tous modes) et des chaînes de déplacement. \\
+\hline
+\label{transit_modal_share}
+\makecell[r]{Part modale du transport collectif \\ \textit{Transit modal share}} & \[m_{transit}\] & - &- & Pourcentage des déplacements de la région urbaine effectués en transport collectif (habituellement pour la période de pointe maximale ou une journée moyenne de semaine). \\
+\hline
+\label{number_of_unique_stop_nodes}
+\makecell[r]{Nombre de noeuds d'arrêts uniques \\ \textit{Number of unique stop nodes}} & \[N_{qu}\] & noeuds & - & Nombre total de noeuds d'arrêts desservis par une seule ligne. \\
+\hline
+\label{number_of_multiple_stop_nodes}
+\makecell[r]{Nombre de noeuds d'arrêts multiples \\ \textit{Number of multiple stop nodes}} & \[N_{qm}\] & noeuds & - & Nombre total de noeuds d'arrêts desservis par plus d'une ligne. \\
+\hline
+\label{total_number_of_nodes}
+\makecell[r]{Nombre total de noeuds d'arrêts \\ \textit{Total number of nodes}} & \[N_q\] & noeuds & \[N_{qu} + N_{qm}\] & Nombre total de noeuds d'arrêts dans le réseau. Ne compter qu'une seule fois les noeuds d'arrêts desservis par plusieurs lignes (noeuds d'arrêts multiples). \\
+\hline
+\label{number_of_lines}
+\makecell[r]{Nombre de lignes \\ \textit{Number of lines}} & \[N_L\] & lignes & - & - \\
+\hline
+\label{number_of_paths}
+\makecell[r]{Nombre de parcours \\ \textit{Number of paths}} & \[N_p\] & parcours & \[\sum_{i=1}^{N_L} {n_{p_i}}\] & Nombre total de parcours sur l'ensemble des lignes du réseau. \\
+\hline
+\label{number_of_unique_segments}
+\makecell[r]{Nombre de segments uniques \\ \textit{Number of unique segments}} & \[N_{lu}\] & segments & - & Nombre total de segments desservis par une seule ligne. \\
+\hline
+\label{number_of_multiple_segments}
+\makecell[r]{Nombre de segments multiples \\ \textit{Number of multiple segments}} & \[N_{lm}\] & segments & & Nombre total de segments desservis par plus d'une ligne. \\
+\hline
+\label{total_number_of_segments}
+\makecell[r]{Nombre total de segments \\ \textit{Total number of segments}} & \[N_l\] & segments & \[N_{lu} + N_{lm}\] & - \\
+\hline
+\label{network_linear_density}
+\makecell[r]{Densité linéaire de réseau \\ \textit{Network linear density}} & \[\rho_L\] & \[{km}\ \text{de ligne}/{km}^2\] & \[\frac{d_{net}}{A_{urb}}\] & Longueur de réseau par rapport à la superficie urbaine. \\
+\hline
+\label{network_coverage_coefficient}
+\makecell[r]{Coefficient de couverture du réseau \\ \textit{Network coverage coefficient}} & \[\mu_L\] & \[km/\text{pers.}\] & \[\frac{{\Delta s}_{net}}{P_u}\] & Nombre de kilomètres de réseau par personne dans la région urbaine. \\
+\hline
+\label{line_overlap_coefficient}
+\makecell[r]{Coefficient de superposition de ligne \\ \textit{Line overlap coefficient}} & \[\lambda\] & - & \[\frac{N_{lm}}{N_l}\] & Pourcentage des segments de lignes qui desservent plus d'une ligne. \\
+\hline
+\label{number_of_depots}
+\makecell[r]{Nombre de garages \\ \textit{Number of depots}} & \[N_G\] & garages & - & Nombre de garages et dépôts dans le réseau. Attention de bien spécifier le type de garage et les types d'unités (modes) qui y sont entreposés. \\
+\hline
+\label{network_average_inter_stop_distance}
+\makecell[r]{Distance inter-arrêt moyenne de réseau \\ \textit{Network average inter-stop distance}} & \[\overline{d_{l_{net}}}\] & \[m\] & \[\frac{d_{net}}{N_l}\] & - \\
+\hline
+\label{number_of_possible_user_paths}
+\makecell[r]{Nombre de parcours possibles \\ \textit{Number of possible user paths}} & \[N_{\Delta q}\] & parcours & \[\frac{1}{2} N_q (N_q-1)\] & Nombre total de paires de noeuds d'arrêts uniques dans le réseau. \\
+\hline
+\label{number_of_possible_direct_user_paths}
+\makecell[r]{Nombre de parcours directs possibles \\ \textit{Number of possible direct user paths}} & \[N_{{\Delta q}_d}\] & parcours & \[\frac{1}{2} \Bigg( \sum_{i=1}^{N_L} {n_{q_i}(n_{q_i} - 1)}\] \[-\sum_{j=1}^{N_{Lm}-1} {n_{q_{m_j}}(n_{q_{m_j}} - 1)} \Bigg)\] & Nombre total de paires de noeuds d'arrêts uniques dans le réseau pouvant être desservies sans transfert (directs). \(N_{L_{m}}\) est le nombre de lignes qui possèdent au moins un segment commun avec une autre ligne et \(n_{q_{m_j}}\) est le nombre de stations sur chaque segment que chaque ligne \(j\) partage avec une ligne déjà comptée. \\
+\hline
+\label{number_of_possible_user_paths_with_transfers}
+\makecell[r]{Nombre de parcours avec transferts possibles \\ \textit{Number of possible user paths with transfers}} & \[N_{{\Delta q}_{tr}}\] & parcours & \[N_{\Delta q} - N_{{\Delta q}_d}\] & Nombre total de paires de noeuds d'arrêts uniques dans le réseau ne pouvant être desservies qu'avec au moins un transfert. \\
+\hline
+\label{direct_user_paths_coefficient}
+\makecell[r]{Coefficient de directivité des parcours \\ \textit{Direct user paths coefficient}} & \[\delta_{{\Delta q}_d}\] & - & \[\frac{N_{{\Delta q}_d}}{N_{\Delta q}}\] & Pourcentage des parcours possibles qui peuvent se faire directement, sans transfert. \\
+\hline
+\label{network_complexity_coefficient}
+\makecell[r]{Coefficient de complexité de réseau \\ \textit{Network complexity coefficient}} & \[\beta\] & segments/arrêt & \[\frac{N_l}{N_q}\] & Ratio du nombre de segments sur le nombre de noeuds d'arrêt. Ne pas compter deux fois les segments bidirectionnels. Prend en compte autant le nombre d'arrêts par ligne que le nombre de segments multiples. \\
+\hline
+\label{accessible_area}
+\makecell[r]{Superficie accessible \\ \textit{Accessible area}} & \[A_a\] & \[km^2\] & - & Superficie desservie par le réseau de transport collectif. Obtenu au moyen de cartes d'accessibilité qui utilisent un calculateur de transport collectif. Attention de préciser les distances ou temps d'accès maximum, les temps d'attente minimum avant l'embarquement, ainsi que la période étudiée (heure de départ ou d'arrivée). Peut se calculer autour d'un point de départ ou d'arrivée avec une heure de départ ou d'arrivée ou de manière globale si aucune limite de temps n'est fournie. \\
+\hline
+\label{network_accessibility_coefficient}
+\makecell[r]{Coefficient d'accessibilité du réseau \\ \textit{Network accessibility coefficient}} & \[\mu_a\] & - & \[\frac{A_a}{A_{urb}}\] & Pourcentage de la superficie urbaine accessible en transport collectif. \\
+\hline
+\label{stop_nodes_accessibility_radius}
+\makecell[r]{Rayon d'accès aux noeuds d'arrêts \\ \textit{Stop nodes accessibility radius}} & \[r_q\] & \[m\] & - & Cette valeur est un paramètre d'analyse des réseaux. \(r_x\) se situe habituellement entre 300 et 500m pour un arrêt de bus et entre 500 et 1000m pour une station de métro, SLR, SRB, train régional ou autre mode à grande fiabilité et à haute fréquence de service. Pour davantage de précision, un intervalle de temps d'accès en minutes est privilégiée, mais nécessite un calculeur de chemin pour obtenir les temps d'accès vers l'arrêt. \\
+\hline
+\label{stop_nodes_accessible_area}
+\makecell[r]{Superficie accessible aux noeuds d'arrêts \\ \textit{Stop nodes accessible area}} & \[A_q\] & \[m^2/station\] & \[\pi r_q^2\] & Superficie desservie par le réseau de transport collectif. Obtenu au moyen de cartes d'accessibilité qui utilisent un calculateur de chemin transport collectif. Attention de préciser les distances ou temps d'accès maximum, les temps d'attente minimum avant l'embarquement, ainsi que la période étudiée (heure de départ ou d'arrivée). Peut se calculer autour d'un point de départ ou d'arrivée avec une heure de départ ou d'arrivée ou de manière globale si aucune limite de temps n'est fournie. \\
+\hline
+\label{network_coverage_coefficient}
+\makecell[r]{Coefficient de couverture du réseau \\ \textit{Network coverage coefficient}} & \[\mu_c\] & - & \[\frac{N_q A_q}{A_u}\] si rayon d'accès unique & Pourcentage de la superficie urbaine qui comprend un noeud d'arrêt de transport collectif à l'intérieur du rayon d'accès choisi. Bien indiquer le rayon choisi, qui peut varier en fonction du type d'arrêt et du niveau de service offert à chaque arrêt. Attention aux conversions d'unités (\(km^2 \leftrightarrow m^2\)). \\
+\hline
+\label{number_of_employees}
+\makecell[r]{Nombre d'employés \\ \textit{Number of employees}} & \[N_e\] & employés & - & Nombre total d'employés dans le réseau. \\
+\hline
+\label{labor_productivity}
+\makecell[r]{Productivité de main d'oeuvre \\ \textit{Labor productivity}} & \[\eta_{We}\] & \[\text{unités}-km/\text{employé}\] & \[\frac{W_{u}}{N_e}\] & Nombre d'unités-km de service offerts par employé par jour. \\
+\hline
+\label{labor_efficiency}
+\makecell[r]{Efficacité de main d'oeuvre \\ \textit{Labor efficiency}} & \[\eta_{Ce}\] & \[\text{places}-km/\text{employé}\] & \[\frac{W_{o_{net}}} {N_e}\] & Travail offert par employé par jour. \\
+\hline
+\label{passenger_volume_efficiency}
+\makecell[r]{Efficacité de volume de passagers \\ \textit{Passenger volume efficiency}} & \[\eta_P\] & \[pass/\text{unités}-km\] & \[\frac{\sum_{i=1}^{N_L} { \overline{P_{L_{{tot}_i}}}}} {W_{u}}\] & Volume de passagers transportés sur l'ensemble des lignes par jour par unités-km. \\
+\hline
+\label{energy_consumption}
+\makecell[r]{Consommation énergétique \\ \textit{Energy consumption}} & \[E\] & \[kWh\] & - & Consommation énergétique totale. Spécifier la période (par jour, par semaine, par année, etc.) \\
+\hline
+\label{energy_efficiency}
+\makecell[r]{Efficacité énergétique \\ \textit{Energy efficency}} & \[\eta_E\] & \[kWh/\text{unités}-km\] & \[\frac{E}{W_{u}}\] & Consommation énergétique par unités-km. Spécifier la période (par jour, par semaine, par année). \\
+\hline
+\label{reliability}
+\makecell[r]{Fiabilité \\ \textit{Reliability}} & \[R\] & \[\%\] & - & Pourcentage des passages à l'heure aux arrêts par rapport aux horaires planifiés. Idéalement: entre 0 et 3 minutes de retard. En pratique habituellement: entre 1 minutes d'avance et 5 minutes de retard. \\
+\hline
+\label{trips_completion_rate}
+\makecell[r]{Taux de voyages complétés \\ \textit{Trips completion rate}} & \[R_o\] & \[\%\] & - & Pourcentage des voyages effectués par rapport aux voyages planifiés. \\
+\hline
+\end{longtable}
+
+\end{document}

--- a/packages/transition-backend/file/definitions/definitions-fr.tex
+++ b/packages/transition-backend/file/definitions/definitions-fr.tex
@@ -1,0 +1,1397 @@
+\documentclass{article}
+\usepackage[colorlinks = true,
+            linkcolor = blue,
+            urlcolor  = blue,
+            citecolor = blue,
+            anchorcolor = blue]{hyperref}
+
+\usepackage{longtable}
+\usepackage{tabulary}
+\usepackage{multirow}
+\usepackage{amsmath}
+\usepackage[none]{hyphenat}
+\usepackage[utf8]{inputenc}
+\usepackage{array}
+\usepackage{mathtools}
+\usepackage{amsmath}
+\usepackage{tabularx}
+\usepackage{makecell}
+\usepackage[legalpaper, landscape, top=0.5in, left=0.5in, right=0.7in, bottom=0.2in, includefoot]{geometry}
+
+\begin{document}
+
+\newcolumntype{C}[1]{>{\centering\arraybackslash}m{#1}}   %% centered
+\newcolumntype{R}[1]{>{\raggedleft\arraybackslash}m{#1}}  %% right aligned
+\newcolumntype{L}[1]{>{\raggedright\arraybackslash}m{#1}}  %% left aligned
+\setlength\LTleft{0pt}
+\setlength\LTright{0pt}
+\setlength\LTcapwidth{\textwidth}
+\setlength{\abovedisplayskip}{0.1pt}
+\setlength{\belowdisplayskip}{0.1pt}
+\renewcommand{\arraystretch}{1.2}
+\newdimen\NetTableWidth
+
+\title{Transport collectif • Définitions et symboles}
+
+\author{Pierre-Léo Bourbonnais et étudiants du cours CIV6708}
+
+\section*{Transport collectif • Définitions et symboles}
+
+\subsection*{Arrêts, noeuds d'arrêt, stations et segments}
+
+\noindent
+  \NetTableWidth=\dimexpr
+    \linewidth
+    - 8\tabcolsep
+    - 5\arrayrulewidth % if package array is loaded
+  \relax
+
+  \begin{longtable}{%
+    R{.15\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    L{.65\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{node}
+\makecell[r]{Noeud d'arrêt \\ \textit{Stop node}} & \[q\] & - & - & Regroupement de panneaux et/ou de quais d'embarquement et de débarquement situés à proximité et étant considérés comme un lieu de transfert direct lorsque plusieurs lignes s'y rencontrent. Par exemple, lorsque plusieurs panneaux d'arrêts sont situés chaque coin d'une intersection, ils représentent un seul noeud d'arrêt. \\
+\hline
+\label{stop}
+\makecell[r]{Arrêt \\ \textit{Stop}} & \[s\] & - & - & Position précise du centroïde de quai ou du panneau d'arrêt permettant l'embarquement et/ou le débarquement des passagers d'une unité en service sur une ligne. Fait partie d'un noeud d'arrêt. \\
+\hline
+\label{station}
+\makecell[r]{Station \\ \textit{Station}} & \[S\] & - & - & Bâtiment facilitant le transfert entre plusieurs arrêts. Lorsque plusieurs modes distincts se trouvent à proximité ou à l'intérieur de la station, on l'appelle alors station intermodale. \\
+\hline
+\label{segment}
+\makecell[r]{Segment \\ \textit{Segment}} & \[l\] & - & - & Segment de ligne entre deux arrêts consécutifs, représenté par un parcours précis sur le réseau routier ou ferré (rails). \\
+\hline
+\label{unique_stop_node}
+\makecell[r]{Noeud d'arrêt unique \\ \textit{Unique stop node}} & \[q_u\] & - & - & Noeud d'arrêt desservi par une seule ligne (à sens unique ou bidirectionnelle). \\
+\hline
+\label{multiple_stop_node}
+\makecell[r]{Noeud d'arrêt multiple \\ \textit{Multiple stop node}} & \[q_m\] & - & - & Noeud d'arrêt desservi par plus d'une ligne. \\
+\hline
+\label{unique_stop}
+\makecell[r]{Arrêt unique \\ \textit{Unique stop}} & \[s_u\] & - & - & Panneau d'arrêt ou quai desservi par une seule ligne (à sens unique ou bidirectionnelle). \\
+\hline
+\label{multiple_stop}
+\makecell[r]{Arrêt multiple \\ \textit{Multiple stop}} & \[s_m\] & - & - & Panneau d'arrêt ou quai desservi par plus d'une ligne. \\
+\hline
+\label{unique_segment}
+\makecell[r]{Segment unique \\ \textit{Unique segment}} & \[l_u\] & - & - & Segment par lequel passe une seule ligne (à sens unique ou bidirectionnelle). \\
+\hline
+\label{multiple_segment}
+\makecell[r]{Segment multiple \\ \textit{Multiple segment}} & \[l_m\] & - & - & Segment par lequel passe plus d'une ligne. \\
+\hline
+\label{terminal}
+\makecell[r]{Terminus \\ \textit{Terminal}} & \[s_T\] ou \[q_T\]  & - & - & Premier ou dernier noeud d'arrêt ou arrêt d'une ligne. Permet habituellement à au moins une unité de se stationner pour le temps de battement. \\
+\hline
+\label{outbound_terminal}
+\makecell[r]{Terminus de départ \\ \textit{Departure terminal}} & \[{s^{\prime}_T}\] ou \[q^{\prime}_T\] & - & - & Premier noeud d'arrêt ou premier arrêt d'un parcours ou d'une ligne. \\
+\hline
+\label{inbound_terminal}
+\makecell[r]{Terminus d'arrivée  \\ \textit{Arrival terminal}} & \[{s^{\prime\prime}_T}\] ou \[{q^{\prime\prime}_T}\] & - & - & Dernier noeud d'arrêt ou dernier arrêt d'un parcours ou d'une ligne. \\
+\hline
+\label{stop_time}
+\makecell[r]{Passage-arrêt \\ \textit{Stop-time}} & \[s_t\] ou \[q_t\] & - & - & Passage d'une unité en service sur une ligne à un arrêt ou un noeud d'arrêt particulier, dans une direction donnée et à une heure précise (horaire). Comprend une heure d'arrivée à laquelle l'unité arrive à l'arrêt et une heure de départ à laquelle l'unité quitte l'arrêt. \\
+\hline
+\label{stop_sequence}
+\makecell[r]{Arrêt-séquence \\ \textit{Stop-sequence}} & \[s_{seq}\] ou \[q_{seq}\] & - & - & Combinaison d'un noeud d'arrêt ou d'arrêt et d'un numéro de séquence sur un parcours d'une ligne. Un parcours comprend un arrêt-séquence pour chaque arrêt desservi. Un parcours aller de 4 arrêts (A, B, C et D) aura 4 arrêts-séquence: arrêt A séquence 1, arrêt B séquence 2, arrêt C séquence 3 et arrêt D séquence 4. Le parcours retour aura les arrêts-séquence inversés suivants: arrêt D séquence 1, arrêt C séquence 2, arrêt B séquence 3 et arrêt A séquence 4.\\
+\hline
+\label{connection}
+\makecell[r]{Connexion \\ \textit{Connection}} & \[c\] & - & - & Déplacement d'une unité en service sur une ligne sur un segment particulier (entre deux noeuds d'arrêt) et selon un horaire précis. Comprend une heure de départ à laquelle l'unité quitte l'arrêt de départ (arrêt précédent) et une heure d'arrivée à laquelle l'unité arrive à l'arrêt d'arrivée (arrêt suivant). \\
+\hline
+\end{longtable} 
+
+
+
+
+\pagebreak
+\subsection*{Véhicules, unités et garages • \textit{Vehicles, units and depots}}
+
+\begin{longtable}{%
+    R{.25\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.1\NetTableWidth}%
+    L{.5\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{transit_unit}
+\makecell[r]{Unité de transport collectif \\ \textit{Transit unit (Unit)}} & \[u\] & - & - & Ensemble de voitures, de wagons ou de remorques couplés constituant un train. Un bus régulier ou articulé représente une seule unité. \\
+\hline
+\label{vehicle}
+\makecell[r]{Véhicule (wagon/voiture) \\ \textit{Vehicle (trailer/car)}} & \[y\] & - & - & Voiture, wagon ou remorque faisant partie d'une unité. \\
+\hline
+\label{depot}
+\makecell[r]{Garage/dépôt \\ \textit{Depot}} & \[G\] & - & - & Garage pour bus ou dépôt ferroviaire où sont entreposés les unités et véhicules et où on effectue leur maintenance. Habituellement, le garage constitue également le lieu de départ et d'arrivée des véhicules et chauffeurs assignés aux services en début et en fin de tournée. \\
+\hline
+\label{depot_unit_capacity}
+\makecell[r]{Capacité d'unités du garage \\ \textit{Depot units capacity}} & \[{N_u}_G\] & unités & - & Nombre d'unités pouvant être stationnées simultanément dans le garage ou le dépôt. Attention de bien spécifier si cette capacité comprend les emplacements réservés aux véhicules en maintenance. \\
+\hline
+\label{fleet_size}
+\makecell[r]{Taille de la flotte \\ \textit{Fleet size} } & \[F\] & unités & - & Flotte totale (nombre d'unités) incluant les unités en service, en réserve et en maintenance. \\
+\hline
+\label{reserve_fleet_size}
+\makecell[r]{Taille de la flotte en réserve \\ \textit{Reserve fleet size}} & \[F_r\] & unités & - & Nombre d'unités réservées pour remplacer les unités devant être retirées de la circulation (incidents) et ajouter du service lors d'événements spéciaux ou de congestion sévère ralentissant le service planifié. \\
+\hline
+\label{maintenance_fleet_size}
+\makecell[r]{Taille de la flotte en maintenance \\ \textit{Maintenance fleet size}} & \[F_m\] & unités & - & Nombre d'unités en réparation ou en maintenance préventive. Ces unités ne peuvent être utilisées pour effectuer du service. \\
+\hline
+\label{service_fleet_size}
+\makecell[r]{Taille de la flotte en service \\ \textit{Service fleet size}} & \[F_s\] & unités & \[F - F_m - F_r\] & Nombre d'unités pouvant être utilisées pour effectuer le service planifié pendant la période de pointe maximale. \\
+\hline
+\label{fleet_use_ratio}
+\makecell[r]{Ratio d'utilisation de la flotte \\ \textit{Fleet use ratio}} & \[\mu_{F_u}\] & - & \[\frac{F_s + F_r}{F}\] & - \\
+\hline
+\label{reserve_fleet_ratio}
+\makecell[r]{Ratio de la flotte en réserve \\ \textit{Reserve fleet ratio}} & \[\mu_{F_r}\] & - & \[\frac{F_r}{F}\] & - \\
+\hline
+\label{maintenance_fleet_ratio}
+\makecell[r]{Ratio de la flotte en maintenance \\ \textit{Maintenance fleet ratio}} & \[\mu_{F_m}\] & - & \[\frac{F_m}{F}\] & - \\
+\hline
+\label{service_fleet_ratio}
+\makecell[r]{Ratio de la flotte en service \\ \textit{Service fleet ratio}} & \[\mu_{F_s}\] & - & \[\frac{F_s}{F}\] & - \\
+\hline
+\label{vehicles_per_unit}
+\makecell[r]{Nombre de véhicules par unité \\ \textit{Number of vehicles per unit}} & \[n_y\] & véhicules & - & Nombre de voitures, de wagons ou de remorques couplés constituant l'unité. \\
+\hline
+\label{required_units}
+\makecell[r]{Nombre d'unités requises \\ \textit{Required number of units}} & \[n_u\] & unités & - & Nombre d'unités requises pour effectuer un service pour une période données (habituellement sur une ligne en particulier). \\
+\hline
+\label{maximum_acceleration}
+\makecell[r]{Accélération maximale \\ \textit{Maximum acceleration}} & \[a_{max}\] & \[m/s^2\] & - & Accélération maximale d'une unité. \\
+\hline
+\label{programmed_acceleration}
+\makecell[r]{Accélération programmée \\ \textit{Programmed acceleration}} & \[a\] & \[m/s^2\] & - & Accélération utilisée en service. Cette accélération doit être le meilleur équilibre entre le confort des passagers, l'efficacité énergétique et l'optimisation du service. \\
+\hline
+\label{maximum_deceleration}
+\makecell[r]{Décélération maximale \\ \textit{Maximum deceleration}} & \[b_{max}\] & \[m/s^2\] & - & Décélération maximale d'une unité lors d'un freinage d'urgence. Utiliser en valeur absolue (positive). \\
+\hline
+\label{programmed_deceleration}
+\makecell[r]{Décélération programmée \\ \textit{Programmed deceleration}} & \[b\] & \[m/s^2\] & - & Décélération utilisée en service. Cette décélération/freinage doit être le meilleur équilibre entre le confort des passagers et l'optimisation du service. Utiliser en valeur absolue (positive). \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+    R{.31\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.11\NetTableWidth}%
+    C{.2\NetTableWidth}%
+    L{.3\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{floor_area_per_standee}
+\makecell[r]{Superficie au sol par place debout \\ \textit{Floor area per standee}} & \[e\] & \[m^2\] & - & Superficie prévue pour chaque place debout (empreinte au sol). Confortable, circulation convenable: \(0.25 m^2\); Inconfortable, circulation difficile: \(0.15 m^2\) \\
+\hline
+\label{vehicle_capacity}
+\makecell[r]{Capacité de véhicule \\ \textit{Vehicle capacity}} & \[C_y\] & places & \[C_{y_{se}} + C_{y_{st}}\] & Nombre de places assises et debout dans le véhicule. \\
+\hline
+\label{unit_capacity}
+\makecell[r]{Capacité d'unité \\ \textit{Unit capacity}} & \[C_{u}\] & places & \[C_{{u}_{se}} + C_{{u}_{st}}\] & Nombre de places assises et debout dans l'unité. \\
+\hline
+\label{vehicle_seated_capacity}
+\makecell[r]{Capacité de sièges par véhicule \\ \textit{Vehicle seated capacity}} & \[C_{y_{se}}\] & places & - & - \\
+\hline
+\label{vehicle_standees_capacity}
+\makecell[r]{Capacité de passagers debout par véhicule \\ \textit{Vehicle standees capacity}} & \[C_{y_{st}}\] & places & - & Attention de bien préciser l'espace disponible par place debout \(e\) entre \(0.15m^2\) (inconfortable) et \(0.25m^2\) (confortable). \\
+\hline
+\label{unit_seated_capacity}
+\makecell[r]{Capacité de sièges par unité \\ \textit{Unit seated capacity}} & \[C_{u_{se}}\] & places & \[n_y C_{{y}_{se}}\] si toutes les voitures de l'unité ont la même capacité de sièges. & - \\
+\hline
+\label{unit_standees_capacity}
+\makecell[r]{Capacité de passagers debout par unité \\ \textit{Unit standees capacity}} & \[C_{u_{st}}\] & places & \[n_y C_{{y}_{st}}\] si toutes les voitures de l'unité ont la même capacité de places debout. & - \\
+\hline
+\label{vehicle_boarding_door_channels}
+\makecell[r]{Nombre de voies d'embarquement par véhicule \\ \textit{Number of boarding door channels per vehicle}} & \[{n_{Bch}}_y\] & voies d'embarquement & - & Nombre de voies permettant l'embarquement d'une personne à la fois dans le véhicule. \\
+\hline
+\label{vehicle_alighting_door_channels}
+\makecell[r]{Nombre de voies de débarquement par véhicule \\ \textit{Number of alighting door channels per vehicle}} & \[{n_{Ach}}_y\] & voies de débarquement & - & Nombre de voies permettant le débarquement d'une personne à la fois dans le véhicule. \\
+\hline
+\label{vehicle_mixed_door_channels}
+\makecell[r]{Nombre de voies d'accès mixtes par véhicule \\ \textit{Number of mixed door channels per vehicle}} & \[{n_{ABch}}_{y}\] & voies mixtes & - & Nombre de voies permettant l'embarquement ou le débarquement d'une personne à la fois dans le véhicule. \\
+\hline
+\label{vehicle_door_channels}
+\makecell[r]{Nombre total de voies d'accès par véhicule \\ \textit{Number of door channels per vehicle}} & \[{n_{ch}}_y\] & voies d'accès & \[{n_{Ach}}_{y} + {n_{Bch}}_{y} + {n_{ABch}}_{y}\] & Nombre de voies d'accès permettant l'embarquement, le débarquement ou les deux dans le véhicule. \\
+\hline
+\label{unit_boarding_door_channels}
+\makecell[r]{Nombre de voies d'embarquement par unité \\ \textit{Number of boarding door channels per unit}} & \[{n_{Bch}}_{u}\] & voies d'embarquement & - & Nombre de voies permettant l'embarquement d'une personne à la fois dans l'ensemble des véhicules de l'unité. \\
+\hline
+\label{unit_alighting_door_channels}
+\makecell[r]{Nombre de voies de débarquement par unité \\ \textit{Number of alighting door channels per unit}} & \[{n_{Ach}}_{u}\] & voies de débarquement & - & Nombre de voies permettant le débarquement d'une personne à la fois dans l'ensemble des véhicules de l'unité. \\
+\hline
+\label{unit_mixed_door_channels}
+\makecell[r]{Nombre de voies d'accès mixtes par unité \\ \textit{Number of mixed door channels per unit}} & \[{n_{ABch}}_{u}\] & voies mixtes & - & Nombre de voies permettant l'embarquement ou le débarquement d'une personne à la fois dans l'ensemble des véhicules de l'unité. \\
+\hline
+\label{unit_door_channels}
+\makecell[r]{Nombre total de voies d'accès par unité \\ \textit{Number of door channels per unit}} & \[{n_{ch}}_{u}\] & voies d'accès & \[{n_{Ach}}_{u} + {n_{Bch}}_{u} + {n_{ABch}}_{u}\] & Nombre de voies d'accès permettant l'embarquement, le débarquement ou les deux dans l'ensemble des véhicules de l'unité. \\
+\hline
+\end{longtable}
+
+
+\pagebreak
+\subsection*{Lignes et parcours • \textit{Lines and paths}}
+
+\begin{longtable}{%
+    R{.18\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    L{.56\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{line}
+\makecell[r]{Ligne \\ \textit{Line}} & \[L\] & - & - & Ligne de transport collectif comprenant un ou plusieurs parcours distincts mais désignée de manière unique et possédant un identifiant (numéro ou lettre) et un nom (le nom peut changer en fonction de la direction desservie). Une ligne peut être bidirectionnelle, en boucle bidirectionnelle ou en boucle à sens unique, avec possiblement des parcours réduits (ligne courte) ou allongés pour certaines périodes de la journée ou pour desservir des clientèles particulières. \\
+\hline
+\label{path}
+\makecell[r]{Parcours \\ \textit{Path}} & \[p\] & - & - & Parcours unique dans une direction déterminée sur une ligne. Un parcours est défini pour chaque séquence d'arrêts distincte desservie par la ligne. Un parcours comprend un ensemble d'arrêts-séquences et un parcours géographique sur le réseau (routier, ferroviaire ou autre). \\
+\hline
+\label{path_outbound}
+\makecell[r]{Parcours aller \\ \textit{Outbound path}} & \[p_{out}\] ou \[{p^{\prime}}\] & - & - & Parcours effectué dans la première direction (aller) pour une ligne bidirectionnelle ou la seule direction pour une ligne en boucle à sens unique. Le choix de la direction aller est arbitraire. Habituellement, le parcours aller est la direction empruntée lors du premier départ de la première tournée de la journeé sur la ligne. \\
+\hline
+\label{path_inbound}
+\makecell[r]{Parcours retour \\ \textit{Inbound path}} & \[p_{in}\] ou \[{p^{\prime\prime}}\] & - & - & Parcours effectué en sens contraire (retour) pour une ligne bidirectionnelle ou la deuxième direction spécifiée sur la ligne lorsque le parcours de retour n'est pas l'inverse exact du parcours aller. \\
+\hline
+\label{trip}
+\makecell[r]{Voyage \\ \textit{Trip}} & \[o\] & - & - & Un voyage est le déplacement en service d'une unité sur un parcours d'une ligne selon un horaire. \\
+\hline
+\label{schedule}
+\makecell[r]{Horaire \\ \textit{Schedule}} & \[O\] & - & - & Un horaire est un ensemble de voyages effectués pour un même service (calendrier) pour une ligne donnée. \\
+\hline
+\label{run}
+\makecell[r]{Tournée \\ \textit{Run}} & \[r\] & - & - & Une tournée est un ensemble de voyages desservis par une même unité ou un même chauffeur. Une tournée peut desservir plusieurs parcours et plusieurs lignes (interlignage). Habituellement, une tournée débute et se termine à un garage. \\
+\hline
+\label{block}
+\makecell[r]{Bloc \\ \textit{Block}} & \[r_b\] & - & - & Un bloc est un ensemble de voyages consécutifs desservis par une même unité et à l'intérieur duquel les passagers peuvent demeurer dans le véhicule pour un transfert instantané et/ou garanti. \\
+\hline
+\label{spatial_directivity}
+\makecell[r]{Directivité spatiale \\ \textit{Spatial directivity}} & \[\delta\] & - & \[\frac{d_e}{d_o}\] & Ratio représentant le caractère direct d'un parcours par rapport au parcours direct à vol d'oiseau (distance euclidienne). Inverse de la tortuosité (aussi appelée directitude). \\
+\hline
+\label{spatial_tortuosity}
+\makecell[r]{Tortuosité spatiale \\ \textit{Tortuosity}} & \[\tau\] & - & \[\frac{d_o}{d_e}\] & Ratio représentant le caractère tortueux du parcours par rapport au parcours direct à vol d'oiseau (distance euclidienne). Inverse de la directivité. \\
+\hline
+\label{spatial_network_directivity}
+\makecell[r]{Directivité spatiale réseau \\ \textit{Spatial network directivity}} & \[\delta_n\] & - & \[\frac{d_n}{d_o}\] & Ratio représentant le caractère direct d'un parcours par rapport au parcours le plus court en distance sur le réseau entre les deux terminus (habituellement le parcours le plus court en voiture). Inverse de la tortuosité réseau. \\
+\hline
+\label{spatial_network_tortuosity}
+\makecell[r]{Tortuosité spatiale réseau \\ \textit{Spatial network tortuosity}} & \[\tau_n\] & - & \[\frac{d_o}{d_n}\] & Ratio représentant le caractère tortueux du parcours par rapport au parcours le plus court en distance sur le réseau entre les deux terminus (habituellement le parcours le plus court en voiture). Inverse de la directivité réseau. \\
+\hline
+\label{temporal_directivity}
+\makecell[r]{Directivité temporelle \\ \textit{Temporal Directivity}} & \[\delta_t\] & - & \[\frac{t_n}{t_o}\] & Ratio représentant le caractère direct d'un parcours par rapport au parcours le plus rapide en temps sur le réseau entre les deux terminus (habituellement le parcours le plus rapide en voiture). Inverse de la tortuosité temporelle. \\
+\hline
+\label{temporal_tortuosity}
+\makecell[r]{Tortuosité temporelle \\ \textit{Temporal tortuosity}} & \[\tau_t\] & - & \[\frac{t_o}{t_n}\] & Ratio représentant le caractère tortueux du parcours par rapport au parcours le plus rapide en temps sur le réseau entre les deux terminus (habituellement le parcours le plus direct en voiture). Inverse de la directivité temporelle. \\
+\hline
+\end{longtable} 
+
+\begin{longtable}{%
+    R{.29\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.12\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    L{.43\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{number_of_paths_on_line}
+\makecell[r]{Nombre de parcours sur la ligne \\ \textit{Number of path on line}} & \[n_p\] & parcours & - & Nombre de parcours desservis sur une ligne. \\
+\hline
+\label{number_of_segments_on_path}
+\makecell[r]{Nombre de segments sur le parcours \\ \textit{Number of segments on path}} & \[n_l\] & segments & - & Nombre total de segments desservis par le parcours. \\
+\hline
+\label{number_of_segments_on_path_outbound}
+\makecell[r]{Nombre de segments aller \\ \textit{Number of outbound segments}} & \[{n_l}^{\prime}\] & segments & - & Nombre total de segments desservis par le parcours. \\
+\hline
+\label{number_of_segments_on_path_inbound}
+\makecell[r]{Nombre de segments retour \\ \textit{Number of inbound segments}} & \[{n_l}^{\prime\prime}\] & segments & - & Nombre total de segments desservis par le parcours. \\
+\hline
+\label{number_of_stops_on_path}
+\makecell[r]{Nombre d'arrêts sur le parcours \\ \textit{Number of stops on path}} & \[n_q\] ou \[n_s\] & noeuds d'arrêts ou arrêts & - & Nombre total de noeuds d'arrêts desservis par le parcours. \\
+\hline
+\label{number_of_stops_on_path_outbound}
+\makecell[r]{Nombre d'arrêts aller \\ \textit{Number of outbound stops}} & \[{n_q}^{\prime}\] ou \[{n_s}^{\prime}\] & noeuds d'arrêts ou arrêts & - & Nombre total de noeuds d'arrêts desservis par le parcours aller. \\
+\hline
+\label{number_of_stops_on_path_inbound}
+\makecell[r]{Nombre d'arrêts retour \\ \textit{Number of inbound stops}} & \[{n_q}^{\prime\prime}\] ou \[{n_s}^{\prime\prime}\] & noeuds d'arrêts ou arrêts & - & Nombre total de noeuds d'arrêts desservis par le parcours retour. \\
+\hline
+\label{stop_nodes_linear_density}
+\makecell[r]{Densité linéaire de noeuds d'arrêts \\ \textit{Stop nodes linear density}} & \[{\rho}_{q_L}\] & \[\frac{\textnormal{noeuds d'arrêts}}{km}\] & \[\frac{n_q}{d}\] & Densité linéaire de noeuds d'arrêts sur une ligne ou un tronc de lignes. \\
+\hline
+\label{stop_nodes_area_density}
+\makecell[r]{Densité surfacique de noeuds d'arrêts \\ \textit{Stop nodes area density}} & \[{\rho}_{q_A}\] & \[\frac{\textnormal{noeuds d'arrêts}}{{km}^2}\] & \[\frac{N_q}{\textnormal{A}}\] & Densité surfacique de noeuds d'arrêts dans une région, un territoire donné. \\
+\hline
+\label{number_of_outbound_inbound_trips}
+\makecell[r]{Nombre de voyages aller-retour \\ \textit{Number of outbound-inbound trips}} & \[N_o\] ou \[k\] & voyages & - & Nombre total de voyages effectués dans les deux directions pour une période donnée pour une ligne bidirectionnelle ou dans la seule direction pour une ligne en boucle à sens unique. Attention aux ambiguïtés lorsque plusieurs parcours distincts sont utilisés pendant une période sur la ligne. \\
+\hline
+\end{longtable}
+
+
+\pagebreak
+\subsection*{Distances et longueurs • \textit{Distances and lengths}}
+
+\begin{longtable}{%
+    R{.3\NetTableWidth}%
+    C{.06\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.14\NetTableWidth}%
+    L{.4\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{acceleration_distance}
+\makecell[r]{Distance d'accélération \\ \textit{Acceleration distance}} & \[d_a\] & \[m\] & \[\frac{{v_p}^2}{2 a}\] & Distance parcourue lors de la phase d'accélération après avoir quitté l'arrêt précédent. \\
+\hline
+\label{deceleration_distance}
+\makecell[r]{Distance de décélération \\ \textit{Deceleration distance}} & \[d_b\] & \[m\] & \[\frac{{v_p}^2}{2 b}\] & Distance parcourue lors de la phase de décélération/freinage avant d'atteindre le prochain arrêt. \\
+\hline
+\label{distance_at_programmed_speed}
+\makecell[r]{Distance à vitesse programmée \\ \textit{Distance at programmed speed}} & \[d_{v_p}\] & \[m\] & \[d_l - d_a - d_b\] (catégorie A ou B seulement) & Distance entre la fin de l'accélération et le début de la décélération entre arrêts. \\
+\hline
+\label{interstop_distance}
+\makecell[r]{Distance inter-arrêt (longueur de segment) \\ \textit{Interstop distance (segment length)}} & \[d_l\] & \[m\] & - & Distance totale parcourue entre deux arrêts consécutifs sur le parcours. \\
+\hline
+\label{average_interstop_distance}
+\makecell[r]{Distance inter-arrêt moyenne de parcours \\ \textit{Average path interstop distance}} & \[\overline{d_l}\] & \[m\] & \[\frac{\sum_{i=1}^{n_l} {d_l}_i} {n_l}\] & Moyenne des distances inter-arrêts du parcours. \\
+\hline
+\label{median_interstop_distance}
+\makecell[r]{Distance inter-arrêt médiane de parcours \\ \textit{Median path interstop distance}} & \[\widetilde{d_l}\] & \[m\] & - & Médiane des distances inter-arrêts du parcours. \\
+\hline
+\label{minimum_interstop_distance}
+\makecell[r]{Distance inter-arrêt minimale de parcours \\ \textit{Minimum path interstop distance}} & \[{d_l}_{min}\] & \[m\] & - & Longueur du segment inter-arrêts le plus court du parcours. \\
+\hline
+\label{maximum_interstop_distance}
+\makecell[r]{Distance inter-arrêt maximale de parcours \\ \textit{Maximum path interstop distance}} & \[{d_l}_{max}\] & \[m\] & - & Longueur du segment inter-arrêts le plus long du parcours. \\
+\hline
+\label{average_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt moyenne de ligne \\ \textit{Average line interstop distance}} & \[\overline{{d_l}_L}\] & \[m\] & \[\frac{\sum_{j=1}^{n_p} {(\sum_{i=1}^{{n_l}_j} {d_l}_i})} {\sum_{j=1}^{n_p} {{n_l}_j}}\] & Distance moyenne des segments inter-arrêts d'une ligne dans les deux directions. \\
+\hline
+\label{median_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt médiane de ligne \\ \textit{Median path interstop distance}} & \[\widetilde{{d_l}_L}\] & \[m\] & - & Médiane des distances inter-arrêts de la ligne. \\
+\hline
+\label{minimum_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt minimale de ligne \\ \textit{Minimum path interstop distance}} & \[{{d_l}_L}_{min}\] & \[m\] & - & Longueur du segment inter-arrêts le plus court de la ligne. \\
+\hline
+\label{maximum_line_interstop_distance}
+\makecell[r]{Distance inter-arrêt maximale de ligne \\ \textit{Maximum path interstop distance}} & \[{{d_l}_L}_{max}\] & \[m\] & - & Longueur du segment inter-arrêts le plus long de la ligne. \\
+\hline
+\label{path_length}
+\makecell[r]{Longueur de parcours \\ \textit{Path length}} & \[d_p\] & \[m\] & \[\sum_{i=1}^{n_l} {d_l}_i\] & Longueur totale du parcours. \\
+\hline
+\label{path_outbound_length}
+\makecell[r]{Longueur de parcours aller \\ \textit{Outbound path length}} & \[d^{\prime}\] & \[m\] & \[\sum_{i=1}^{{n_l}_{p^{\prime}}} {d_l}_i\] & Longueur totale du parcours en direction aller. \\
+\hline
+\label{path_inbound_length}
+\makecell[r]{Longueur de parcours retour \\ \textit{Inbound path length}} & \[d^{\prime\prime}\] & \[m\] & \[\sum_{i=1}^{{n_l}_{p^{\prime\prime}}} {d_l}_i\] & Longueur totale du parcours en direction retour. \\
+\hline
+\label{line_length}
+\makecell[r]{Longueur de ligne \\ \textit{Line length}} & \[d_L\] & \[m\] & \[\sum_{i=1}^{{N_l}_L} {d_l}_i\] & Longueur totale du parcours dans une seule direction. Valable seulement pour les lignes unidirectionnelles, en boucle ou bidirectionnelles symétriques. \\
+\hline
+\label{network_length}
+\makecell[r]{Longueur de réseau \\ \textit{Network length}} & \[D_{net}\] & \[km\] & \[\sum_{i=1}^{N_{l_u}} {{d_l}_i} + \sum_{i=1}^{N_{l_{m}}} {{d_l}_i}\] & Longueur totale de tous les segments uniques de lignes (dans une direction). Ne compter qu'une seule fois les segments superposés (sur lesquels passent plusieurs parcours). \\
+\hline
+\label{lines_length}
+\makecell[r]{Longueur de lignes \\ \textit{Lines lengths}} & \[D_{L_{tot}}\] & \[km\] & \[\sum_{i=1}^{N_L} {{d_L}_i}\] & Longueur totale de l'ensemble des lignes (dans une direction). Additionner les segments superposés. \\
+\hline
+\label{vehicle_length}
+\makecell[r]{Longueur de véhicule \\ \textit{Vehicle length}} & \[l_y\] & \[m\] & - & Longueur d'un véhicule. \\
+\hline
+\label{unit_length}
+\makecell[r]{Longueur d'unité \\ \textit{Unit length}} & \[l_u\] & \[m\] & \[\sum_{i=1}^{n_y} {l_y}_i\] & Longueur d'une unité. \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+    R{.3\NetTableWidth}%
+    C{.06\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.14\NetTableWidth}%
+    L{.46\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{network_direct_distance}
+\makecell[r]{Distance réseau directe \\ \textit{Direct network distance}} & \[d_n\] & \[m\] & - & {Distance sur le réseau routier, ferroviaire ou autre qui minimise la distance totale entre les deux terminus, sans avoir à s'arrêter en chemnin (ne tient pas compte des arrêts en route).} \\
+\hline
+\label{euclidean_distance}
+\makecell[r]{Distance euclidienne \\ \textit{Euclidian distance}} & \[d_e\] & \[m\] & - & Distance à vol d'oiseau entre les deux terminus. \\
+\hline
+\label{access_distance}
+\makecell[r]{Distance d'accès à l'origine \\ \textit{Access distance}} & \[{d_e}_O\] & \[m\] & - & Distance parcourue par l'usager de l'origine du déplacement au premier arrêt de son parcours de transport collectif. \\
+\hline
+\label{egress_distance}
+\makecell[r]{Distance d'accès à destination \\ \textit{Egress distance}} & \[{d_e}_D\] & \[m\] & - & Distance parcourue par l'usager du dernier arrêt de son parcours de transport collectif à la destination du déplacement. \\
+\hline
+\label{access_egress_distance}
+\makecell[r]{Distance d'accès à l'origine et à destination \\ \textit{Access/egress distance}} & \[{d_e}_{OD}\] & \[m\] & \[{d_e}_O + {d_e}_D\] & Distance parcourue par l'usager de l'origine au premier arrêt et du dernier arrêt à la destination de son parcours de transport collectif. \\
+\hline
+\label{transfer_distance}
+\makecell[r]{Distance de transfert \\ \textit{Transfer distance}} & \[d_{tr}\] & \[m\] & - & Distance parcourue pour se déplacer d'un arrêt à l'autre lors d'un transfert particulier. \\
+\hline
+\label{total_transfer_distance}
+\makecell[r]{Distance totale de transfert \\ \textit{Total transfer distance}} & \[{d_{tr}}_{tot}\] & \[m\] & \[\sum_{i=1}^{n_{tr}} {d_{tr}}_i\] & Distance totale parcourue pour se déplacer d'un arrêt à l'autre lors de tous les transferts effectués pendant le parcours. N'inclut pas les distances d'accès à l'origine et à destination. \\
+\hline
+\label{total_access_egress_transfer_distance}
+\makecell[r]{Distance totale d'accès et de transfert \\ \textit{Total access/sgress and transfer distance}} & \[d_{e_{tot}}\] & \[m\] & \[{d_e}_{OD} + {d_{tr}}_{tot}\]& Somme des distances d'accès de l'origine du déplacement au premier arrêt et du dernier arrêt de son parcours de transport collectif à la destination du déplacement, et de la distance totale de transfert. Cette distance représente la distance totale parcourue à pied, à vélo ou en voiture pour accéder au service de transport collectif à l'origine et à destination et pour se déplacer entre les arrêts de transfert. \\
+\hline
+\label{in_vehicle_distance}
+\makecell[r]{Distance en véhicule \\ \textit{In-vehicle distance}} & \[d_{veh}\] & \[m\] & - & Distance parcourue en véhicule sur une ligne entre l'embarquement à un arrêt et le débarquement à un arrêt subséquent sur la ligne. \\
+\hline
+\label{total_in_vehicle_distance}
+\makecell[r]{Distance totale en véhicule \\ \textit{Total in-vehicle distance}} & \[d_{{veh}_{tot}}\] & \[m\] & \[\sum_{i=1}^{n_{tr}+1} d_{{veh}_i}\] & Distance totale parcourue en véhicule lors du parcours de transport collectif complet, incluant les distances de tous les segments de ligne empruntés. \\
+\hline
+\label{total_od_distance}
+\makecell[r]{Distance totale OD \\ \textit{Total OD distance}} & \[d_{OD}\] & \[m\] & \[d_{e_{tot}} + d_{{veh}_{tot}}\] & Distance totale parcourue lors d'un déplacement de transport collectif, incluant l'accès et les transferts. \\
+\hline
+\label{total_od_transit_distance}
+\makecell[r]{Distance totale OD transport collectif \\ \textit{Total OD transit distance}} & \[d_{transit}\] ou \[d_{TC}\] & \[m\] & \[d_{OD}\] & Distance totale calculée en transport collectif. Permet de comparer la compétitivité des modes entre eux. \\
+\hline
+\label{total_od_driving_distance}
+\makecell[r]{Distance totale OD voiture \\ \textit{Total OD driving distance}} & \[d_{car}\] ou \[d_{driving}\]  & \[m\] & - & Distance totale du chemin le plus rapide calculé en voiture. Attention de bien spécifier si le parcours optimal a été calculé en tenant compte de la congestion. \\
+\hline
+\label{total_od_cycling_distance}
+\makecell[r]{Distance totale OD vélo \\ \textit{Total OD cycling distance}} & \[d_{bicycle}\] ou \[d_{cycling}\] & \[m\] & - & Distance totale du chemin le plus rapide calculé à vélo. \\
+\hline
+\label{total_od_walking_distance}
+\makecell[r]{Distance totale OD marche \\ \textit{Total OD walking distance}} & \[d_{foot}\] ou \[d_{walking}\] & \[m\] & - & Distance totale du chemin le plus rapide calculé à pied. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Temps et durées • \textit{Time and durations}}
+
+\begin{longtable}{%
+    R{.28\NetTableWidth}%
+    C{.07\NetTableWidth}%
+    C{.03\NetTableWidth}%
+    C{.22\NetTableWidth}%
+    L{.40\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{acceleration_time}
+\makecell[r]{Temps d'accélération \\ \textit{Acceleration time}} & \[t_a\] & \[s\] & \[\frac{v_p}{a}\] & Temps requis pour accélérer de l'arrêt complet à la vitesse programmée. \\
+\hline
+\label{deceleration_time}
+\makecell[r]{Temps de décélération \\ \textit{Deceleration time}} & \[t_b\] & \[s\] & \[\frac{v_p}{b}\] & Temps requis pour ralentir et freiner de la vitesse programmée à l'arrêt complet. \\
+\hline
+\label{travel_time_at_programmed_speed}
+\makecell[r]{Temps à vitesse programmée \\ \textit{Travel time at programmed speed}} & \[t_{v_p}\] & \[s\] & \[\frac{d_{v_p}}{v_p}\] (catégorie A ou B seulement) & Temps entre la fin de l'accélération et le début de la décélération d'un segment entre arrêts. \\
+\hline
+\label{segment_interstop_travel_time}
+\makecell[r]{Temps de parcours de segment/inter-arrêts \\ \textit{Segment/Interstop travel time}} & \[t_l\] & \[s\] & \[t_a + t_{v_p} + t_b\] ou \[\sqrt[]{\frac{2(a + b){d}_l}{a b}}\] si la distance inter-arrêt ne permet pas d'atteindre la vitesse programmée & Temps de parcours entre deux arrêts consécutifs qui n'inclut pas les temps d'arrêt, mais qui inclut les temps d'accélération et de décélération, ainsi que les temps d'arrêt aux feux de circulation ou en congestion. Les expressions ne sont valables que pour les catégories A ou B (aucune congestion ou feux de circulation). \\
+\hline
+\label{average_interstop_travel_time}
+\makecell[r]{Temps de parcours de segment moyen \\ \textit{Average interstop travel time}} & \[\overline{t_l}\] & \[s\] & \[\frac{\sum_{i=1}^{n_l} {t_l}_i}{n_l}\] & Moyenne des temps de parcours inter-arrêt d'un parcours ou des parcours aller et retour d'une ligne bidirectionnelle. \\
+\hline
+\label{median_interstop_travel_time}
+\makecell[r]{Temps de parcours de segment médian \\ \textit{Median interstop travel time}} & \[\widetilde{t_l}\] & \[s\] & & Médiane des temps de parcours inter-arrêt d'un parcours ou des parcours aller et retour d'une ligne bidirectionnelle. \\
+\hline
+\label{door_opening_time}
+\makecell[r]{Temps d'ouverture des portes \\ \textit{Door opening time}} & \[t_{do}\] & \[s\] & - & Temps requis pour l'ouverture de toutes les portes d'une unité pour le débarquement et/ou l'embarquement des passagers. \\
+\hline
+\label{door_closing_time}
+\makecell[r]{Temps de fermeture des portes \\ \textit{Door closing time}} & \[t_{dc}\] & \[s\] & - & Temps requis pour la fermeture de toutes les portes d'une unité pour le débarquement et/ou l'embarquement des passagers. \\
+\hline
+\label{dwell_time}
+\makecell[r]{Temps d'arrêt \\ \textit{Dwell time}} & \[t_q\] ou \[t_s\] & \[s\] & $\begin{gathered}[t] \max{\Big(\frac{n_B}{n_{{Bch}_{u}}} \overline{t_B}\ ,\ \frac{n_A}{n_{{Ach}_{u}}} \overline{t_A}\Big)} \\ + t_{do} + t_{dc} \end{gathered}$ & Temps pendant lequel l'unité en service sur un parcours est à l'arrêt complet, permettant l'embarquement et le débarquement des passagers au quai ou vis-à-vis le panneau d'arrêt. \\
+\hline
+\label{average_dwell_time}
+\makecell[r]{Temps d'arrêt moyen \\ \textit{Average dwell time}} & \[\overline{t_q}\] & \[s\] & \[\frac{\sum_{i=1}^{n_q} {t_q}_i}{n_q}\] & Moyenne des temps d'arrêt d'un parcours. \\
+\hline
+\label{median_dwell_time}
+\makecell[r]{Temps d'arrêt median \\ \textit{Median dwell time}} & \[\widetilde{t_q}\] & \[s\] & & Médiane des temps d'arrêt d'un parcours. \\
+\hline
+\label{stop_to_stop_time}
+\makecell[r]{Temps arrêt à arrêt \\ \textit{Stop to stop time}} & \[t_{\Delta s}\] & \[s\] & \[t_q + t_l\] & Temps total entre le départ de l'arrêt précédent et le départ de l'arrêt suivant. Comprend le temps de parcours inter-arrêts et le temps d'arrêt. \\
+\hline
+\label{line_average_dwell_time}
+\makecell[r]{Temps d'arrêt moyen de ligne \\ \textit{Line average dwell time }} & \[\overline{t_q}_L\] & \[s\] & \[\frac{\sum_{j=1}^{n_p} {(\sum_{i=1}^{{n_q}_j} {{t_q}_j}_i})} {\sum_{j=1}^{n_p} {n_q}_j}\] & Moyenne des temps d'arrêt d'une ligne. Attention aux ambiguïtés lorsque la ligne possède plusieurs parcours, notamment des parcours bidirectionnels non symétriques avec des temps d'arrêt non semblables. \\
+\hline
+\label{maximum_dwell_time}
+\makecell[r]{Temps d'arrêt maximal \\ \textit{Maximum dwell time}} & \[{t_q}_{max}\] & \[s\] & \[\max_{i=1}^{n_q} {{t_q}_i}\] & Temps d'arrêt à l'arrêt le plus achalandé et/ou demandant le plus de temps d'embarquement et de débarquement sur l'ensemble du parcours. \\
+\hline
+\label{line_maximum_dwell_time}
+\makecell[r]{Temps d'arrêt maximal de ligne \\ \textit{Line maximum dwell time}} & \[{{t_q}_L}_{max}\] & \[s\] & \[\max_{i=1}^{{n_q}_L} {{t_q}_i}\] & Temps d'arrêt à l'arrêt le plus achalandé et/ou demandant le plus de temps d'embarquement et de débarquement sur la ligne. Attention aux ambiguïtés lorsque la ligne possède plusieurs parcours, notamment des parcours bidirectionnels non symétriques avec des temps d'arrêt non semblables. \\
+\hline
+\label{reaction_time}
+\makecell[r]{Temps de réaction \\ \textit{Reaction time}} & \[t_r\] & \[s\] & - & Temps de réaction du conducteur ou du système autonome entre le début de la consigne ou de la demande de freinage ou d'accélération et le début du freinage ou de l'accélération. \\
+\hline
+\label{operating_time}
+\makecell[r]{Temps d'opération \\ \textit{Operating time}} & \[T_o\] & \[s\] & \[\sum_{i=1}^{n_l} {t_l}_i + \sum_{i=1}^{n_q - 1} {t_q}_i = \frac{d_L}{V_o}\]& Temps total entre le départ du terminus de départ et l'arrivée au terminus d'arrivée. Habituellement, on compte un temps d'arrêt de moins que le nombre d'arrêts sur le parcours (le temps au premier arrêt est inclus dans le battement). \\
+\hline
+\label{operating_time_outbound}
+\makecell[r]{Temps d'opération aller \\ \textit{Outbound operating time}} & \[{T_o}^\prime\] & \[s\] & \[\sum_{i=1}^{{n_l}_p} {t_l}_i + \sum_{i=1}^{n_q - 1} {t_q}_i \] où p est le parcours aller & Temps total entre le départ du terminus de départ et l'arrivée au terminus d'arrivée du parcours aller. Habituellement, on compte un temps d'arrêt de moins que le nombre d'arrêts sur le parcours (le temps au premier arrêt est inclus dans le battement). \\
+\hline
+\label{operating_time_return}
+\makecell[r]{Temps d'opération retour \\ \textit{Inbound operating time}} & \[{T_o}^{\prime\prime}\] & \[s\] & \[\sum_{i=1}^{{n_l}_p} {t_l}_i + \sum_{i=1}^{n_q - 1} {t_q}_i \] où p est le parcours retour & Temps total entre le départ du terminus de départ et l'arrivée au terminus d'arrivée du parcours retour. Habituellement, on compte un temps d'arrêt de moins que le nombre d'arrêts sur le parcours (le temps au premier arrêt est inclus dans le battement). \\
+\hline
+\label{layover_time}
+\makecell[r]{Temps de battement \\ \textit{Layover time}} & \[{t_t}\] & \[s\] & - & Temps requis pour débarquer les passagers au dernier arrêt, pour permettre à l'unité de se remettre en disponibilité pour le parcours suivant, pour rattraper les retards accumulés et pour embarquer les passagers pour le prochain départ en direction inverse. Habituellement, le battement n'inclut que le temps d'arrêt au départ du terminus, mais pas à l'arrivée (inclus dans le temps d'opération). \\
+\hline
+\label{minimum_layover_time}
+\makecell[r]{Temps de battement minimum \\ \textit{Minimum layover time}} & \[{t_t}_{min}\] & \[s\] & - & Temps de  battement minimum requis, peu importe le temps d'opération prévu. \\
+\hline
+\label{path_layover_time}
+\makecell[r]{Temps de battement de parcours \\ \textit{Path layover time}} & \[{t_t}_p\] & \[s\] & \[\max \Big( {t_t}_{min}\ ,\  {\gamma_t} {T_o} \Big)\] & Temps de battement au terminus d'arrivée du parcours. \\
+\hline
+\label{outbound_layover_time}
+\makecell[r]{Temps de battement aller \\ \textit{Outbound layover time}} & \[{t_t}^\prime\] & \[s\] & \[\max \Big( {t_t}_{min}\ ,\  {\gamma_t}^\prime {T_o}^{\prime} \Big)\] & Temps de battement au terminus 1 (à la fin du parcours aller). \\
+\hline
+\label{inbound_layover_time}
+\makecell[r]{Temps de battement retour \\ \textit{Inbound layover time}} & \[{t_t}^{\prime\prime}\] & \[s\] & \[\max \Big( {t_t}_{min}\ ,\  {\gamma_t}^{\prime\prime} {T_o}^{\prime\prime} \Big)\] & Temps de battement au terminus 2 (à la fin du parcours retour) \\
+\hline
+\label{total_layover_time}
+\makecell[r]{Temps de battement total \\ \textit{Total layover time}} & \[t_t\] & \[s\] & \[\max \Big( 2{t_t}_{min}\ ,\  {\gamma_t}^\prime {T_o}^\prime + {\gamma_t}^{\prime\prime} {T_o}^{\prime\prime} \Big)\] ou \[ \max \Big( 2{t_t}_{min}\ ,\  2 \gamma_t T_o \Big)\] pour une ligne symétrique & Temps de battement total à l'ensemble des terminus d'une ligne bidirectionnelle ou d'une ligne en boucle. Attention aux ambiguïtés si la ligne possède plusieurs parcours distincts. Le temps de battement inclut les temps d'embarquement et de débarquement des passagers aux terminus. \\
+\hline
+\label{layover_coefficient}
+\makecell[r]{Coefficient de battement \\ \textit{Layover coefficient}} & \[\gamma_t\] & - & \[\frac{t_t} {T_o}\] & Pourcentage du temps d'opération utilisé pour les battements. Le temps de battement est ajouté au temps d'opération pour obtenir le temps de cycle. Utilisé pour les lignes symétriques. \\
+\hline
+\label{outbound_layover_coefficient}
+\makecell[r]{Coefficient de battement aller \\ \textit{Outbound layover coefficient}} & \[{\gamma_t}^\prime\] & - & \[\frac{{t_t}^\prime}{{T_o}^\prime}\] & Pourcentage du temps d'opération du parcours aller utilisé pour le battement aller. \\
+\hline
+\label{inbound_layover_coefficient}
+\makecell[r]{Coefficient de battement retour \\ \textit{Inbound layover coefficient}} & \[{\gamma_t}^{\prime\prime}\] & - & \[\frac{{t_t}^{\prime\prime}}{{T_o}^{\prime\prime}}\] & Pourcentage du temps d'opération du parcours retour utilisé pour le battement retour. \\
+\hline
+\label{total_layover_coefficient}
+\makecell[r]{Coefficient de battement total \\ \textit{Total layover coefficient}} & \[\gamma_t\] & - & \[\frac{{t_t}^{\prime} + {t_t}^{\prime\prime}} {{T_o}^{\prime} + {T_o}^{\prime\prime}}\] & Pourcentage du temps d'opération total utilisé pour les battements. \\
+\hline
+\label{non_productive_tts_layover_time}
+\makecell[r]{Temps improductif de battement cadencé \\ \textit{Non-productive TTS layover time}} & \[{t_t}_{h_p}\] & \[s\] & \[T_c - {T_c}_{min}\] & Temps devant être ajouté au temps de cycle minimum d'une ligne pour pouvoir obtenir un horaire cadencé.\\
+\hline
+\label{total_non_productive_ttslayover_time}
+\makecell[r]{Temps improductif total de battement cadencé \\ \textit{Total non-productive TTS layover time}} & \[{t_t}_{{h_p}_{total}}\] & \[s\] & \[\sum_{i=1}^{n_L} {t_t}_{{h_p}_i} {{n_u}_i}\] où \(n_L\) est le nombre de lignes affectées par le cadencement & Temps total devant être ajouté aux temps de cycle minimum des lignes pour pouvoir obtenir un horaire cadencé.\\
+\hline
+\label{half_cycle_time}
+\makecell[r]{Temps de demi-cycle \\ \textit{Half-cycle time}} & \[{T_c}_p\] & \[s\] & \[{T_o} + {t_t} \] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée. \\
+\hline
+\label{outbound_half_cycle_time}
+\makecell[r]{Temps de demi-cycle aller \\ \textit{Outbound half-cycle time}} & \[{{T_c}_p}^{\prime}\] & \[s\] & \[{T_o}^{\prime} + {t_t}^{\prime} \] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée du parcours aller. \\
+\hline
+\label{inbound_half_cycle_time}
+\makecell[r]{Temps de demi-cycle retour \\ \textit{Inbound half-cycle time}} & \[{{T_c}_p}^{\prime\prime}\] & \[s\] & \[{T_o}^{\prime\prime} + {t_t}^{\prime\prime} \] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée du parcours retour. \\
+\hline
+\label{cycle_time}
+\makecell[r]{Temps de cycle \\ \textit{Cycle time}} & \[T_c\] & \[s\] & \[{T_o}^\prime + {t_t}^{\prime} +  {T_o}^{\prime\prime} + {t_t}^{\prime\prime}\] & Le temps de cycle (ou temps de remise en disponibilité) inclut le temps d'opération dans les deux directions et le temps de battement à tous les terminus des parcours aller et retour ou du terminus dans le cas d'une ligne en boucle. Ce temps représente le temps de remise en disponibilité de l'unité pour un prochain voyage. \\
+\hline
+\end{longtable}
+
+
+\begin{longtable}{%
+    R{.3\NetTableWidth}%
+    C{.08\NetTableWidth}%
+    C{.04\NetTableWidth}%
+    C{.14\NetTableWidth}%
+    L{.44\NetTableWidth}%
+  }
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{direct_network_travel_time}
+\makecell[r]{Temps de parcours réseau direct \\ \textit{Direct network travel time}} & \[t_n\] & \[s\] & - & Temps de parcours calculé sur le réseau routier, ferroviaire ou autre le plus rapide entre les deux terminus, sans passer nécessairement par les arrêts du parcours. \\
+\hline
+\label{deadhead_time}
+\makecell[r]{Temps haut-le-pied \\ \textit{Deadhead time}} & \[t_d\] & \[s\] & - & Somme des temps de parcours entre le garage et le premier terminus en début de tournée, entre le dernier terminus et le garage en fin de tournée, des temps de parcours requis lors des parcours de repositionnement au départ des terminus et les temps de parcours d'interlignage si la tournée effectue du service sur plusieurs lignes. \\
+\hline
+\label{platform_time}
+\makecell[r]{Temps plateforme \\ \textit{Platform time}} & \[T_p\] & \[s\] & \[k T_c + t_d\] où \[k\] est le nombre de voyages aller-retour effectués pendant la tournée & Temps total pendant lequel une unité est en opération sur une tournée complète, en service productif et en haut-le-pied. Attention aux ambiguïtés lorsque les tournées comprennent des parcours d'interlignage. \\
+\hline
+\label{access_egress_time}
+\makecell[r]{Temps d'accès \\ \textit{Access/egress time}} & \[t_{e}\] & \[s\] & - & Temps de parcours à pied, à vélo ou en voiture permettant d'atteindre un arrêt. \\
+\hline
+\label{access_time}
+\makecell[r]{Temps d'accès à l'origine \\ \textit{Access time}} & \[{t_e}_O\] & \[s\] & \[v_e {d_e}_O\] & Temps d'accès de l'usager entre l'origine du déplacement et le premier arrêt de son parcours de transport collectif. Un calculateur de chemin réseau pour le mode d'accès (marche, vélo, voiture ou autre) peut permettre d'obtenir un temps d'accès calibré et tenant compte des obstacles et des feux de circulation. \\
+\hline
+\label{egress_time}
+\makecell[r]{Temps d'accès à destination \\ \textit{Egress time}} & \[{t_e}_D\] & \[s\] & \[v_e {d_e}_D\] & Temps d'accès de l'usager entre le dernier arrêt de son parcours de transport collectif et la destination du déplacement. \\
+\hline
+\label{access_egress_time_od}
+\makecell[r]{Temps total d'accès à l'origine et à destination \\ \textit{Access/egress time}} & \[{t_e}_{OD}\] & \[s\] & \[{t_e}_O + {t_e}_D\]& Temps total d'accès de l'usager de l'origine du déplacement au premier arrêt et du dernier arrêt de son parcours de transport collectif à la destination du déplacement. N'inclut pas le temps total d'accès de transfert. \\
+\hline
+\label{transfer_time}
+\makecell[r]{Temps de transfert \\ \textit{Transfer time}} & \[t_{tr}\] & \[s\] & - & Temps de parcours permettant de passer d'un arrêt à l'autre lors d'un transfer. N'inclut pas le temps d'attente lors du transfert. \\
+\hline
+\label{total_transfer_time}
+\makecell[r]{Temps total de transfert \\ \textit{Total transfer time}} & \[{t_{tr}}_{tot}\] & \[s\] & \[\sum_{i=1}^{n_{tr}} d_{tr}\] & Temps total de parcours permettant de passer d'un arrêt à l'autre lors de tous les transferts effectués pendant le parcours. N'inclut pas les temps d'accès à l'origine et à destination ni le temps d'attente lors du transfert. \\
+\hline
+\label{total_access_egress_transfer_time}
+\makecell[r]{Temps total d'accès et de transfert \\ \textit{Total access/egress and transfer time}} & \[{t_e}_{tot}\] & \[s\] & \[{t_e}_{OD} + {t_{tr}}_{tot}\] & Somme des temps d'accès de l'usager de l'origine du déplacement au premier arrêt et du dernier arrêt de son parcours de transport collectif à la destination du déplacement, et du temps total d'accès de transfert. Ce temps représente le total du temps de parcours effectué à pied, à vélo ou en voiture pour accéder au service de transport collectif à l'origine et à destination et pour se déplacer entre les arrêts de transfert. \\
+\hline
+\label{waiting_time}
+\makecell[r]{Temps d'attente \\ \textit{Waiting time}} & \[t_w\] & \[s\] & - & Temps d'attente avant l'embarquement à un arrêt. \\
+\hline
+\label{origin_waiting_time}
+\makecell[r]{Temps d'attente à l'origine \\ \textit{Origin waiting time}} & \[{t_w}_O\] & \[s\] & - & Temps d'attente au premier arrêt d'embarquement du parcours. \\
+\hline
+\label{transfer_waiting_time}
+\makecell[r]{Temps d'attente de transfert \\ \textit{Transfer waiting time}} & \[{t_w}_{tr}\] & \[s\] & - & Temps d'attente avant l'embarquement à un arrêt lors d'un transfert. \\
+\hline
+\label{minimum_waiting_time}
+\makecell[r]{Temps minimum d'attente \\ \textit{Minimum waiting time}} & \[{t_w}_{min}\] & \[s\] & - & Temps minimum de sécurité (d'arrivée à l'avance) avant l'embarquement à un arrêt pour tenir compte des retards possibles de la ligne précédente lors d'un transfert, des incertitudes sur les temps d'accès et de la possibilité que l'unité parte en avance sur l'horaire planifié à l'arrêt d'embarquement. Utilisé pour les calculs de chemin transport collectif. \\
+\hline
+\label{total_transfer_waiting_time}
+\makecell[r]{Temps total d'attente de transfert \\ \textit{Total transfer waiting time}} & \[{{t_w}_{tr}}_{tot}\] & \[s\] & \[\sum_{i=1}^{n_{tr}} {{t_w}_i}\] & Temps total d'attente lors des transferts. N'inclut ni le temps d'attente à l'origine, ni les temps d'accès aux transferts. \\
+\hline
+\label{total_waiting_time}
+\makecell[r]{Temps total d'attente \\ \textit{Total waiting time}} & \[{t_w}_{tot}\] & \[s\] & \[{t_w}_O + {{t_w}_{tr}}_{tot}\] & Temps total d'attente, incluant le temps d'attente à l'origine et les temps d'attente de transfert. \\
+\hline
+\label{in_vehicle_time}
+\makecell[r]{Temps en véhicule \\ \textit{In-vehicle time}} & \[t_{veh}\] & \[s\] & - & Temps passé en véhicule sur une ligne entre l'embarquement à un arrêt et le débarquement à un arrêt subséquent sur la ligne. \\
+\hline
+\label{total_in_vehicle_time}
+\makecell[r]{Temps total en véhicule \\ \textit{Total in-vehicle time}} & \[{t_{veh}}_{tot}\] & \[s\] & \[\sum_{i=1}^{n_{tr}+1} t_{{veh}_i}\] & Temps total passé en véhicule lors du parcours de transport collectif complet, incluant les temps de parcours de tous les segments de ligne empruntés et les temps d'arrêt en route. \\
+\hline
+\label{total_od_time}
+\makecell[r]{Temps total OD \\ \textit{Total OD time}} & \[T_{OD}\] & \[s\] & \[ {t_e}_{tot} + {t_w}_{tot} + {t_{veh}}_{tot}\] & Temps total entre l'origine et la destination. \\
+\hline
+\label{average_single_boarding_time}
+\makecell[r]{Temps moyen d'embarquement par passager \\ \textit{Average single boarding time}} & \[\overline{t_B}\] & \[s\] & - & \\
+\hline
+\label{average_single_alighting_time}
+\makecell[r]{Temps moyen de débarquement par passager \\ \textit{Average single alighting time}} & \[\overline{t_A}\] & \[s\] & - & \\
+\hline
+\label{reported_total_time}
+\makecell[r]{Temps total rapporté \\ \textit{Reported total time}} & \[T_{rep}\] \[{T_{rep}}_L\] & \[s\] & - & Temps total déclaré comme ayant été travaillé par les employés. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{total_paid_time}
+\makecell[r]{Temps total payé \\ \textit{Total paid time}} & \[T_{paid}\] \[{T_{paid}}_L\] & \[s\] & - & Temps total payé aux employés. Inclut les temps déclarés travaillés et les absences, retards, congés, etc. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{total_service_time}
+\makecell[r]{Temps total travaillé en service \\ \textit{Total service time}} & \[T_{serv}\] \[{T_{serv}}_L\] & \[s\] & - & Temps total pour lequel du travail en service a été effectué par les employés. Ce temps n'inclut pas les temps haut-le-pied et les temps de battement. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{personnel_attendence_coefficient}
+\makecell[r]{Coefficient d'efficacité de présence \\ \textit{Personnel attendence coefficient}} & \[\eta_a\] \[{\eta_a}_L\] & - & \[\frac{T_{rep}}{T_{paid}}\] \[\frac{{T_{rep}}_L}{{T_{paid}}_L}\] & Permet d'évaluer le ratio entre les heures rapportées travaillées et les heures payées qui comprennent les absences, retards, congés, etc. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{run_cutting_and_schedule_efficiency_coefficient}
+\makecell[r]{Coefficient d'efficacité d'habillage \\ \textit{Run-cutting and schedule efficiency coefficient}} & \[\eta_s\] \[{\eta_s}_L\] & - & \[\frac{T_{serv}}{T_{rep}}\] \[\frac{{T_{serv}}_L}{{T_{rep}}_L}\] & Permet d'évaluer le ratio entre les heures travaillées pour offrir un service aux usagers et les heures rapportées travaillées, qui incluent les réunions, les pauses, les vérifications avant départ, les temps haut-le-pied, les temps en terminus, etc. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{terminal_efficiency_coefficient}
+\makecell[r]{Coefficient d'efficacité en terminus \\ \textit{Terminal efficiency coefficient}} & \[\eta_t\] \[{\eta_t}_L\] & - & \[\frac{{T_o}^\prime + {T_o}^{\prime\prime}}{T_c}\] lorsque les lignes sont bidirectionnelles et symétriques & Représente le ratio entre le temps total d'opération aller-retour et le temps de cycle qui inclut les battements en terminus. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{global_efficiency_coefficient}
+\makecell[r]{Coefficient d'efficacité globale \\ \textit{Global operating efficiency coefficient}} & \[\eta\] \[{\eta}_L\] & - & \[\eta_a \eta_s \eta_t\] \[{\eta_a}_L {\eta_s}_L {\eta_t}_L\] & Représente l'efficacité globale d'une ligne ou d'un réseau. Utiliser l'indice L lorsque le coefficient représente l'efficiacité d'une ligne en particulier (la ligne ne doit pas partager d'unités ou de main d'oeuvre avec une autre). \\
+\hline
+\label{total_transit_od_time}
+\makecell[r]{Temps total OD en transport collectif \\ \textit{Total transit OD travel time}} & \[T_{transit}\] ou \[T_{TC}\] & \[s\] & \[T_{OD}\] & Temps calculé en transport collectif. Permet de comparer la compétitivité des modes entre eux. \\
+\hline
+\label{total_driving_od_time}
+\makecell[r]{Temps total OD en voiture \\ \textit{Total driving OD travel time}} & \[T_{car}\] ou \[T_{driving}\] & \[s\] & - & Temps de parcours du chemin le plus rapide calculé en voiture. Attention de bien spécifier si ce temps et le parcours emprunté tient compte de la congestion. \\
+\hline
+\label{total_bicycle_od_time}
+\makecell[r]{Temps total OD à vélo \\ \textit{Total cycling OD travel time}} & \[T_{bicycle}\] ou \[T_{cycling}\] & \[s\] & - & Temps de parcours du chemin le plus rapide calculé à vélo. \\
+\hline
+\label{total_walking_od_time}
+\makecell[r]{Temps total OD à pied \\ \textit{Total walking OD travel time}} & \[T_{foot}\] ou \[T_{walking}\] & \[s\] & - & Temps de parcours du chemin le plus rapide calculé à pied. \\
+\hline
+\label{transit_driving_competitivity_coefficient}
+\makecell[r]{Coefficient de compétitivité TC/voiture \\ \textit{Transit/driving competitivity coefficient}} & \[\mu_{car}\] ou \[\mu_{driving}\] & - & \[\frac{T_{transit}}{T_{car}}\] & Une valeur \(> 1\) indique que le transport collectif est plus lent. \\
+\hline
+\label{transit_cycling_competitivity_coefficient}
+\makecell[r]{Coefficient de compétitivité du TC/vélo \\ \textit{Transit/cycling competitivity coefficient}} & \[\mu_{bicycle}\] ou \[\mu_{cycling}\] & - & \[\frac{T_{transit}}{T_{bicycle}}\] & Une valeur \(> 1\) indique que le transport collectif est plus lent. \\
+\hline
+\label{transit_walking_competitivity_coefficient}
+\makecell[r]{Coefficient de compétitivité TC/marche \\ \textit{Transit/walking competitivity coefficient}} & \[\mu_{foot}\] ou \[\mu_{walking}\] & - & \[\frac{T_{transit}}{T_{foot}}\] & Une valeur \(> 1\) indique que le transport collectif est plus lent. \\
+\hline
+\end{longtable} 
+
+
+
+
+\pagebreak
+\subsection*{Vitesses • \textit{Speeds and velocities}}
+
+\begin{longtable}{%
+  R{.26\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.04\NetTableWidth}%
+  C{.18\NetTableWidth}%
+  L{.44\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{unit_maximum_speed}
+\makecell[r]{Vitesse maximale de l'unité \\ \textit{Unit maximum speed}} & \[v_{max}\] & \[{km}/h\] & - & Vitesse que l'unité peut atteindre à puissance maximale. \\
+\hline
+\label{design_speed}
+\makecell[r]{Vitesse de conception \\ \textit{Design speed}} & \[v_d\] & \[{km}/h\] & - & Vitesse maximale possible sur un tronçon. Tient compte des contraintes de confort et de sécurité. \\
+\hline
+\label{legal_speed}
+\makecell[r]{Vitesse légale \\ \textit{Legal speed}} & \[v_{reg}\] & \[{km}/h\] & - & Vitesse légale permise sur le tronçon. \\
+\hline
+\label{programmed_speed}
+\makecell[r]{Vitesse programmée \\ \textit{Programmed speed}} & \[v_p\] & \[{km}/h\] & - & Vitesse programmée en service sur un tronçon ou un segment. Habituellement, cette vitesse est déterminée de manière à optimiser, dans le meilleur équilibre, l'efficacité énergétique et la minimisation des temps de parcours inter-arrêts. \(v_p \leq v_{reg} \leq v_d\) \\
+\hline
+\label{operating_speed}
+\makecell[r]{Vitesse d'opération \\ \textit{Operating speed}} & \[V_o\] & \[{km}/h\] & \[\frac{d_p}{T_o}\] & Vitesse commerciale perçue par l'usager sur un parcours, qui inclut les temps d'arrêt. \\
+\hline
+\label{outbound_operating_speed}
+\makecell[r]{Vitesse d'opération aller \\ \textit{Outbound operating speed}} & \[{V_o}^\prime\] & \[{km}/h\] & \[\frac{d^{\prime}}{{T_o}^{\prime}}\] & Vitesse commerciale pour le parcours aller. \\
+\hline
+\label{inbound_operating_speed}
+\makecell[r]{Vitesse d'opération retour \\ \textit{Inbound operating speed}} & \[{V_o}^{\prime\prime}\] & \[{km}/h\] & \[\frac{d^{\prime\prime}}{{T_o}^{\prime\prime}}\] & Vitesse commerciale pour le parcours retour. \\
+\hline
+\label{line_operating_speed}
+\makecell[r]{Vitesse d'opération de ligne \\ \textit{Line operating speed}} & \[{V_o}_L\] & \[{km}/h\] & \[\frac{d^{\prime} + d^{\prime\prime}}{{T_o}^{\prime} + {T_o}^{\prime\prime}}\] & Vitesse commerciale sur la ligne. Attention aux ambiguïtés lorsque la ligne n'est pas bidirectionnelle symétrique ou en boucle. \\
+\hline
+\label{half_cycle_speed}
+\makecell[r]{Vitesse de demi-cycle \\ \textit{Half-cycle speed}} & \[V_{1/2c}\] & \[{km}/h\] & \[\frac{d_p}{T_{1/2c}}\] & Vitesse moyenne pendant un demi-cycle (parcours) \\
+\hline
+\label{outbound_half_cycle_speed}
+\makecell[r]{Vitesse de demi-cycle aller \\ \textit{Outbound half-cycle speed}} & \[{V_{1/2c}}^{\prime}\] & \[{km}/h\] & \[\frac{d^{\prime}}{{T_{1/2c}}^{\prime}}\] & Vitesse moyenne pendant le demi-temps de cycle aller. \\
+\hline
+\label{inbound_half_cycle_speed}
+\makecell[r]{Vitesse de demi-cycle retour \\ \textit{Inbound half-cycle speed}} & \[{V_{1/2c}}^{\prime\prime}\] & \[{km}/h\] & \[\frac{d^{\prime\prime}}{{T_{1/2c}}^{\prime\prime}}\] & Vitesse moyenne pendant le demi-temps de cycle retour. \\
+\hline
+\label{cycle_speed}
+\makecell[r]{Vitesse de cycle \\ \textit{Cycle speed}} & \[V_c\] & \[{km}/h\] & \[\frac{d^{\prime} + d^{\prime\prime}}{T_c}\] & Vitesse moyenne aller-retour pendant le temps de cycle. \\
+\hline
+\label{platform_speed}
+\makecell[r]{Vitesse plateforme \\ \textit{Platform speed}} & \[V_p\] & \[{km}/h\] & \[\frac{k(d^{\prime} + d^{\prime\prime})}{T_p}\] où \[k\] est le nombre de voyages aller-retour effectués pendant la tournée & Vitesse moyenne pendant le temps pour lequel une unité est en opération sur une tournée complète, en service productif et en haut-le-pied. Attention aux ambiguïtés lorsque les tournées comprennent des parcours d'interlignage. \\
+\hline
+\label{segment_speed}
+\makecell[r]{Vitesse de segment/inter-arrêt \\ \textit{Segment/interstop speed}} & \[v_l\] & \[{km}/h\] & \[\frac{d_l}{t_l}\] & Vitesse moyenne entre le départ de l'arrêt précédent et l'arrivée à l'arrêt suivant (segment). N'inclut pas le temps d'arrêt. \\
+\hline
+\label{stop_to_stop_speed}
+\makecell[r]{Vitesse arrêt à arrêt \\ \textit{Stop to stop speed}} & \[v_{\Delta s}\] ou \[v_{\Delta q}\] & \[{km}/h\] & \[\frac{d_l}{t_l + t_q}\] & Vitesse moyenne entre le départ de l'arrêt précédent et le départ de l'arrêt suivant. Inclut le temps d'arrêt. \\
+\hline
+\label{average_segment_speed}
+\makecell[r]{Vitesse moyenne de segment/inter-arrêt \\ \textit{Average segment/interstop speed}} & \[\overline{v_l}\] & \[{km}/h\] & \[\frac{ \sum_{i=1}^{n_l} {\frac{{d_l}_i}{{t_l}_i}}} {n_l} \] & Moyenne des vitesses inter-arrêt des segments d'un parcours ou d'une ligne. \\
+\hline
+\label{average_in_vehicle_speed}
+\makecell[r]{Vitesse moyenne en véhicule \\ \textit{Average in-vehicle speed}} & \[v_{veh}\] & \[{km}/h\] & - & Vitesse moyenne d'opération des segments de la ligne ou des lignes utilisées lors du déplacement. \\
+\hline
+\label{access_egress_speed}
+\makecell[r]{Vitesse d'accès \\ \textit{Access/egress speed}} & \[v_e\] & \[{km}/h\] & - & Vitesse de marche, à vélo ou en voiture pour accéder aux arrêts à l'origine et à destination et lors des transferts. Un calcul de chemin bien calibré permet d'obtenir des vitesses plus réalistes, en tenant compte notamment des feux de circulation, de la congestion et des obstacles. \\
+\hline
+\label{od_speed}
+\makecell[r]{Vitesse OD \\ \textit{OD speed}} & \[V_{OD}\] & \[{km}/h\] & \[\frac{d_{OD}}{T_{OD}}\] & Vitesse moyenne globale d'un parcours de l'origine à la destination, en tenant compte des accès, des transferts, de tous les segments en véhicule, ainsi que de tous les temps d'arrêt et d'attente. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Fréquences et intervalles • \textit{Frequencies and periods}}
+
+\begin{longtable}{%
+  R{.29\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.05\NetTableWidth}%
+  C{.15\NetTableWidth}%
+  L{.43\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{frequency}
+\makecell[r]{Fréquence \\ \textit{Frequency}} & \[f\] & \[\text{unités}/h\] & \[\frac{60}{h}=\frac{n_u}{T_c}\] & Nombre de passages d'une unité par heure sur un parcours ou une ligne (\(T_c\) est en heures). \\
+\hline
+\label{minimum_frequency}
+\makecell[r]{Fréquence minimale \\ \textit{Minimum frequency}} & \[f_{min}\] & \[\text{unités}/h\] & \[\frac{60}{h_{max}}\] & Fréquence de service minimale selon contraintes et réglementations nationales, régionales ou locales. Cette fréquence peut être différente selon la période de service (matin, pointe du matin, journée, pointe du soir, soir, nuit, fin de semaine, etc.) \\
+\hline
+\label{minimum_peak_frequency}
+\makecell[r]{Fréquence minimale de pointe \\ \textit{Minimum peak frequency}} & \[{f_{peak}}_{min}\] & \[\text{unités}/h\] & \[\frac{60}{{h_{peak}}_{max}}\] & Fréquence de service minimale de pointe selon contraintes et réglementations nationales, régionales ou locales. \\
+\hline
+\label{minimum_off_peak_frequency}
+\makecell[r]{Fréquence minimale hors-pointe \\ \textit{Minimum off-peak frequency}} & \[{f_{off}}_{min}\] & \[\text{unités}/h\] & \[\frac{60}{{h_{off}}_{max}}\] & Fréquence de service minimale hors-pointe selon contraintes et réglementations nationales, régionales ou locales. Habituellement valable entre les pointes du matin et de l'après-midi et en soirée. \\
+\hline
+\label{way_constrained_maximum_frequency}
+\makecell[r]{Fréquence maximale contrainte de voie \\ \textit{Way constrained maximum frequency}} & \[{f_l}_{max}\] & \[\text{unités}/h\] & \[\frac{60}{{h_l}_{min}}\] & Fréquence maximale de service possible en tenant compte de la voie dans laquelle se déplace les unités affectées au parcours ou à la ligne. Cette fréquence tient compte des vitesses maximales permises, des critères de sécurité et des obstacles sur la voie (aiguillages, congestion, virages, etc.) \\
+\hline
+\label{dwell_constrained_maximum_frequency}
+\makecell[r]{Fréquence maximale contrainte d'arrêt \\ \textit{Dwell constrained maximum frequency}} & \[{f_s}_{max}\] & \[\text{unités}/h\] & \[\frac{60}{{h_s}_{min}}\] & Fréquence maximale de service possible en tenant compte de l'arrêt limitant sur le parcours ou la ligne. Tient compte de l'espace disponible aux arrêts, du nombre d'unités pouvant s'y arrêter, des temps d'arrêts prévus et des critères de sécurité. La plupart du temps, \({f_s}_{max} \ll {{f_l}_{max}}\) \\
+\hline
+\label{maximum_frequency}
+\makecell[r]{Fréquence maximale \\ \textit{Maximum frequency}} & \[f_{max}\] & \[\text{unités}/h\] & \[\min \Big({{f_s}_{max}}\ ,\ {{f_l}_{max}}\Big)\] & Fréquence maximale de service possible en tenant compte des contraintes de voie et d'arrêt. \\
+\hline
+\label{peak_frequency}
+\makecell[r]{Fréquence de pointe \\ \textit{Peak frequency}} & \[f_{peak}\] & \[\text{unités}/h\] & \[\frac{60}{h_{peak}}\] & Fréquence pendant la période de pointe maximale (fréquence maximale offerte) sur un parcours ou une ligne. \\
+\hline
+\label{ultra_peak_frequency}
+\makecell[r]{Fréquence d'ultra-pointe \\ \textit{Ultra-peak frequency}} & \[f_{up}\] & \[\text{unités}/h\] & \[\frac{60}{h_{up}}\] & Fréquence requise pendant le 15 minutes le plus achalandé de la période de pointe maximale (fréquence maximale requise) sur un parcours ou une ligne. \\
+\hline
+\label{off_peak_frequency}
+\makecell[r]{Fréquence hors-pointe \\ \textit{Off-peak frequency}} & \[f_{off}\] & \[\text{unités}/h\] & \[\frac{60}{h_{off}}\] & Fréquence pendant la période hors-pointe (fréquence offerte) sur un parcours ou une ligne. \\
+\hline
+\label{average_frequency}
+\makecell[r]{Fréquence moyenne \\ \textit{Average frequency}} & \[\overline{f}\] & \[\text{unités}/h\] & \[\frac{\sum_{i=1}^{n_\text{périodes}} {f_i}}{n_\text{périodes}}\] & Fréquence moyenne d'un ensemble de périodes de service sur un parcours ou une ligne. \\
+\hline
+\label{stop_weighted_peak_frequency}
+\makecell[r]{Fréquence de pointe pondérée par arrêt \\ \textit{Stop weighted peak frequency}} & \[{f_{peak}}_s\] ou \[{f_{peak}}_q\] & \[\text{unités}/h\] & \[\frac{\sum_{i=1}^{n_q} {f_i}}{n_q}\] & Attention de spécifier si la fréquence à chaque arrêt est la fréquence de la ligne avec la meilleure fréquence qui dessert l'arrêt ou la fréquence moyenne de toutes les lignes qui desservent l'arrêt. \\
+\hline
+\label{headway_or_period}
+\makecell[r]{Intervalle ou période \\ \textit{Headway or period}} & \[h\] & \[min\] & \[\frac{60}{f}=\frac{T_c}{n_u}\] & Intervalle de temps entre le passage consécutif de deux unités sur un parcours ou une ligne (\(T_c\) est en minutes). \\
+\hline
+\label{maximum_headway}
+\makecell[r]{Intervalle maximum \\ \textit{Maximum headway}} & \[h_{max}\] & \[min\] & \[\frac{60}{f_{min}}\] & Intervalle de service maximum selon contraintes et réglementations nationales, régionales ou locales. Cet intervalle peut être différente selon la période de service (matin, pointe du matin, journée, pointe du soir, soir, nuit, fin de semaine, etc.) \\
+\hline
+\label{maximum_peak_headway}
+\makecell[r]{Intervalle maximum de pointe \\ \textit{Maximum peak headway}} & \[{f_{peak}}_{max}\] & \[\text{unités}/h\] & \[\frac{60}{{h_{peak}}_{min}}\] & Intervalle maximum de pointe selon contraintes et réglementations nationales, régionales ou locales. \\
+\hline
+\label{maximum_off_peak_headway}
+\makecell[r]{Intervalle maximum hors-pointe \\ \textit{Maximum off-peak headway}} & \[{h_{off}}_{max}\] & \[\text{min}\] & \[\frac{60}{{f_{off}}_{min}}\] & Intervalle maximum hors-pointe selon contraintes et réglementations nationales, régionales ou locales. Habituellement valable entre les pointes du matin et de l'après-midi et en soirée. \\
+\hline
+\label{way_constrained_minimum_headway}
+\makecell[r]{Intervalle minimum selon contrainte de voie \\ \textit{Way constrained minimum headway}} & \[{h_l}_{min}\] & \[min\] & \[\frac{60}{{f_l}_{max}}\] & Intervalle minimum de service possible en tenant compte de la voie dans laquelle se déplace les unités affectées au parcours ou à la ligne. Cet intervalle tient compte des vitesses maximales permises, des critères de sécurité et des obstacles sur la voie (aiguillages, congestion, virages, etc.) \\
+\hline
+\label{dwell_constrained_minimum_headway}
+\makecell[r]{Intervalle minimum selon contrainte d'arrêt \\ \textit{Dwell constrained minimum headway}} & \[{h_s}_{min}\] & \[min\] & \[\frac{60}{{f_s}_{max}}\] & Intervalle minimum de service possible en tenant compte de l'arrêt limitant sur le parcours ou la ligne. Tient compte de l'espace disponible aux arrêts, du nombre d'unités pouvant s'y arrêter, des temps d'arrêts prévus et des critères de sécurité. La plupart du temps, \({h_s}_{min} \gg {{h_l}_{min}}\) \\
+\hline
+\label{minimum_headway}
+\makecell[r]{Intervalle minimum \\ \textit{Minimum headway}} & \[h_{min}\] & \[min\] & \[\max \Big({{h_s}_{min}}\ ,\ {{h_l}_{min}}\Big)\] & Fréquence maximale de service possible en tenant compte des contraintes de voie et d'arrêt. \\
+\hline
+\label{peak_headway}
+\makecell[r]{Intervalle de pointe \\ \textit{Peak headway}} & \[h_{peak}\] & \[min\] & \[\frac{60}{f_{peak}}\] & Intervalle pendant la période de pointe maximale (intervalle minimum offert) sur un parcours ou une ligne. \\
+\hline
+\label{ultra_peak_headway}
+\makecell[r]{Intervalle d'ultra-pointe \\ \textit{Ultra-peak headway}} & \[h_{up}\] & \[min\] & \[\frac{60}{f_{up}}\] & Intervalle requis pendant le 15 minutes le plus achalandé de la période de pointe maximale (intervalle minimum requis) sur un parcours ou une ligne. \\
+\hline
+\label{off_peak_headway}
+\makecell[r]{Intervalle hors-pointe \\ \textit{Off-peak headway}} & \[h_{off}\] & \[min\] & \[\frac{60}{f_{off}}\] & Intervalle pendant la période hors-pointe (fréquence offerte) sur un parcours ou une ligne. \\
+\hline
+\label{average_headway}
+\makecell[r]{Intervalle moyen \\ \textit{Average headway}} & \[\overline{h}\] & \[min\] & \[\frac{\sum_{i=1}^{n_\text{périodes}} {h_i}}{n_\text{périodes}}\] & Intervalle moyen d'un ensemble de périodes de service sur un parcours ou une ligne. \\
+\hline
+\label{stop_weighted_peak_headway}
+\makecell[r]{Intervalle de pointe pondéré par arrêt \\ \textit{Stop weighted peak headway}} & \[{h_{peak}}_s\] ou \[{h_{peak}}_q\] & \[min\] & \[\frac{\sum_{i=1}^{n_q} {h_i}}{n_q}\] & Attention de spécifier si l'intervalle à chaque arrêt est l'intervalle de la ligne avec le plus petit intervalle qui dessert l'arrêt ou l'intervalle moyen de toutes les lignes qui desservent l'arrêt. \\
+\hline
+\label{pulsation_headway_or_tts_headway}
+\makecell[r]{Intervalle de pulsation ou intervalle cadencé \\ \textit{Pulsation headway or TTS headway}} & \[h_p\] & \[min\] & - & Intervalle permettant de synchroniser plusieurs lignes entre elles aux points focaux (horaires cadencés ou \textit{Timed-Transfer-System - TTS}). Habituellement: 10, 15 ou 20 minutes en réseaux urbains et 30 ou 60 minutes en réseaux interurbains/régionaux. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Volumes et demande • \textit{Volumes and demand}}
+
+\begin{longtable}{%
+  R{.35\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.06\NetTableWidth}%
+  C{.1\NetTableWidth}%
+  L{.41\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{volume}
+\makecell[r]{Volume/Demande \\ \textit{Volume/Demand}} & \[P\] & \[pass/h\] & - & Nombre de passagers par heure sur un parcours, une ligne, à un arrêt, un noeud d'arrêt ou une station. \\
+\hline
+\label{number_of_boardings_at_stop}
+\makecell[r]{Nombre d'embarquements à un arrêt \\ \textit{Number of boardings at stop}} & \[n_B\] & \[pass\] & - & - \\
+\hline
+\label{number_of_alightings_at_stop}
+\makecell[r]{Nombre de débarquements à un arrêt \\ \textit{Number of alightings at stop}} & \[n_A\] & \[pass\] & - & - \\
+\hline
+\label{total_number_of_boardings}
+\makecell[r]{Nombre total d'embarquements \\ \textit{Total number of boardings}} & \[N_B\] & \[pass\] & \[\sum_{i=1}^{n_q} {{n_B}_i}\] & Nombre total d'embarquements sur un voyage d'une ligne, dans une direction. \\
+\hline
+\label{total_number_of_alightings}
+\makecell[r]{Nombre total de débarquements \\ \textit{Total number of alightings}} & \[N_A\] & \[pass\] & \[\sum_{i=1}^{n_q} {{n_A}_i}\] & Nombre total de débarquements sur un voyage d'une ligne, dans une direction. \\
+\hline
+\label{maximum_number_of_boardings_in_channel}
+\makecell[r]{Nombre d'embarquements maximum en voie d'accès \\ \textit{Maximum number of boardings in channel}} & \[{n_B}_{max}\] & \[pass\] & \[\overline{n_B} \xi_B\] & Nombre total d'embarquements à la voie d'embarquement la plus achalandée. \\
+\hline
+\label{maximum_number_of_alightings_in_channel}
+\makecell[r]{Nombre de débarquements maximum en voie d'accès \\ \textit{Maximum number of alightings in channel}} & \[{n_A}_{max}\] & \[pass\] & \[\overline{n_A} \xi_A\] & Nombre total de débarquements à la voie de débarquement la plus achalandée. \\
+\hline
+\label{average_number_of_boardings_per_channel}
+\makecell[r]{Nombre moyen d'embarquements par voie d'accès \\ \textit{Average number of boardings per channel}} & \[\overline{n_B}\] & \[pass\] & \[\frac{n_B} {{n_{Bch}}_u}\] & Nombre moyen d'embarquements par voie d'embarquement. \\
+\hline
+\label{average_number_of_alightings_per_channel}
+\makecell[r]{Nombre moyen de débarquements par voie d'accès \\ \textit{Average number of alightings per channel}} & \[\overline{n_A}\] & \[pass\] & \[\frac{n_A} {{n_{Ach}}_u}\] & Nombre moyen de débarquements par voie de débarquement. \\
+\hline
+\label{boarding_distribution_coefficient}
+\makecell[r]{Coefficient de distribution des embarquements \\ \textit{Boarding distribution coefficient}} & \[\xi_B\] & - & \[\frac{{n_B}_{max}} {\overline{n_B}}\] & Facteur permettant de déterminer la distribution des embarquements sur l'ensemble des voies d'embarquement. \\
+\hline
+\label{alighting_distribution_coefficient}
+\makecell[r]{Coefficient de distribution des débarquements \\ \textit{Alighting distribution coefficient}} & \[\xi_A\] & - & \[\frac{{n_A}_{max}} {\overline{n_A}}\] & Facteur permettant de déterminer la distribution des débarquements sur l'ensemble des voies de débarquement. \\
+\hline
+\label{maximum_volume}
+\makecell[r]{Volume maximum (horaire) \\ \textit{Maximum volume (hourly)}} & \[P_{max}\] & \[pass/h\] & - & Nombre total de passagers ayant voyagé sur le segment le plus achalandé d'une ligne, dans la direction la plus achalandée, pendant l'heure de pointe maximale. \\
+\hline
+\label{segment_volume}
+\makecell[r]{Volume de segment \\ \textit{Segment volume}} & \[P_l\] & \[pass/h\] & - & Nombre total de passagers ayant voyagé sur le segment, par heure. \\
+\hline
+\label{average_path_volume}
+\makecell[r]{Volume moyen de parcours \\ \textit{Average path volume}} & \[\overline{P_p}\] & \[pass/h\] & \[\frac{\sum_{i=1}^{{n_l}} {P_l}_i}{{n_l}}\] & Nombre moyen de passagers par segment du parcours par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{average_outbound_volume}
+\makecell[r]{Volume moyen aller \\ \textit{Average outbound volume}} & \[\overline{{P_p}^{\prime}}\] & \[pass/h\] & \[\frac{\sum_{i=1}^{{n_l}^{\prime}} {P_l}_i}{{n_l}^{\prime}}\] & Nombre moyen de passagers par segment du parcours aller par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{average_inbound_volume}
+\makecell[r]{Volume moyen retour \\ \textit{Average inbound volume}} & \[\overline{{P_p}^{\prime\prime}}\] & \[pass/h\] & \[\frac{\sum_{i=1}^{{n_l}^{\prime\prime}} {P_l}_i}{{n_l}^{\prime\prime}}\] & Nombre moyen de passagers par segment du parcours retour par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{average_line_volume}
+\makecell[r]{Volume moyen de ligne \\ \textit{Average line volume}} & \[\overline{P_L}\] & \[pass/h\] & \[\frac{\overline{{P_p}^{\prime}} + \overline{{P_p}^{\prime\prime}}}{2}\] & Nombre moyen de passagers par segment de la ligne par heure. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{maximum_load_segment}
+\makecell[r]{Segment à volume maximal \\ \textit{Maximum load segment (MLS)}} & \[l_{P_{max}}\] & - & - & Segment le plus achalandé d'une ligne, dans la direction la plus achalandée, pendant l'heure de pointe maximale. \\
+\hline
+\label{maximum_volume_stop}
+\makecell[r]{Arrêt à volume maximal \\ \textit{Maximum volume stop}} & \[s_{P_{max}}\] & - & - & Arrêt comportant le plus grand nombre d'embarquements et de débarquements pendant l'heure de pointe maximale (panneau ou plateforme unique). \\
+\hline
+\label{maximum_volume_stop_node}
+\makecell[r]{Noeud d'arrêt à volume maximal \\ \textit{Maximum volume stop node}} & \[q_{P_{max}}\] & - & - & Noeud d'arrêt comportant le plus grand nombre d'embarquements et de débarquements pendant l'heure de pointe maximale. \\
+\hline
+\label{maximum_volume_station}
+\makecell[r]{Station à volume maximal \\ \textit{Maximum volume station}} & \[S_{P_{max}}\] & - & - & Station comportant le plus grand nombre d'embarquements et de débarquements sur tous ses arrêts desservis pendant l'heure de pointe maximale. \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+  R{.25\NetTableWidth}%
+  C{.06\NetTableWidth}%
+  C{.07\NetTableWidth}%
+  C{.21\NetTableWidth}%
+  L{.41\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{ultra_peak_15_minutes_volume}
+\makecell[r]{Volume d'ultra-pointe sur 15 minutes \\ \textit{Ultra-peak 15 minutes volume}} & \[P_{up15}\] & \[pass/{{15}\ min}\] & - & Nombre total de passagers ayant voyagé sur le segment le plus achalandé d'une ligne, dans la direction la plus achalandée, pendant le 15 minute de pointe maximale. Permet d'obtenir la pointe de volume la plus précise possible. \\
+\hline
+\label{ultra_peak_volume}
+\makecell[r]{Volume d'ultra-pointe (horaire) \\ \textit{Ultra-peak volume (hourly)}} & \[P_{up}\] & \[pass/h\] & \[4 P_{up15}\] & Volume maximum sur 15 minutes extrapolé sur une heure. \\
+\hline
+\label{peak_hour_factor}
+\makecell[r]{Facteur d'heure de pointe \\ \textit{Peak-hour factor (PHF)}} & \[\gamma_{PHF}\] & - & \[\frac{P_{max}}{P_{up}} = \frac{1}{\gamma_{PHC}}\] & Facteur permettant de tenir compte du volume maximum sur 15 minutes. \(0.25 \leq \gamma_{PHF} \leq 1\). \\
+\hline
+\label{peak_hour_coefficient}
+\makecell[r]{Coefficient d'heure de pointe \\ \textit{Peak-hour coefficient (PHC)}} & \[\gamma_{PHC}\] & - & \[\frac{P_{up}}{P_{max}} = \frac{1}{\gamma_{PHF}}\] & Coefficient permettant de tenir compte du volume maximum sur 15 minutes. \(1 \leq \gamma_{PHC} \leq 4\). \\
+\hline
+\label{design_volume}
+\makecell[r]{Volume de conception \\ \textit{Design volume}} & \[P_d\] & \[pass/h\] & \[\gamma_{PHC} P_{max} = P_{up}\] & Volume utilisé pour déterminer les capacités requises sur la ligne ou le coefficient d'utilisation de la capacité offerte. \\
+\hline
+\label{daily_path_volume}
+\makecell[r]{Volume quotidien de parcours \\ \textit{Daily path volume}} & \[{{P_p}_{day}}\] & \[pass/jour\] & \[\sum_{i=0}^{23} {P_i}\] où \(P_i\) représente le volume de passagers entre l'heure \(i\) et l'heure \(i+1\) sur le parcours & Nombre de passagers par jour transportés sur le parcours, dans une direction. \\
+\hline
+\label{daily_line_volume}
+\makecell[r]{Volume quotidien de ligne \\ \textit{Daily line volume}} & \[{{P_L}_{day}}\] & \[pass/jour\] & \[\sum_{i=0}^{23} {P_i}\] où \(P_i\) représente le volume de passagers entre l'heure \(i\) et l'heure \(i+1\) & Nombre de passagers par jour transportés sur tous les voyages de la ligne. \\
+\hline
+\label{potential_demand}
+\makecell[r]{Demande potentielle \\ \textit{Potential demand}} & \[P_{pot}\] & \[pass/h\] & \[P_{lat} + P_{obs}\] & Volume de passagers qui existerait si le service et la tarification étaient optimaux. \\
+\hline
+\label{latent_demand}
+\makecell[r]{Demande latente \\ \textit{Latent demand}} & \[P_{lat}\] & \[pass/h\] & \[P_{pot} - P_{obs}\] & Demande non desservie ou non satisfaite. \\
+\hline
+\label{observed_volume}
+\makecell[r]{Volume observé \\ \textit{Observed volume}} & \[P_{obs}\] & \[pass/h\] & \[P_{pot} - P_{lat}\] & Volume de passagers observé dans le réseau ou la ligne. \\
+\hline
+\end{longtable}
+
+
+
+
+\pagebreak
+\subsection*{Capacités, travail et productivité • \textit{Capacities, work and productivity}}
+
+\begin{longtable}{%
+  R{.25\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.12\NetTableWidth}%
+  C{.15\NetTableWidth}%
+  L{.40\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{capacity}
+\makecell[r]{Capacité \\ \textit{Capacity}} & \[C\] & \[places/h\] & - & Capacité d'une ligne, dans une direction, par heure. \\
+\hline
+\label{unit_capacity}
+\makecell[r]{Capacité de l'unité \\ \textit{Unit capacity}} & \[c_u\] & \[places\] & - & Capacité d'une unité. \\
+\hline
+\label{seated_unit_capacity}
+\makecell[r]{Capacité de sièges de l'unité \\ \textit{Seated unit capacity}} & \[c_{u_{seat}}\] & \[places\] & - & Capacité de sièges d'une unité. \\
+\hline
+\label{standee_unit_capacity}
+\makecell[r]{Capacité debout de l'unité \\ \textit{Standee unit capacity}} & \[c_{u_{stand}}\] & \[places\] & - & Capacité de passagers debouts d'une unité. \\
+\hline
+\label{vehicle_capacity}
+\makecell[r]{Capacité du véhicule \\ \textit{Vehicle capacity}} & \[c_y\] & \[places\] & - & Capacité d'un véhicule. \\
+\hline
+\label{seated_vehicle_capacity}
+\makecell[r]{Capacité de sièges du véhicule \\ \textit{Seated vehicle capacity}} & \[c_{y_{seat}}\] & \[places\] & - & Capacité de sièges d'un véhicule. \\
+\hline
+\label{standee_vehicle_capacity}
+\makecell[r]{Capacité debout du véhicule \\ \textit{Standee vehcile capacity}} & \[c_{y_{stand}}\] & \[places\] & - & Capacité de passagers debouts d'un véhicule. \\
+\hline
+\label{line_capacity}
+\makecell[r]{Capacité de ligne \\ \textit{Line capacity}} & \[C_L\] & \[places/h\] & \[c_u f_{up} = \frac{60 c_u}{h_{up}} = \frac{P_d}{\alpha_c}\] & Capacité maximale offerte sur une ligne en pointe, dans une direction, en tenant compte du coefficient de confort. Cette capacité est \(\leq\) à la capacité théorique maximale qui ne tient pas compte du niveau de confort souhaité. \\
+\hline
+\label{comfort_coefficient}
+\makecell[r]{Coefficient de confort \\ \textit{Comfort coefficient/Load factor}} & \[\alpha_c\] & - & - & Coefficient permettant de déterminer le niveau de confort requis lors de la conception et du choix de la capacité offerte. Si on veut éviter les passagers debout: \(\alpha_c = c_{{u}_{seat}} / c_{u}\). Relativement confortable: \(\alpha_c = 0.7\) \\
+\hline
+\label{network_maximum_line_capacity}
+\makecell[r]{Capacité de ligne maximale de réseau \\ \textit{Network maximum line capacity}} & \[{C_L}_{max}\] & \[places/h\] & - & Capacité de la ligne qui offre la plus grande capacité dans le réseau, en pointe, dans une direction. \\
+\hline
+\label{programmed_capacity}
+\makecell[r]{Capacité programmée \\ \textit{Programmed capacity}} & \[C_p\] & \[places/h\] & - & Capacité de ligne pour une période donnée (pas nécessairement la pointe), dans une direction. \\
+\hline
+\label{line_capacity_coefficient}
+\makecell[r]{Coefficient de capacité de ligne \\ \textit{Line capacity coefficient}} & \[\delta_p\] & - & \[\frac{C_p}{C_L}\] & Ratio entre la capacité programmée pour la période donnée et la capacité de ligne en pointe. \\
+\hline
+\label{used_capacity_coefficient}
+\makecell[r]{Coefficient d'utilisation de la capacité \\ \textit{Used capacity coefficient}} & \[\alpha_u\] & - & \[\frac{\sum_{i=1}^{n_l} {P_{l_i}}}{{C_L}{n_l}}\] & Coefficient permettant d'évaluer le pourcentage d'utilisation de la capacité offerte sur une ligne, par heure. \\
+\hline
+\label{station_capacity}
+\makecell[r]{Capacité de station \\ \textit{Station capacity}} & \[C_S\] & \[places/h\] & - & Nombre de places pouvant s'arrêter à une station, par heure (toutes lignes et directions passant par la station). \\
+\hline
+\label{node_capacity}
+\makecell[r]{Capacité de noeud d'arrêt \\ \textit{Stop node capacity}} & \[C_q\] & \[places/h\] & - & Nombre de places pouvant s'arrêter à un noeud d'arrêt, par heure (toutes lignes et directions passant par le noeud). \\
+\hline
+\label{stop_capacity}
+\makecell[r]{Capacité d'arrêt \\ \textit{Stop capacity}} & \[C_s\] & \[places/h\] & - & Nombre de places pouvant s'arrêter à un arrêt (panneau ou un quai/plateforme), par heure (toutes lignes et directions passant par l'arrêt). \\
+\hline
+\label{offered_work}
+\makecell[r]{Travail offert \\ \textit{Offered work}} & \[w_o\] & \[places-km/h\] & \[C_L d_L\] & Travail offert sur la ligne dans une direction, pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{outbound_offered_work}
+\makecell[r]{Travail offert aller \\ \textit{Outbound offered work}} & \[{w_o}^{\prime}\] & \[places-km/h\] & \[C_L d^{\prime}\] & Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{inbound_offered_work}
+\makecell[r]{Travail offert retour \\ \textit{Inbound offered work}} & \[{w_o}^{\prime\prime}\] & \[places-km/h\] & \[C_L d^{\prime\prime}\] & Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{cycle_offered_work}
+\makecell[r]{Travail offert de cycle \\ \textit{Cycle offered work}} & \[{w_{o_c}}\] & \[places-km/h\] & \[{w_o}^{\prime} + {w_o}^{\prime\prime}\] & Travail total offert aller-retour (cycle complet), pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{used_work}
+\makecell[r]{Travail utilisé \\ \textit{Used work}} & \[w_u\] & \[pass-km/h\] & \[\sum_{i=1}^{n_l} {{P_l}_i {d_l}_i}\] & Travail comprenant le volume de passagers qui a utilisé les différents segments de la ligne, dans une direction. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{outbound_used_work}
+\makecell[r]{Travail utilisé aller \\ \textit{Outbound used work}} & \[{w_u}^{\prime}\] & \[pass-km/h\] & \[\sum_{i=1}^{n_l} {{P_l}_i {d_l}_i}\] où \(l_i\) sont les segments du parcours aller & Travail comprenant le volume de passagers qui a utilisé les différents segments de la ligne, en direction aller, pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{inbound_used_work}
+\makecell[r]{Travail utilisé retour \\ \textit{Inbound used work}} & \[{w_u}^{\prime\prime}\] & \[pass-km/h\] & \[\sum_{i=1}^{n_l} {{P_l}_i {d_l}_i}\] où \(l_i\) sont les segments du parcours retour & Travail comprenant le volume de passagers qui a utilisé les différents segments de la ligne, en direction retour, pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{cycle_used_work}
+\makecell[r]{Travail utilisé de cycle \\ \textit{Cycle used work}} & \[{w_{u_c}}\] & \[pass-km/h\] & \[{w_o}^{\prime} + {w_o}^{\prime\prime}\] & Travail total utilisé aller-retour (cycle complet), pendant une heure. Attention aux ambiguïtés si la ligne n'est pas bidirectionnelle symétrique. \\
+\hline
+\label{line_daily_offered_work}
+\makecell[r]{Travail offert quotidien de ligne \\ \textit{Line daily offered work}} & \[W_o\] & \[places-km/jour\] & \[\sum_{i=1}^{N_o} {w_{o_i}}\] où \(w_{o_i}\) est le travail offert par un voyage aller-retour & Travail total offert sur une ligne pendant une journée complète de service. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{line_daily_used_work}
+\makecell[r]{Travail utilisé quotidien de ligne \\ \textit{Line daily used work}} & \[W_u\] & \[pass-km/jour\] & \[\sum_{i=0}^{23} {w_{u_i}}\] où \(w_{u_i}\) est le travail utilisé sur un voyage aller-retour & Travail total utilisé par des passagers sur une ligne pendant une journée complète de service. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{network_daily_offered_work}
+\makecell[r]{Travail offert quotidien de réseau \\ \textit{Daily network offered work}} & \[W_{o_{net}}\] & \[places-km/jour\] & \[\sum_{i=1}^{N_L} {W_{o_i}}\] & Travail offert par jour sur l'ensemble des lignes du réseau. \\
+\hline
+\label{network_daily_used_work}
+\makecell[r]{Travail utilisé quotidien dans le réseau \\ \textit{Daily network used work}} & \[W_{u_{net}}\] &\[pass-km/jour\] & \[\sum_{i=1}^{N_L} {W_{u_i}}\] & Travail utilisé par jour sur l'ensemble des lignes du réseau. \\
+\hline
+\label{productive_capacity}
+\makecell[r]{Capacité productive \\ \textit{Productive capacity}} & \[Q\] & \[places-km/h^2\] & \[C_L {V_o}_L\] & Mesure de performance la plus utile, puisqu'elle tient compte autant de la capacité d'une ligne que de la vitesse d'opération offerte. La capacité productive est par heure, par direction. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\label{unit_daily_productivity}
+\makecell[r]{Productivité d'unité quotidienne \\ \textit{Unit daily productivity}} & \[w_{u}\] & \[\textit{unité}-{km}\] & \[N_o (d^{\prime} + d^{\prime\prime})\] où \(N_o\) est le nombre de voyages aller-retour par jour & Nombre de km offerts par une unité par jour. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{total_unit_daily_productivity}
+\makecell[r]{Productivité d'unités quotidienne totale \\ \textit{Total unit daily productivity}} & \[W_{u}\] & \[\textit{unités}-{km}\] & \[\sum_{i=1}^{N_{u}} {w_{{u}_i}}\] & Nombre total d'unités-km offerts par jour. Attention de spécifier de quel service il s'agit (semaine, fin de semaine, etc.). \\
+\hline
+\label{productive_volume}
+\makecell[r]{Volume productif \\ \textit{Productive volume}} & \[Q_u\] & \[pass-km/h^2\] & \[\overline{P_L} {V_o}_L\] & Tient compte du volume de passagers moyen sur la ligne. La capacité productive utilisée est par heure, par direction. Attention de mentionner la période (pointe, hors pointe, journée, etc.) \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+  R{.35\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.05\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  L{.44\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{used_work_coefficient}
+\makecell[r]{Coefficient d'utilisation du travail \\ \textit{Used work coefficient}} & \[\alpha_w\] & - & \[\frac{w_{u_c}}{w_{o_c}}\] & Permet d'évaluer le pourcentage du travail offert, par heure, qui a été utilisé par des passagers. \\
+\hline
+\label{daily_line_used_work_coefficient}
+\makecell[r]{Coefficient d'utilisation du travail quotidien de ligne \\ \textit{Daily line used work coefficient}} & \[\alpha_W\] & - & \[\frac{W_u}{W_o}\] & Permet d'évaluer le pourcentage du travail offert quotidien qui a été utilisé par des passagers. \\
+\hline
+\label{daily_network_used_work_coefficient}
+\makecell[r]{Coefficient d'utilisation du travail quotidien de réseau \\ \textit{Daily network used work coefficient}} & \[\alpha_{W_{net}}\] & - & \[\frac{W_{u_{net}}}{W_{o_{net}}}\] & Permet d'évaluer le pourcentage du travail offert quotidien qui a été utilisé par des passagers sur l'ensemble du réseau. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Coûts • \textit{Costs}}
+
+\begin{longtable}{%
+  R{.23\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.04\NetTableWidth}%
+  C{.2\NetTableWidth}%
+  L{.45\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{operating_cost_per_unit_hour}
+\makecell[r]{Coût d'opération par unité-heure \\ \textit{Operating cost per unit-hour}} & \[c_{t_o}\] & \[\$/h\] & - & Coût d'opération d'une unité par heure de fonctionnement. Attention d'inclure les temps haut-le-pied et les battements. \\
+\hline
+\label{operating_cost_per_unit_km}
+\makecell[r]{Coût d'opération par unité-km \\ \textit{Operating cost per unit-km}} & \[c_{d_o}\] & \[\$/km\] & & Coût d'opération d'une unité par km. Attention d'inclure les distances des parcours haut-le-pied. \\
+\hline
+\label{total_operating_cost}
+\makecell[r]{Coût total d'opération \\ \textit{Total operating cost}} & \[C_o\] & \[\$\] & \[\sum_{i=1}^{N_{u}} {c_{t_o} t_i}\] ou \[\sum_{i=1}^{N_{u}} {c_{d_o} d_i}\] où \(N_u\) est le nombre d'unités en service pendant la période visée. & Coût d'opération total. Attention de bien indiquer la période de service pour le calcul de \(t\) et \(d\) (heure, jour, semaine, année, etc.). \\
+\hline
+\label{total_hourly_operating_cost}
+\makecell[r]{Coût d'opération horaire total \\ \textit{Total hourly operating cost}} & \[C_{t_o}\] & \[\$\] & \[\sum_{i=1}^{N_{u}} {c_{t_o}}\] où \(N_u\) est le nombre d'unités en service pendant la période visée. & Coût d'opération moyen par heure. Habituellement calculé en pointe, hors-pointe ou sur 24h. \\
+\hline
+\label{user_hourly_cost}
+\makecell[r]{Coût usager horaire \\ \textit{User hourly cost}} & \[c_{t_u}\] & \[\$/h\] & - & Coût horaire associé aux déplacements des usagers (valeur du temps). Peut varier selon la socio-démographie et les caractéristiques de l'usager. \\
+\hline
+\label{total_user_cost}
+\makecell[r]{Coût usager total \\ \textit{Total user cost}} & \[C_u\] & \[\$\] & \[\sum_{i=1}^{N_{OD}} {c_{t_u} T_{OD}}\] & Coût usager total représentant la somme des coûts de chaque déplacement complété. Attention de bien indiquer la période de service pour le calcul de \(t\) et \({\Delta s}\) (heure, jour, semaine, année, etc.). \\
+\hline
+\label{total_hourly_user_cost}
+\makecell[r]{Coût usager horaire total \\ \textit{Total hourly user cost}} & \[C_{t_u}\] & \[\$/h\] & \[\frac{\sum_{i=1}^{N_{OD}} {c_{t_u} T_{OD}}}{\Delta t}\] où \(\Delta t\) est la durée en heures de la période visée. & Coût usager horaire total représentant la somme des coûts de chaque déplacement complété, ramenée sur une heure. Habituellement calculé en pointe, hors-pointe ou sur 24h. \\
+\hline
+\label{total_cost}
+\makecell[r]{Coût total \\ \textit{Total cost}} & \[C\] & \[\$\] & \[C_o + C_u\] & Coût total incluant les coûts d'opération et la valeur du temps pour les usagers. \\
+\hline
+\label{total_hourly_cost}
+\makecell[r]{Coût horaire total \\ \textit{Total hourly cost}} & \[C_h\] & \[\$/h\] & \[C_{t_o} + C_{t_u}\] & Coût total horaire incluant les coûts d'opération et les coûts usager. \\
+\hline
+\end{longtable}
+
+\begin{longtable}{%
+  R{.3\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  C{.04\NetTableWidth}%
+  C{.08\NetTableWidth}%
+  L{.5\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{minimum_transfer_penalty}
+\makecell[r]{Pénalité de transfert minimum \\ \textit{Minimum transfer penalty}} & \[c_t\] & \[\$\] & - & Pénalité (valeur du temps augmentée) pour chaque transfert effectué. Représente la pénibilité de transfert. \\
+\hline
+\label{transfer_access_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'accès de transfert \\ \textit{Transfer access time penalty factor}} & \[\mu_{tr}\] & - & - & Facteur par lequel on multiplie le temps d'accès de transfert. Varie en fonction de la perception de pénibilité associée aux temps d'accès entre arrêts de transfert. \\
+\hline
+\label{waiting_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'attente \\ \textit{Waiting time penalty factor}} & \[\mu_w\] & - & - & Facteur par lequel on multiplie le temps d'attente. Varie en fonction de la perception de pénibilité associée aux temps d'attente. \\
+\hline
+\label{access_egress_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'accès OD \\ \textit{Access/egress time penalty factor}} & \[\mu_{e_{OD}}\] & - & - & Facteur par lequel on multiplie le temps d'accès à l'origine et à destination. Varie en fonction de la perception de pénibilité associée aux temps d'accès à l'origine et à destination. \\
+\hline
+\label{total_access_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps d'accès total \\ \textit{Total access time penalty factor}} & \[\mu_e\] & - & - & Facteur par lequel on multiplie le temps d'accès total. Varie en fonction de la perception de pénibilité associée aux temps d'accès total (à l'origine, à destination et lors des transferts). \\
+\hline
+\label{in_vehicle_time_penalty_factor}
+\makecell[r]{Facteur de pénalité du temps en véhicule \\ \textit{In-vehicle time penalty factor}} & \[\mu_{veh}\] & - & - & Facteur par lequel on multiplie le temps en véhicule. Varie en fonction de la perception de pénibilité associée aux temps en véhicule. \\
+\hline
+\end{longtable}
+
+
+
+\pagebreak
+\subsection*{Agences, réseaux, services, horaires, déplacements et indicateurs globaux • \textit{Agencies, networks, services, schedules, user trips and global indicators}}
+
+\begin{longtable}{%
+  R{.28\NetTableWidth}%
+  C{.05\NetTableWidth}%
+  C{.15\NetTableWidth}%
+  C{.16\NetTableWidth}%
+  L{.37\NetTableWidth}%
+}
+\hline
+\makecell[r]{Définition \\ \textit{Definition}} & \makecell[c]{Symbole \\ \textit{Symbol}} & \makecell[c]{Unité \\ \textit{Unit}} & \makecell[c]{Expression \\ \textit{Expression}} & \makecell[l]{Description \\ \textit{Description}} \\ 
+\hline
+\hline
+\endhead
+\label{agency}
+\makecell[r]{Agence \\ \textit{Agency}} & \[A^G\] & - & - & Agence possédant un réseau de transport collectif \\
+\hline
+\label{network}
+\makecell[r]{Réseau \\ \textit{Network}} & \[N^T\] & - & - & Réseau de transport collectif comprenant des lignes et des services/horaires pour une ou plusieurs agences \\
+\hline
+\label{service}
+\makecell[r]{Service \\ \textit{Service}} & \[H\] &  &  & Ensemble d'horaires associés pour une période ou un type de service donné (service de semaine, de fin de semaine, de nuit, service spécial, etc.). \\
+\hline
+\label{scenario}
+\makecell[r]{Scénario \\ \textit{Scenario}} & \[H_S\] &  &  & Ensemble de services utilisé pour des fins de design, de comparaison et de simulation. \\
+\hline
+\label{user_trip}
+\makecell[r]{Déplacement \\ \textit{User trip}} & \[OD\] & - & - & Déplacement de transport collectif effectué par un usager \\
+\hline
+\label{total_number_of_user_trips}
+\makecell[r]{Nombre total de déplacements \\ \textit{Total number of user trips}} & \[N_{OD}\] & dépl. & - & Nombre total de déplacements de transport collectif effectués par l'ensemble des usagers. Préciser s'il s'agit de l'ensemble du réseau, d'une ligne ou d'un parcours, et si la période est une heure, une journée, une semaine, un an, etc. \\
+\hline
+\label{direct_user_trips}
+\makecell[r]{Nombre total de déplacements directs \\ \textit{Total number of direct user trips}} & \[N_{{OD}_d}\] & dépl. & - & Nombre total de déplacements de transport collectif effectués par l'ensemble des usagers sans transfert. Préciser s'il s'agit de l'ensemble du réseau, d'une ligne ou d'un parcours, et si la période est une heure, une journée, une semaine, un an, etc. \\
+\hline
+\label{direct_user_trips_coefficient}
+\makecell[r]{Coefficient de directivité des déplacements \\ \textit{Direct user trips coefficient}} & \[\delta_{{OD}_d}\] & - & \[\frac{N_{{OD}_d}}{N_{OD}}\] & Pourcentage des déplacements qui sont faits directement, sans transfert. \\
+\hline
+\label{urban_population}
+\makecell[r]{Population urbaine \\ \textit{Urban population}} & \[P_{urb}\] & pers. & - & Population de la région urbaine dans laquelle le réseau offre son service. \\
+\hline
+\label{number_of_transfers}
+\makecell[r]{Nombre de transferts \\ \textit{Number of transfers}} & \[n_{tr}\] & transferts & - & Nombre de transferts effectués par l'usager lors d'un parcours de transport collectif. \\
+\hline
+\label{total_number_of_transfers}
+\makecell[r]{Nombre total de transferts \\ \textit{Total number of transfers}} & \[N_{tr}\] & transferts & \[\sum_{i=1}^{} {n_{tr}}_i\] & Nombre total de transferts effectués par l'ensemble des usagers. Préciser s'il s'agit de l'ensemble du réseau, d'une ligne ou d'un parcours, et si la période est une heure, une journée, une semaine, un an, etc. \\
+\hline
+\label{urban_area}
+\makecell[r]{Superficie urbaine \\ \textit{Urban area}} & \[A_{urb}\] & \[km^2\] & - & Superficie de la région urbaine dans laquelle le réseau offre son service. \\
+\hline
+\label{transit_usage_habit}
+\makecell[r]{Habitude d'utilisation du transport collectif \\ \textit{Transit usage habit}} & \[\overline{n_{OD}}\] & \[dep\] & - & Nombre moyen de déplacements transport collectif par personne par année, incluant les non-utilisateurs du transport collectif. Cet indicateur est très souvent utillisé dans les comparaisons entre villes, mais ne tient pas compte des particularités locales, du nombre de déplacements moyen total par personne (tous modes) et des chaînes de déplacement. \\
+\hline
+\label{transit_modal_share}
+\makecell[r]{Part modale du transport collectif \\ \textit{Transit modal share}} & \[m_{transit}\] & - &- & Pourcentage des déplacements de la région urbaine effectués en transport collectif (habituellement pour la période de pointe maximale ou une journée moyenne de semaine). \\
+\hline
+\label{number_of_unique_stop_nodes}
+\makecell[r]{Nombre de noeuds d'arrêts uniques \\ \textit{Number of unique stop nodes}} & \[N_{qu}\] & noeuds & - & Nombre total de noeuds d'arrêts desservis par une seule ligne. \\
+\hline
+\label{number_of_multiple_stop_nodes}
+\makecell[r]{Nombre de noeuds d'arrêts multiples \\ \textit{Number of multiple stop nodes}} & \[N_{qm}\] & noeuds & - & Nombre total de noeuds d'arrêts desservis par plus d'une ligne. \\
+\hline
+\label{total_number_of_nodes}
+\makecell[r]{Nombre total de noeuds d'arrêts \\ \textit{Total number of nodes}} & \[N_q\] & noeuds & \[N_{qu} + N_{qm}\] & Nombre total de noeuds d'arrêts dans le réseau. Ne compter qu'une seule fois les noeuds d'arrêts desservis par plusieurs lignes (noeuds d'arrêts multiples). \\
+\hline
+\label{number_of_lines}
+\makecell[r]{Nombre de lignes \\ \textit{Number of lines}} & \[N_L\] & lignes & - & - \\
+\hline
+\label{number_of_paths}
+\makecell[r]{Nombre de parcours \\ \textit{Number of paths}} & \[N_p\] & parcours & \[\sum_{i=1}^{N_L} {n_{p_i}}\] & Nombre total de parcours sur l'ensemble des lignes du réseau. \\
+\hline
+\label{number_of_unique_segments}
+\makecell[r]{Nombre de segments uniques \\ \textit{Number of unique segments}} & \[N_{lu}\] & segments & - & Nombre total de segments desservis par une seule ligne. \\
+\hline
+\label{number_of_multiple_segments}
+\makecell[r]{Nombre de segments multiples \\ \textit{Number of multiple segments}} & \[N_{lm}\] & segments & & Nombre total de segments desservis par plus d'une ligne. \\
+\hline
+\label{total_number_of_segments}
+\makecell[r]{Nombre total de segments \\ \textit{Total number of segments}} & \[N_l\] & segments & \[N_{lu} + N_{lm}\] & - \\
+\hline
+\label{network_linear_density}
+\makecell[r]{Densité linéaire de réseau \\ \textit{Network linear density}} & \[\rho_L\] & \[{km}\ \text{de ligne}/{km}^2\] & \[\frac{d_{net}}{A_{urb}}\] & Longueur de réseau par rapport à la superficie urbaine. \\
+\hline
+\label{network_coverage_coefficient}
+\makecell[r]{Coefficient de couverture du réseau \\ \textit{Network coverage coefficient}} & \[\mu_L\] & \[km/\text{pers.}\] & \[\frac{{\Delta s}_{net}}{P_u}\] & Nombre de kilomètres de réseau par personne dans la région urbaine. \\
+\hline
+\label{line_overlap_coefficient}
+\makecell[r]{Coefficient de superposition de ligne \\ \textit{Line overlap coefficient}} & \[\lambda\] & - & \[\frac{N_{lm}}{N_l}\] & Pourcentage des segments de lignes qui desservent plus d'une ligne. \\
+\hline
+\label{number_of_depots}
+\makecell[r]{Nombre de garages \\ \textit{Number of depots}} & \[N_G\] & garages & - & Nombre de garages et dépôts dans le réseau. Attention de bien spécifier le type de garage et les types d'unités (modes) qui y sont entreposés. \\
+\hline
+\label{network_average_inter_stop_distance}
+\makecell[r]{Distance inter-arrêt moyenne de réseau \\ \textit{Network average inter-stop distance}} & \[\overline{d_{l_{net}}}\] & \[m\] & \[\frac{d_{net}}{N_l}\] & - \\
+\hline
+\label{number_of_possible_user_paths}
+\makecell[r]{Nombre de parcours possibles \\ \textit{Number of possible user paths}} & \[N_{\Delta q}\] & parcours & \[\frac{1}{2} N_q (N_q-1)\] & Nombre total de paires de noeuds d'arrêts uniques dans le réseau. \\
+\hline
+\label{number_of_possible_direct_user_paths}
+\makecell[r]{Nombre de parcours directs possibles \\ \textit{Number of possible direct user paths}} & \[N_{{\Delta q}_d}\] & parcours & \[\frac{1}{2} \Bigg( \sum_{i=1}^{N_L} {n_{q_i}(n_{q_i} - 1)}\] \[-\sum_{j=1}^{N_{Lm}-1} {n_{q_{m_j}}(n_{q_{m_j}} - 1)} \Bigg)\] & Nombre total de paires de noeuds d'arrêts uniques dans le réseau pouvant être desservies sans transfert (directs). \(N_{L_{m}}\) est le nombre de lignes qui possèdent au moins un segment commun avec une autre ligne et \(n_{q_{m_j}}\) est le nombre de stations sur chaque segment que chaque ligne \(j\) partage avec une ligne déjà comptée. \\
+\hline
+\label{number_of_possible_user_paths_with_transfers}
+\makecell[r]{Nombre de parcours avec transferts possibles \\ \textit{Number of possible user paths with transfers}} & \[N_{{\Delta q}_{tr}}\] & parcours & \[N_{\Delta q} - N_{{\Delta q}_d}\] & Nombre total de paires de noeuds d'arrêts uniques dans le réseau ne pouvant être desservies qu'avec au moins un transfert. \\
+\hline
+\label{direct_user_paths_coefficient}
+\makecell[r]{Coefficient de directivité des parcours \\ \textit{Direct user paths coefficient}} & \[\delta_{{\Delta q}_d}\] & - & \[\frac{N_{{\Delta q}_d}}{N_{\Delta q}}\] & Pourcentage des parcours possibles qui peuvent se faire directement, sans transfert. \\
+\hline
+\label{network_complexity_coefficient}
+\makecell[r]{Coefficient de complexité de réseau \\ \textit{Network complexity coefficient}} & \[\beta\] & segments/arrêt & \[\frac{N_l}{N_q}\] & Ratio du nombre de segments sur le nombre de noeuds d'arrêt. Ne pas compter deux fois les segments bidirectionnels. Prend en compte autant le nombre d'arrêts par ligne que le nombre de segments multiples. \\
+\hline
+\label{accessible_area}
+\makecell[r]{Superficie accessible \\ \textit{Accessible area}} & \[A_a\] & \[km^2\] & - & Superficie desservie par le réseau de transport collectif. Obtenu au moyen de cartes d'accessibilité qui utilisent un calculateur de transport collectif. Attention de préciser les distances ou temps d'accès maximum, les temps d'attente minimum avant l'embarquement, ainsi que la période étudiée (heure de départ ou d'arrivée). Peut se calculer autour d'un point de départ ou d'arrivée avec une heure de départ ou d'arrivée ou de manière globale si aucune limite de temps n'est fournie. \\
+\hline
+\label{network_accessibility_coefficient}
+\makecell[r]{Coefficient d'accessibilité du réseau \\ \textit{Network accessibility coefficient}} & \[\mu_a\] & - & \[\frac{A_a}{A_{urb}}\] & Pourcentage de la superficie urbaine accessible en transport collectif. \\
+\hline
+\label{stop_nodes_accessibility_radius}
+\makecell[r]{Rayon d'accès aux noeuds d'arrêts \\ \textit{Stop nodes accessibility radius}} & \[r_q\] & \[m\] & - & Cette valeur est un paramètre d'analyse des réseaux. \(r_x\) se situe habituellement entre 300 et 500m pour un arrêt de bus et entre 500 et 1000m pour une station de métro, SLR, SRB, train régional ou autre mode à grande fiabilité et à haute fréquence de service. Pour davantage de précision, un intervalle de temps d'accès en minutes est privilégiée, mais nécessite un calculeur de chemin pour obtenir les temps d'accès vers l'arrêt. \\
+\hline
+\label{stop_nodes_accessible_area}
+\makecell[r]{Superficie accessible aux noeuds d'arrêts \\ \textit{Stop nodes accessible area}} & \[A_q\] & \[m^2/station\] & \[\pi r_q^2\] & Superficie desservie par le réseau de transport collectif. Obtenu au moyen de cartes d'accessibilité qui utilisent un calculateur de chemin transport collectif. Attention de préciser les distances ou temps d'accès maximum, les temps d'attente minimum avant l'embarquement, ainsi que la période étudiée (heure de départ ou d'arrivée). Peut se calculer autour d'un point de départ ou d'arrivée avec une heure de départ ou d'arrivée ou de manière globale si aucune limite de temps n'est fournie. \\
+\hline
+\label{network_coverage_coefficient}
+\makecell[r]{Coefficient de couverture du réseau \\ \textit{Network coverage coefficient}} & \[\mu_c\] & - & \[\frac{N_q A_q}{A_u}\] si rayon d'accès unique & Pourcentage de la superficie urbaine qui comprend un noeud d'arrêt de transport collectif à l'intérieur du rayon d'accès choisi. Bien indiquer le rayon choisi, qui peut varier en fonction du type d'arrêt et du niveau de service offert à chaque arrêt. Attention aux conversions d'unités (\(km^2 \leftrightarrow m^2\)). \\
+\hline
+\label{number_of_employees}
+\makecell[r]{Nombre d'employés \\ \textit{Number of employees}} & \[N_e\] & employés & - & Nombre total d'employés dans le réseau. \\
+\hline
+\label{labor_productivity}
+\makecell[r]{Productivité de main d'oeuvre \\ \textit{Labor productivity}} & \[\eta_{We}\] & \[\text{unités}-km/\text{employé}\] & \[\frac{W_{u}}{N_e}\] & Nombre d'unités-km de service offerts par employé par jour. \\
+\hline
+\label{labor_efficiency}
+\makecell[r]{Efficacité de main d'oeuvre \\ \textit{Labor efficiency}} & \[\eta_{Ce}\] & \[\text{places}-km/\text{employé}\] & \[\frac{W_{o_{net}}} {N_e}\] & Travail offert par employé par jour. \\
+\hline
+\label{passenger_volume_efficiency}
+\makecell[r]{Efficacité de volume de passagers \\ \textit{Passenger volume efficiency}} & \[\eta_P\] & \[pass/\text{unités}-km\] & \[\frac{\sum_{i=1}^{N_L} { \overline{P_{L_{{tot}_i}}}}} {W_{u}}\] & Volume de passagers transportés sur l'ensemble des lignes par jour par unités-km. \\
+\hline
+\label{energy_consumption}
+\makecell[r]{Consommation énergétique \\ \textit{Energy consumption}} & \[E\] & \[kWh\] & - & Consommation énergétique totale. Spécifier la période (par jour, par semaine, par année, etc.) \\
+\hline
+\label{energy_efficiency}
+\makecell[r]{Efficacité énergétique \\ \textit{Energy efficency}} & \[\eta_E\] & \[kWh/\text{unités}-km\] & \[\frac{E}{W_{u}}\] & Consommation énergétique par unités-km. Spécifier la période (par jour, par semaine, par année). \\
+\hline
+\label{reliability}
+\makecell[r]{Fiabilité \\ \textit{Reliability}} & \[R\] & \[\%\] & - & Pourcentage des passages à l'heure aux arrêts par rapport aux horaires planifiés. Idéalement: entre 0 et 3 minutes de retard. En pratique habituellement: entre 1 minutes d'avance et 5 minutes de retard. \\
+\hline
+\label{trips_completion_rate}
+\makecell[r]{Taux de voyages complétés \\ \textit{Trips completion rate}} & \[R_o\] & \[\%\] & - & Pourcentage des voyages effectués par rapport aux voyages planifiés. \\
+\hline
+\end{longtable}
+
+\end{document}

--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -29,6 +29,9 @@
     },
     "dependencies": {
         "@turf/turf": "^7.1.0",
+        "@unified-latex/unified-latex-util-align": "^1.8.1",
+        "@unified-latex/unified-latex-util-parse": "^1.8.1",
+        "@unified-latex/unified-latex-util-to-string": "^1.8.1",
         "capnp-ts": "^0.4.0",
         "chaire-lib-backend": "^0.2.2",
         "chaire-lib-common": "^0.2.2",

--- a/packages/transition-backend/src/api/all.socketRoutes.ts
+++ b/packages/transition-backend/src/api/all.socketRoutes.ts
@@ -21,6 +21,7 @@ import transitPathsSocketRoutes from './transitPaths.socketRoutes';
 import placesSocketRoutes from './places.socketRoutes';
 import jobsSocketRoutes from './jobs.socketRoutes';
 import osmSocketRoutes from './osm.socketRoutes';
+import definitionsSocketRoutes from './definitions.socketRoutes';
 
 export default function (socket: EventEmitter, userId?: number) {
     dataSourcesSocketRoutes(socket, userId);
@@ -33,6 +34,7 @@ export default function (socket: EventEmitter, userId?: number) {
     odPairsSocketRoutes(socket);
     placesSocketRoutes(socket);
     osmSocketRoutes(socket);
+    definitionsSocketRoutes(socket);
 
     // Routes only to add if there is an authenticated user
     if (userId !== undefined) {

--- a/packages/transition-backend/src/api/definitions.socketRoutes.ts
+++ b/packages/transition-backend/src/api/definitions.socketRoutes.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+import { getDefinitionInAllLanguages } from '../services/documentation/Definitions';
+import { Dictionary } from 'lodash';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+
+export default function (socket: EventEmitter) {
+    socket.on(
+        'service.getOneDefinition',
+        async (label: string, callback: (status: Status.Status<Dictionary<any>>) => void) => {
+            try {
+                const definitionWithLabel = await getDefinitionInAllLanguages(label);
+                callback(Status.createOk(definitionWithLabel));
+            } catch (error) {
+                console.error(`An error occurred while fetching the definition with label '${label}': ${error}`);
+                callback(Status.createError(`Error fetching the definition with label '${label}'`));
+            }
+        }
+    );
+}

--- a/packages/transition-backend/src/services/documentation/Definitions.ts
+++ b/packages/transition-backend/src/services/documentation/Definitions.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import fs from 'fs';
+import { parse } from '@unified-latex/unified-latex-util-parse';
+import { parseAlignEnvironment } from '@unified-latex/unified-latex-util-align';
+import { toString } from '@unified-latex/unified-latex-util-to-string';
+import { Dictionary } from 'lodash';
+
+/**
+ * Get both the french and english version of a definition from the latex files.
+ * @param label The label indicating the row of the Latex document that we want to obtain as a definition.
+ * @returns A dictionary with a 'fr' and 'en' attribute.
+ */
+export const getDefinitionInAllLanguages = async (label: string): Promise<Dictionary<any>> => {
+    return {
+        fr: getDefinitionInOneLanguage('fr', label),
+        en: getDefinitionInOneLanguage('en', label)
+    };
+};
+
+/**
+ * Get a definition from one of the latex files in a specific language.
+ * @param language The language we want to get the definition in. Right now, supported for 'fr' and 'en'.
+ * @param label The label indicating the row of the Latex document that we want to obtain as a definition.
+ * @returns A dictionary containing the definition. Has a title, symbol, unit, formula, and description attribute.
+ */
+export const getDefinitionInOneLanguage = (language: string, label: string): Dictionary<any> => {
+    const latexText = readFile(language);
+    const AST = parse(latexText).content;
+    const separatedTable = getSeparatedTable(AST);
+    return getOneDefinition(separatedTable, label);
+};
+
+/**
+ * Get the content of one of the definitions latex file in string form.
+ * @param language The version of the file with a specific language we want to read. Right now, supported for 'fr' and 'en'.
+ * @returns The string content of the file.
+ */
+export const readFile = (language: string): string => {
+    const filePath = `${__dirname}/../../../file/definitions/definitions-${language}.tex`;
+    const text = fs.readFileSync(filePath, 'utf-8');
+    return text;
+};
+
+/**
+ * After parsing the latex file, return just the table rows containing the definitions we want.
+ * @param AST An array containing the parsed content of the entire latex file.
+ * @returns An array containing the data of all the definitions.
+ */
+const getSeparatedTable = (AST: any[]): any[] => {
+    let document;
+
+    for (let i = 0; i < AST.length; i++) {
+        if (AST[i]['env'] === 'document') {
+            // The element with the env attribute equal to 'document' is the informational content of the file, as opposed to the metadata and formatting info.
+            document = AST[i]['content'];
+        }
+    }
+
+    const separatedTable: any[] = [];
+
+    for (let i = 0; i < document.length; i++) {
+        // Elements with the 'longtable' env are the tables that contain the information we want.
+        if (document[i]['env'] === 'longtable') {
+            const table = document[i]['content'];
+            const parsedTable = parseAlignEnvironment(table); // This function will automatically split the table in rows and columns.
+            for (let j = 0; j < parsedTable.length; j++) {
+                // Rows with 5 cells are the ones that contain the information we want. The others are just latex syntax.
+                if (parsedTable[j].cells.length === 5) {
+                    separatedTable.push(parsedTable[j].cells);
+                }
+            }
+        }
+    }
+
+    return separatedTable;
+};
+
+/**
+ * Get a specific definition from a pre-treated array that contains all the definition data.
+ * @param separatedTable An AST (abstract syntax tree) array containing the data of all the definitions.
+ * @param label The label indicating the row of the Latex document that we want to obtain as a definition.
+ * @returns A dictionary containing the definition. Has a title, symbol, unit, formula, and description attribute. If the label could not be found, throws an error instead.
+ */
+const getOneDefinition = (separatedTable: any[], label: string): Dictionary<any> => {
+    for (let i = 0; i < separatedTable.length; i++) {
+        const row = separatedTable[i];
+        if (
+            // Depending on if this row was the first in a table or not, the label will be at a different index.
+            (row[0][1].content === 'label' && row[0][1].args[2].content[0].content === label) ||
+            (row[0][3].content === 'label' && row[0][3].args[2].content[0].content === label)
+        ) {
+            // The row contains 5 cells, each of them having one of the attributes we want.
+            return {
+                title: getTitle(row[0]),
+                // Since the symbol, unit, and formula are mathematical expressions, we have to use an extra step to obtain their content.
+                symbol: toString(row[1][1].content).trim(),
+                unit: toString(row[2][1].content).trim(),
+                formula: toString(row[3][1].content).trim(),
+                description: stringifyArray(row[4])
+            };
+        }
+    }
+
+    throw new Error(`Could not find definition with label '${label}'.`);
+};
+
+/**
+ * Get the title from the cell that contains it.
+ * @param titleCell An array representing the cell containing the title.
+ * @returns The title in string form.
+ */
+const getTitle = (titleCell: any[]): string | undefined => {
+    for (let i = 0; i < titleCell.length; i++) {
+        const node = titleCell[i];
+        // The title is contained in the specific node with the type attribute 'group'. Since the index is not constant, this loop is necessary to find it.
+        if (node.type === 'group') {
+            return stringifyArray(node.content);
+        }
+    }
+};
+
+/**
+ * Return the string content of an AST array.
+ * We use this function instead of unified-latex's toString because toString would include the english translation of the title in the italics tag for the french file,
+ * as well as return characters for long strings.
+ * @param astArray The AST array that contains the string.
+ * @returns The content of the array in string form.
+ */
+const stringifyArray = (astArray: any[]): string => {
+    let assembledString = '';
+    for (let i = 0; i < astArray.length; i++) {
+        const wordOrSpace = astArray[i];
+        if (wordOrSpace.type === 'string') {
+            assembledString += wordOrSpace.content;
+        } else if (wordOrSpace.type === 'whitespace') {
+            assembledString += ' ';
+        }
+    }
+
+    return assembledString.trim();
+};

--- a/packages/transition-backend/src/services/documentation/__tests__/Definitions.test.ts
+++ b/packages/transition-backend/src/services/documentation/__tests__/Definitions.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import * as Definitions from '../Definitions';
+
+const simpleLatex = 
+    `\\begin{document}
+    \\begin{longtable}{}
+    \\hline
+    \\makecell[r]{Définition \\\\ \\textit{Definition}} & \\makecell[c]{Symbole \\\\ \\textit{Symbol}} & \\makecell[c]{Unité \\\\ \\textit{Unit}} & \\makecell[c]{Expression \\ \\textit{Expression}} & \\makecell[l]{Description \\\\ \\textit{Description}} \\\\ 
+    \\hline
+    \\hline
+    \\endhead
+    \\label{node}
+    \\makecell[r]{Noeud d'arrêt \\\\ \\textit{Stop node}} & \\[q\\] & - & - & Regroupement de panneaux et/ou de quais d'embarquement et de débarquement situés à proximité et étant considérés comme un lieu de transfert direct lorsque plusieurs lignes s'y rencontrent. Par exemple, lorsque plusieurs panneaux d'arrêts sont situés chaque coin d'une intersection, ils représentent un seul noeud d'arrêt. \\\\
+    \\hline
+    \\label{half_cycle_time}
+    \\makecell[r]{Temps de demi-cycle \\\\ \\textit{Half-cycle time}} & \\[{T_c}_p\\] & \\[s\\] & \\[{T_o} + {t_t} \\] & Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée. \\\\
+    \\hline
+    \\end{longtable}
+    \\end{document}
+    `;
+
+const mockReadFile = jest.spyOn(Definitions, 'readFile');
+mockReadFile.mockReturnValue(simpleLatex);
+
+test('Get definitions that exist', () => {
+    const nodeDefinition = Definitions.getDefinitionInOneLanguage('fr', 'node');
+    expect(nodeDefinition).toEqual({
+        title: "Noeud d'arrêt",
+        symbol: 'q',
+        unit: '-',
+        formula: '-',
+        description: "Regroupement de panneaux et/ou de quais d'embarquement et de débarquement situés à proximité et étant considérés comme un lieu de transfert direct lorsque plusieurs lignes s'y rencontrent. Par exemple, lorsque plusieurs panneaux d'arrêts sont situés chaque coin d'une intersection, ils représentent un seul noeud d'arrêt."
+    });
+
+    const halfCycleTimeDefinition = Definitions.getDefinitionInOneLanguage('fr', 'half_cycle_time');
+    expect(halfCycleTimeDefinition).toEqual({
+        title: "Temps de demi-cycle",
+        symbol: '{T_c}_{p}',
+        unit: 's',
+        formula: '{T_o}+{t_t}',
+        description: "Temps total entre le départ du terminus de départ et la fin du battement au terminus d'arrivée."
+    });
+});
+
+test('Get definition that does not exist', () => {
+    expect(() => Definitions.getDefinitionInOneLanguage('fr', 'wrong_label')).toThrow("Could not find definition with label 'wrong_label'.")
+});

--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -57,6 +57,7 @@
     "react-spinners": "^0.9.0",
     "react-table": "^7.7.0",
     "react-tabs": "^3.2.2",
+    "react-tooltip": "^5.28.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "slugify": "^1.4.7",

--- a/packages/transition-frontend/src/components/dashboard/TransitionRightPanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionRightPanel.tsx
@@ -18,6 +18,7 @@ import GtfsExportForm from '../forms/gtfs/GtfsExportForm';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
 import PreferencesPanel from '../forms/preferences/PreferencesEdit';
+
 interface RightPanelProps extends LayoutSectionProps {
     availableRoutingModes: string[];
     parentRef?: React.RefObject<HTMLDivElement>;

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyButton.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyButton.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import Collapsible from 'react-collapsible';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import MathJax from 'react-mathjax';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
@@ -16,6 +17,7 @@ import { duplicateAgency } from 'transition-common/lib/services/agency/AgencyDup
 import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
 import ButtonList from '../../parts/ButtonList';
+import DocumentationTooltip from '../../parts/DocumentationTooltip';
 import TransitLineButton from '../line/TransitLineButton';
 import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
 import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
@@ -34,6 +36,7 @@ const TransitAgencyButton: React.FunctionComponent<AgencyButtonProps> = (props: 
     const [agencyIsHidden, setAgencyIsHidden] = React.useState(
         serviceLocator.pathLayerManager.agencyIsHidden(props.agency.getId())
     );
+
     const agencyIsSelected = (props.selectedAgency && props.selectedAgency.getId() === props.agency.getId()) || false;
 
     const onSelect: React.MouseEventHandler = async (e: React.MouseEvent) => {
@@ -137,6 +140,12 @@ const TransitAgencyButton: React.FunctionComponent<AgencyButtonProps> = (props: 
         setAgencyIsHidden(true);
     };
 
+    const stopClick: React.MouseEventHandler = React.useCallback((e: React.MouseEvent) => {
+        if (e && typeof e.stopPropagation === 'function') {
+            e.stopPropagation();
+        }
+    }, []);
+
     const isFrozen = props.agency.isFrozen();
     const lines = props.agency.getLines();
 
@@ -222,9 +231,17 @@ const TransitAgencyButton: React.FunctionComponent<AgencyButtonProps> = (props: 
             </Button>
             <div className="tr__form-agencies-panel-lines-list">
                 <Button key={`lines${props.agency.getId()}`} isSelected={agencyIsSelected} flushActionButtons={false}>
+                    <DocumentationTooltip dataTooltipId="line-tooltip" documentationLabel="line" />
                     <Collapsible
                         lazyRender={true}
-                        trigger={props.t('transit:transitLine:List')}
+                        trigger={
+                            <MathJax.Provider>
+                                {props.t('transit:transitLine:List')}&nbsp;
+                                <span onClick={stopClick}>
+                                    <MathJax.Node inline formula={'L'} data-tooltip-id="line-tooltip" />
+                                </span>
+                            </MathJax.Provider>
+                        }
                         open={props.isExpanded}
                         transitionTime={100}
                         onOpen={() => props.onAgencyExpanded(props.agency.getId())}

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import MathJax from 'react-mathjax';
 import _get from 'lodash/get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 
@@ -17,6 +18,7 @@ import Line from 'transition-common/lib/services/line/Line';
 import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollection';
 import TransitAgencyButton from './TransitAgencyButton';
 import ButtonList from '../../parts/ButtonList';
+import DocumentationTooltip from '../../parts/DocumentationTooltip';
 
 export type AgencyListState = {
     expanded: string[];
@@ -34,6 +36,7 @@ interface AgencyListProps extends WithTranslation {
 
 const TransitAgencyList: React.FunctionComponent<AgencyListProps> = (props: AgencyListProps) => {
     const [expandedAgencies, setExpandedAgencies] = React.useState(props.agenciesListState.expanded);
+
     const newAgency = function () {
         const defaultColor = Preferences.get('transit.agencies.defaultColor', '#0086FF');
         const newAgency = new Agency({ color: defaultColor }, true, serviceLocator.collectionManager);
@@ -82,8 +85,12 @@ const TransitAgencyList: React.FunctionComponent<AgencyListProps> = (props: Agen
                     className="_icon"
                     alt={props.t('transit:transitAgency:List')}
                 />{' '}
-                {props.t('transit:transitAgency:List')}
+                {props.t('transit:transitAgency:List')}&nbsp;
+                <MathJax.Provider>
+                    <MathJax.Node inline formula={'A^G'} data-tooltip-id="agency-tooltip" />
+                </MathJax.Provider>
             </h3>
+            <DocumentationTooltip dataTooltipId="agency-tooltip" documentationLabel="agency" />
             <ButtonList key="agencies">
                 {props.agencyCollection &&
                     props.agencyCollection

--- a/packages/transition-frontend/src/components/forms/node/TransitNodePanel.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodePanel.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import MathJax from 'react-mathjax';
 import { faFileUpload } from '@fortawesome/free-solid-svg-icons/faFileUpload';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
 
@@ -15,6 +16,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionDownloadButtons from 'chaire-lib-frontend/lib/components/pageParts/CollectionDownloadButtons';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import CollectionSaveToCacheButtons from '../../parts/CollectionSaveToCacheButtons';
+import DocumentationTooltip from '../../parts/DocumentationTooltip';
 import TransitNodeEdit from './TransitNodeEdit';
 import TransitNodeCollectionEdit from './TransitNodeCollectionEdit';
 import NodesImportForm from './TransitNodeImportForm';
@@ -145,14 +147,20 @@ const NodePanel: React.FunctionComponent<WithTranslation> = (props: WithTranslat
     return (
         <div id="tr__form-transit-nodes-panel" className="tr__form-transit-nodes-panel tr__panel">
             {!state.selectedNode && !state.selectedNodes && !state.selectedStation && !importerSelected && (
-                <h3>
-                    <img
-                        src={'/dist/images/icons/transit/node_white.svg'}
-                        className="_icon"
-                        alt={props.t('transit:transitNode:Nodes')}
-                    />{' '}
-                    {props.t('transit:transitNode:Nodes')}
-                </h3>
+                <>
+                    <h3>
+                        <img
+                            src={'/dist/images/icons/transit/node_white.svg'}
+                            className="_icon"
+                            alt={props.t('transit:transitNode:Nodes')}
+                        />{' '}
+                        {props.t('transit:transitNode:Nodes')}&nbsp;
+                        <MathJax.Provider>
+                            <MathJax.Node inline formula={'q'} data-tooltip-id="node-tooltip" />
+                        </MathJax.Provider>
+                    </h3>
+                    <DocumentationTooltip dataTooltipId="node-tooltip" documentationLabel="node" />
+                </>
             )}
             {state.selectedNodes && state.selectedNode && state.selectedNode.hasChanged() && (
                 <ConfirmModal

--- a/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
@@ -176,6 +176,12 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
         });
     };
 
+    const stopClick: React.MouseEventHandler = React.useCallback((e: React.MouseEvent) => {
+        if (e && typeof e.stopPropagation === 'function') {
+            e.stopPropagation();
+        }
+    }, []);
+
     const isFrozen = props.path.isFrozen();
     const halfCycleTimeSeconds = props.path.getAttributes().data.operatingTimeWithLayoverTimeSeconds;
     const halfCycleTimeMinutes = halfCycleTimeSeconds ? halfCycleTimeSeconds / 60 : undefined;
@@ -222,12 +228,14 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                     : props.t('transit:transitPath:nNode', { n: props.path.countNodes() })}
             </ButtonCell>
             {halfCycleTimeMinutes && (
-                <MathJax.Provider>
-                    <ButtonCell alignment="right">
-                        <MathJax.Node inline formula={'{T_c}_p'} />
-                        &nbsp;{Math.round(halfCycleTimeMinutes * 100) / 100}&nbsp;min
-                    </ButtonCell>
-                </MathJax.Provider>
+                <ButtonCell alignment="right">
+                    <div onClick={stopClick}>
+                        <MathJax.Provider>
+                            <MathJax.Node inline formula={'{T_c}_p'} data-tooltip-id="half-cycle-time-tooltip" />
+                        </MathJax.Provider>
+                    </div>
+                    &nbsp;{Math.round(halfCycleTimeMinutes * 100) / 100}&nbsp;min
+                </ButtonCell>
             )}
             {!props.selectedSchedule && (
                 <ButtonCell

--- a/packages/transition-frontend/src/components/forms/path/TransitPathList.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathList.tsx
@@ -6,11 +6,13 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import MathJax from 'react-mathjax';
 
 import Path from 'transition-common/lib/services/path/Path';
 import Line from 'transition-common/lib/services/line/Line';
 import TransitPathButton from './TransitPathButton';
 import ButtonList from '../../parts/ButtonList';
+import DocumentationTooltip from '../../parts/DocumentationTooltip';
 
 interface PathListProps extends WithTranslation {
     paths: Path[];
@@ -21,27 +23,34 @@ interface PathListProps extends WithTranslation {
 
 const TransitPathList: React.FunctionComponent<PathListProps> = (props: PathListProps) => {
     return (
-        <div className="tr__list-transit-paths-container">
-            <h3>
-                <img
-                    src={'/dist/images/icons/transit/path_white.svg'}
-                    className="_icon"
-                    alt={props.t('transit:transitPath:Paths')}
-                />{' '}
-                {props.t('transit:transitPath:List')}
-            </h3>
-            <ButtonList key="paths">
-                {props.paths.map((path: Path) => (
-                    <TransitPathButton
-                        line={props.line}
-                        key={path.id}
-                        path={path}
-                        selectedPath={props.selectedPath}
-                        selectedSchedule={props.selectedSchedule}
-                    />
-                ))}
-            </ButtonList>
-        </div>
+        <>
+            <div className="tr__list-transit-paths-container">
+                <h3>
+                    <img
+                        src={'/dist/images/icons/transit/path_white.svg'}
+                        className="_icon"
+                        alt={props.t('transit:transitPath:Paths')}
+                    />{' '}
+                    {props.t('transit:transitPath:List')}&nbsp;
+                    <MathJax.Provider>
+                        <MathJax.Node inline formula={'p'} data-tooltip-id="path-tooltip" />
+                    </MathJax.Provider>
+                </h3>
+                <ButtonList key="paths">
+                    {props.paths.map((path: Path) => (
+                        <TransitPathButton
+                            line={props.line}
+                            key={path.id}
+                            path={path}
+                            selectedPath={props.selectedPath}
+                            selectedSchedule={props.selectedSchedule}
+                        />
+                    ))}
+                </ButtonList>
+            </div>
+            <DocumentationTooltip dataTooltipId="half-cycle-time-tooltip" documentationLabel="half_cycle_time" />
+            <DocumentationTooltip dataTooltipId="path-tooltip" documentationLabel="path" />
+        </>
     );
 };
 

--- a/packages/transition-frontend/src/components/parts/DocumentationTooltip.tsx
+++ b/packages/transition-frontend/src/components/parts/DocumentationTooltip.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import MathJax from 'react-mathjax';
+import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
+import { getDefinitionFromServer } from '../../services/definitions/DefinitionsService';
+import { Dictionary } from 'lodash';
+import { Tooltip } from 'react-tooltip';
+
+interface DocumentationTooltipProps extends WithTranslation {
+    dataTooltipId: string; // Attaches to the html elements with the 'data-tooltip-id' property of the same value.
+    documentationLabel: string; // The label of the info we want to fetch from the Latex files.
+}
+
+// This component will fetch and display info from Latex files on the server when hovering over an element it is attached to.
+// To use, give the HTML element you want to attach it to the 'data-tooltip-id' property, setting it to a unique value.
+// Then, place the DocumentationTooltip component close to it in the html, giving the same value to the 'dataTooltipId' prop,
+// and setting the 'documentationLabel' prop to the label of the definition we want to fetch in the Latex files.
+const DocumentationTooltip: React.FunctionComponent<DocumentationTooltipProps> = (props: DocumentationTooltipProps) => {
+    const [definition, setDefinition] = React.useState({ fr: '', en: '' } as Dictionary<any>);
+
+    const [gotError, setGotError] = React.useState(false);
+
+    React.useEffect(() => {
+        getDefinitionFromServer(props.documentationLabel, setDefinition, setGotError);
+    }, []);
+
+    if (gotError) {
+        return (
+            <Tooltip
+                id={props.dataTooltipId}
+                openOnClick={true}
+                closeEvents={{ mouseleave: true }}
+                style={{ maxWidth: '90%', zIndex: 100, color: 'rgb(255, 50, 50)' }}
+                opacity={1}
+            >
+                <div>{props.t('transit:documentationTooltip:errors:DefinitionNotFound')}</div>
+            </Tooltip>
+        );
+    } else {
+        return (
+            <Tooltip
+                id={props.dataTooltipId}
+                openOnClick={true}
+                closeEvents={{ mouseleave: true }}
+                style={{ maxWidth: '90%', zIndex: 100 }}
+                opacity={1}
+            >
+                {definition.fr === '' ? (
+                    <LoadingPage />
+                ) : (
+                    <MathJax.Provider>
+                        <h3>{definition[props.i18n.language]?.title}</h3>
+                        <p>
+                            {props.t('transit:documentationTooltip:Symbol')}:{' '}
+                            <MathJax.Node inline formula={definition[props.i18n.language]?.symbol} />
+                        </p>
+                        {definition[props.i18n.language]?.unit !== '-' && (
+                            <p>
+                                {props.t('transit:documentationTooltip:Unit')}:{' '}
+                                <MathJax.Node inline formula={definition[props.i18n.language]?.unit} />
+                            </p>
+                        )}
+                        {definition[props.i18n.language]?.formula !== '-' && (
+                            <p>
+                                {props.t('transit:documentationTooltip:Expression')}:{' '}
+                                <MathJax.Node inline formula={definition[props.i18n.language]?.formula} />
+                            </p>
+                        )}
+                        <p>
+                            {props.t('transit:documentationTooltip:Description')}: {definition[props.i18n.language]?.description}
+                        </p>
+                    </MathJax.Provider>
+                )}
+            </Tooltip>
+        );
+    }
+};
+
+export default withTranslation(['transit'])(DocumentationTooltip);

--- a/packages/transition-frontend/src/services/definitions/DefinitionsService.ts
+++ b/packages/transition-frontend/src/services/definitions/DefinitionsService.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import React from 'react';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { Dictionary } from 'lodash';
+
+export const getDefinitionFromServer = (
+    label: string,
+    setDefinition: React.Dispatch<React.SetStateAction<Dictionary<string>>>,
+    setGotError: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+    serviceLocator.socketEventManager.emit(
+        'service.getOneDefinition',
+        label,
+        (definitionFromServer: Status.Status<Dictionary<any>>) => {
+            if (Status.isStatusOk(definitionFromServer)) {
+                setDefinition(Status.unwrap(definitionFromServer));
+            } else {
+                setGotError(true);
+            }
+        }
+    );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,12 +774,32 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.1.0.tgz#0a1dee4bbce87ff71602625d33f711cafd8afc08"
   integrity sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.8.tgz#aa43561be075815879305965020f492cdb43da12"
+  integrity sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.8"
+
 "@floating-ui/dom@^1.0.1":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.0.tgz#29fea1344fdef15b6ba270a733d20b7134fee5c2"
   integrity sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==
   dependencies:
     "@floating-ui/core" "^1.0.5"
+
+"@floating-ui/dom@^1.6.1":
+  version "1.6.12"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.12.tgz#6333dcb5a8ead3b2bf82f33d6bc410e95f54e556"
+  integrity sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/utils@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
 
 "@fortawesome/fontawesome-common-types@6.6.0":
   version "6.6.0"
@@ -3338,7 +3358,7 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
-"@types/geojson@*", "@types/geojson@^7946.0.10", "@types/geojson@^7946.0.14":
+"@types/geojson@*", "@types/geojson@^7946.0", "@types/geojson@^7946.0.10", "@types/geojson@^7946.0.14", "@types/geojson@^7946.0.7":
   version "7946.0.14"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
   integrity sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==
@@ -4070,6 +4090,233 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
+"@unified-latex/unified-latex-builder@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-builder/-/unified-latex-builder-1.8.0.tgz#2ba25a88fb0a4741452a6705fc80882579a002eb"
+  integrity sha512-1s5MIan/qaYeqJI1Tk3bfUwdkk0jIrQXRJt0dF0j3JWT9RG60WbiXp+593eOJgFYJtn+h3FdM0bvalfa+ZzTXg==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+
+"@unified-latex/unified-latex-ctan@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-ctan/-/unified-latex-ctan-1.8.1.tgz#4ba43906469d4e8b87684b125bf260ce6621edcd"
+  integrity sha512-doCNkEpfBClt6jVeN88d8nt3a4xt30vWHY7rKKY9JcvQC1S9I9NGsr3ebPVGYmT0sxk6gBvohPVc5Kddo027nQ==
+  dependencies:
+    "@unified-latex/unified-latex-builder" "^1.8.0"
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-argspec" "^1.8.1"
+    "@unified-latex/unified-latex-util-arguments" "^1.8.1"
+    "@unified-latex/unified-latex-util-comments" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-pegjs" "^1.8.1"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+    "@unified-latex/unified-latex-util-render-info" "^1.8.0"
+    "@unified-latex/unified-latex-util-replace" "^1.8.0"
+    "@unified-latex/unified-latex-util-scan" "^1.8.0"
+    "@unified-latex/unified-latex-util-split" "^1.8.0"
+    "@unified-latex/unified-latex-util-trim" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    color "^4.2.3"
+
+"@unified-latex/unified-latex-prettier@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-prettier/-/unified-latex-prettier-1.8.1.tgz#9133d2ba63154664b01d12b63fda0493670b0eea"
+  integrity sha512-Zc9t4Y+83xUusrh9YCvQ353nwSgI8kWKyXEJJW0upHirICPx9FX6wOrmfD9ifOIarOcwZ2mpiMK8BM6fdejTPA==
+  dependencies:
+    "@unified-latex/unified-latex-ctan" "^1.8.1"
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-align" "^1.8.1"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-parse" "^1.8.1"
+    "@unified-latex/unified-latex-util-pgfkeys" "^1.8.1"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+    "@unified-latex/unified-latex-util-trim" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    prettier "^3.0.3"
+
+"@unified-latex/unified-latex-types@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-types/-/unified-latex-types-1.8.0.tgz#7f4693c5acb6eeea86f65cd6145cdd8084adef02"
+  integrity sha512-GLJbBmmfDOWtdEbpQCLb7++zPxXin36aC9XOVCuiVNMR9VYv3szOJa+ZdTilVCFHpOeFhKh6zRws96vJgz2tGA==
+
+"@unified-latex/unified-latex-util-align@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-align/-/unified-latex-util-align-1.8.1.tgz#d4fbe6701243322f695b16bf616dcf39253af609"
+  integrity sha512-csJxLrvziRc5ZkhcRsYI7gSQBGC4fXucPtwNkTscbSIy7PfYF7BfWBPc61sb9jXQg4T4R6MLdG/Tz6Pgb6z1bw==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-pegjs" "^1.8.1"
+
+"@unified-latex/unified-latex-util-argspec@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-argspec/-/unified-latex-util-argspec-1.8.1.tgz#4935a0565182938306fdd4bf4eabdc3bd4d2673b"
+  integrity sha512-fEHtg0gUbqTCRQXsx21YA7C7CRZC+LJtPQmG4UCLVlwlfF4l9KZ0oxt0XWPIxV5bLj79otGR0nJEqdxMDuNtYA==
+  dependencies:
+    "@unified-latex/unified-latex-util-pegjs" "^1.8.1"
+
+"@unified-latex/unified-latex-util-arguments@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-arguments/-/unified-latex-util-arguments-1.8.1.tgz#5cc02ea34a61f42dcbb621546cd34344ccbcc0be"
+  integrity sha512-BrU+MOVAzrViiS3he5f9I8l3ZVL5hUEEFaFM8kvrzX3EGEfwjiFTpJu6Z0xzuYvIIxi9hkoVMr54MBFRmE1+tA==
+  dependencies:
+    "@unified-latex/unified-latex-builder" "^1.8.0"
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-argspec" "^1.8.1"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-render-info" "^1.8.0"
+    "@unified-latex/unified-latex-util-scan" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    unified "^10.1.2"
+
+"@unified-latex/unified-latex-util-catcode@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-catcode/-/unified-latex-util-catcode-1.8.0.tgz#a966738cac9064b8a50e15f846dec066f88e3f82"
+  integrity sha512-8VJX3ZpRsGl5fGsQkmL6s9oocLos7O8LPNueHhiQOfXRHLCorI5llQxDUPqDcjQ2kfM4oos/5WLGPgf6pzAIhQ==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+
+"@unified-latex/unified-latex-util-comments@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-comments/-/unified-latex-util-comments-1.8.0.tgz#f3a77dc618b296c67572402683a4f9f43c6bdd22"
+  integrity sha512-EQxcQknRbFf7nUqZ9zus6oC0zEWL1sgvziwl/nTTnSsefII0pGMKRw7jBI+Hqr4/U5+RzDYTeCIhP6FVQhHGMw==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-replace" "^1.8.0"
+
+"@unified-latex/unified-latex-util-environments@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-environments/-/unified-latex-util-environments-1.8.1.tgz#89a3d8e50ae035aed7c00993d9e2c326bba0bf0e"
+  integrity sha512-UFn6m9jbPzQm+pj/Vm46VcJ3QnUJv73JsEcRYKI8GOh7gmHKFN+hWUHinQ/IPD5da7m10A2o9eGWd4So5E5QwQ==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-arguments" "^1.8.1"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+    "@unified-latex/unified-latex-util-render-info" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    unified "^10.1.2"
+
+"@unified-latex/unified-latex-util-match@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-match/-/unified-latex-util-match-1.8.0.tgz#025b300ccd9c1a25a3a01f6e24326d2ff087b833"
+  integrity sha512-fjuLI1KVhWTHkfWn0kR8/RhM2oD2hxWhzgskUMLJ/IZMye9ESvVo8ItG4y+BtpwGFWpTmCtpMNXHjknIQxza9Q==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+
+"@unified-latex/unified-latex-util-parse@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-parse/-/unified-latex-util-parse-1.8.1.tgz#2cc3b82838c0dc4baf1c53c7f362461786a0da15"
+  integrity sha512-5fbVouRZXWtIYth5awwAd0zbO+aYEmyXGGlUeczglN8QRudhaiKe7X/ozqtBs0GnZiPeu3FbFRSelErKivVYdQ==
+  dependencies:
+    "@unified-latex/unified-latex-ctan" "^1.8.1"
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-arguments" "^1.8.1"
+    "@unified-latex/unified-latex-util-catcode" "^1.8.0"
+    "@unified-latex/unified-latex-util-environments" "^1.8.1"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-pegjs" "^1.8.1"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+    "@unified-latex/unified-latex-util-trim" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    unified "^10.1.2"
+
+"@unified-latex/unified-latex-util-pegjs@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-pegjs/-/unified-latex-util-pegjs-1.8.1.tgz#96af348e58844e8aa843d350dc191ae33d68ae6a"
+  integrity sha512-1N6WknnzKGACFCmgaEZ2j89j5C2dKhmAOCfy6moD+AMm6nUb69Xp9pJ1jDfqz+Uz9+zRo5I6ksr6q5GgmAJvtw==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+
+"@unified-latex/unified-latex-util-pgfkeys@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-pgfkeys/-/unified-latex-util-pgfkeys-1.8.1.tgz#b7dfe554444e7b6905ee204ec356cce512617a15"
+  integrity sha512-VwZeUzmPgKwO2sZ9xx4Ul0Mp82DVdWg32krOlH9dzW4ZQDOBTnRtvx6LQmg9b7Iz3F2pHLYU0LCCaJlvFNBm1A==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-pegjs" "^1.8.1"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+
+"@unified-latex/unified-latex-util-print-raw@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-print-raw/-/unified-latex-util-print-raw-1.8.0.tgz#f16942d46a0ce41f0650ef47d8d7c0e3d696bb1a"
+  integrity sha512-lMuLqnHXCDNqrjslf6hBAA2McEI+oaaxvjA9zfeAeWZyZh+DUJjkmwiuxYejwHHKbQvqzregNP4wtb9OvaC21g==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+
+"@unified-latex/unified-latex-util-render-info@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-render-info/-/unified-latex-util-render-info-1.8.0.tgz#b8589a5f435a7d085344ac0390a1b4f891c5579f"
+  integrity sha512-8rkCQ1chHBwGee/jRxM0Qtvru4Z9bv738oVmi4f+2QDnpxMMwj774EXMXnVOo982OM7e8ZTosH6IXcN6KehyzQ==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+
+"@unified-latex/unified-latex-util-replace@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-replace/-/unified-latex-util-replace-1.8.0.tgz#d4639a762a129173cd2f34b52e203c39dab4c7b8"
+  integrity sha512-F3WRwWZPbdYqy58qGpSpA0wXRh/1vdbuCK4/Gi/Mxbc/LvrzJKEc5H6lgB0SsrLgPybr3lzRmUCvuzSI3vC+3g==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-split" "^1.8.0"
+    "@unified-latex/unified-latex-util-trim" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    unified "^10.1.2"
+
+"@unified-latex/unified-latex-util-scan@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-scan/-/unified-latex-util-scan-1.8.0.tgz#8821f0f3ea79992ce62a1baa6e6f3653fae6443e"
+  integrity sha512-4WWDTcLOhlkZsGmGl/IZA0Jg2rTitVwGf6ktxs57AyuCEdzHA5ZeNwzSewW8wpHQdLfnPX+LNEnaukwEdWfF1g==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+    trie-prefix-tree "^1.5.1"
+
+"@unified-latex/unified-latex-util-split@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-split/-/unified-latex-util-split-1.8.0.tgz#90faa432a420fc70b9247587c85c513635a76eab"
+  integrity sha512-gRlRge72wcvLRs6bEoVbh0fDACbkioEPDJOr7XaCuQqjNNu1VTXlcvImZQVXCdMG6CJ4lqiaJRwnUupK4rsmsA==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+
+"@unified-latex/unified-latex-util-to-string@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-to-string/-/unified-latex-util-to-string-1.8.1.tgz#6ff49777f724719c9c468f221111b2176362f959"
+  integrity sha512-5/fgMgrZa1a2tzGTC4hMB42O3oht+kV1lF9fnzsra9tLA45w69hm1BbC7GA2Q2cE1EFGCA6UTfcAaBkfY77fWA==
+  dependencies:
+    "@unified-latex/unified-latex-prettier" "^1.8.1"
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-print-raw" "^1.8.0"
+    prettier "^2.8.8"
+    unified "^10.1.2"
+
+"@unified-latex/unified-latex-util-trim@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-trim/-/unified-latex-util-trim-1.8.0.tgz#f4b211e5ff5a0c11ac8b264a223ba87d2e440417"
+  integrity sha512-jZYPJxkZkcQV49lOMJonGD7G3tgUFyJ0A54AGb0Rvpj05feaCzTL5TN7GGiow0pfAqpnolGDcCVmtFm8nlrmAA==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
+    "@unified-latex/unified-latex-util-visit" "^1.8.0"
+    unified "^10.1.2"
+
+"@unified-latex/unified-latex-util-visit@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@unified-latex/unified-latex-util-visit/-/unified-latex-util-visit-1.8.0.tgz#8f4408b8a10e02e2dc7c6eb9dba01fdbe2875daf"
+  integrity sha512-kCmeZMQCC5yRUzTLW30Ulr1RvsXVJ2ar2JB9OWSzu3oXRNVcB7Ga34GGGQuBhS7WXEqcqcqAiArfgJKdA1yIIA==
+  dependencies:
+    "@unified-latex/unified-latex-types" "^1.8.0"
+    "@unified-latex/unified-latex-util-match" "^1.8.0"
 
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
@@ -5108,6 +5355,11 @@ classnames@^2.2.1:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
+classnames@^2.3.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 clean-css@^5.2.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"
@@ -5236,6 +5488,14 @@ color-string@^1.5.2:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@3.0.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
@@ -5243,6 +5503,14 @@ color@3.0.x:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@2.0.19:
   version "2.0.19"
@@ -11165,10 +11433,15 @@ prettier-eslint-cli@^8.0.1:
     rxjs "^7.8.1"
     yargs "^17.7.2"
 
-prettier@^3.0.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
-  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+prettier@^3.0.1, prettier@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 pretty-error@^4.0.0:
   version "4.0.0"
@@ -11753,6 +12026,14 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.13.1:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-tooltip@^5.28.0:
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.28.0.tgz#c7b5343ab2d740a428494a3d8315515af1f26f46"
+  integrity sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==
+  dependencies:
+    "@floating-ui/dom" "^1.6.1"
+    classnames "^2.3.0"
 
 react-transition-group@^4.3.0:
   version "4.4.1"
@@ -12827,7 +13108,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12853,15 +13134,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -12994,7 +13266,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13021,13 +13293,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -13375,6 +13640,11 @@ traverse@~0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
+trie-prefix-tree@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/trie-prefix-tree/-/trie-prefix-tree-1.5.1.tgz#209c91f0e66cde53af2c5de8aceeca5558cdf03d"
+  integrity sha512-Jjvj/dA97wXnabG/NLJUgo4IQMj6vucH+Qxm7of/omfWSmZlPqdRU6Ta4GmQqCZH+n3/iYZUwfvUoEhB0Hs83Q==
+
 trim-lines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
@@ -13624,7 +13894,7 @@ unicorn-magic@^0.1.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
-unified@^10.0.0:
+unified@^10.0.0, unified@^10.1.2:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-10.1.2.tgz#b1d64e55dafe1f0b98bb6c719881103ecf6c86df"
   integrity sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==
@@ -14118,7 +14388,7 @@ workerpool@^6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14140,15 +14410,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Add Latex documentation to the server, and send definitions to the client that can then be displayed when clicking on specific symbols thanks to a new React tooltip component.
Adds this tooltip to Agencies, Lines, Paths, half cycle time, and Stop Nodes.
Fix: #136 

Examples:
![image](https://github.com/user-attachments/assets/73fc3672-d7c7-4aa2-aa7d-93bf38d350ad)
![image](https://github.com/user-attachments/assets/3bad0e8e-bdc2-415d-8faf-f48a68f92228)

