### PR TITLE
Clean up withTranslation()

### DIFF
--- a/packages/chaire-lib-frontend/src/components/dashboard/BottomPanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/BottomPanel.tsx
@@ -32,4 +32,4 @@ const BottomPanel: React.FunctionComponent<BottomPanelProps> = ({ contributions,
     return <section id="tr__bottom-panel">{contributionElements}</section>;
 };
 
-export default withTranslation(['transit', 'main'])(BottomPanel);
+export default withTranslation()(BottomPanel);

--- a/packages/chaire-lib-frontend/src/components/dashboard/BottomPanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/BottomPanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import { Contribution, LayoutSectionProps } from '../../services/dashboard/DashboardContribution';
 
@@ -32,4 +31,4 @@ const BottomPanel: React.FunctionComponent<BottomPanelProps> = ({ contributions,
     return <section id="tr__bottom-panel">{contributionElements}</section>;
 };
 
-export default withTranslation()(BottomPanel);
+export default BottomPanel;

--- a/packages/chaire-lib-frontend/src/components/dashboard/FullSizePanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/FullSizePanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import { Contribution, LayoutSectionProps } from '../../services/dashboard/DashboardContribution';
 
@@ -38,4 +37,4 @@ const FullSizePanel: React.FunctionComponent<FullSizePanelProps> = ({
     return <section id="tr__full-size-panel">{contributionElements}</section>;
 };
 
-export default withTranslation()(FullSizePanel);
+export default FullSizePanel;

--- a/packages/chaire-lib-frontend/src/components/dashboard/FullSizePanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/FullSizePanel.tsx
@@ -38,4 +38,4 @@ const FullSizePanel: React.FunctionComponent<FullSizePanelProps> = ({
     return <section id="tr__full-size-panel">{contributionElements}</section>;
 };
 
-export default withTranslation(['transit', 'main'])(FullSizePanel);
+export default withTranslation()(FullSizePanel);

--- a/packages/chaire-lib-frontend/src/components/dashboard/MenuBar.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/MenuBar.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import { Contribution, LayoutSectionProps } from '../../services/dashboard/DashboardContribution';
 
@@ -31,4 +30,4 @@ const MenuBar: React.FunctionComponent<MenuBarProps> = ({ contributions, ...prop
     return <nav id="tr__left-menu">{contributionElements}</nav>;
 };
 
-export default withTranslation()(MenuBar);
+export default MenuBar;

--- a/packages/chaire-lib-frontend/src/components/dashboard/MenuBar.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/MenuBar.tsx
@@ -31,4 +31,4 @@ const MenuBar: React.FunctionComponent<MenuBarProps> = ({ contributions, ...prop
     return <nav id="tr__left-menu">{contributionElements}</nav>;
 };
 
-export default withTranslation(['transit', 'main'])(MenuBar);
+export default withTranslation()(MenuBar);

--- a/packages/chaire-lib-frontend/src/components/dashboard/NotificationArea.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/NotificationArea.tsx
@@ -77,4 +77,4 @@ const NotificationArea: React.FunctionComponent<WithTranslation> = (props: WithT
     );
 };
 
-export default withTranslation([])(NotificationArea);
+export default withTranslation()(NotificationArea);

--- a/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
@@ -47,4 +47,4 @@ const RightPanel: React.FunctionComponent<RightPanelProps> = ({ contributions, .
     );
 };
 
-export default withTranslation(['transit', 'main'])(RightPanel);
+export default withTranslation()(RightPanel);

--- a/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import { Contribution, LayoutSectionProps, PanelSectionProps } from '../../services/dashboard/DashboardContribution';
 import ErrorBoundary from '../pageParts/ErrorBoundary';
@@ -47,4 +46,4 @@ const RightPanel: React.FunctionComponent<RightPanelProps> = ({ contributions, .
     );
 };
 
-export default withTranslation()(RightPanel);
+export default RightPanel;

--- a/packages/chaire-lib-frontend/src/components/dashboard/Toolbar.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/Toolbar.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import { Contribution, LayoutSectionProps } from '../../services/dashboard/DashboardContribution';
 import NotificationArea from './NotificationArea';
@@ -37,4 +36,4 @@ const Toolbar: React.FunctionComponent<MenuBarProps> = ({ contributions, ...prop
     );
 };
 
-export default withTranslation()(Toolbar);
+export default Toolbar;

--- a/packages/chaire-lib-frontend/src/components/dashboard/Toolbar.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/Toolbar.tsx
@@ -37,4 +37,4 @@ const Toolbar: React.FunctionComponent<MenuBarProps> = ({ contributions, ...prop
     );
 };
 
-export default withTranslation(['transit', 'main'])(Toolbar);
+export default withTranslation()(Toolbar);

--- a/packages/chaire-lib-frontend/src/components/dashboard/__tests__/__snapshots__/BottomPanel.test.tsx.snap
+++ b/packages/chaire-lib-frontend/src/components/dashboard/__tests__/__snapshots__/BottomPanel.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Active section change 1`] = `
-<withI18nextTranslation(BottomPanel)
+<BottomPanel
   activeSection="test"
   contributions={
     [
@@ -25,49 +25,21 @@ exports[`Active section change 1`] = `
     ]
   }
 >
-  <BottomPanel
-    activeSection="test"
-    contributions={
-      [
-        {
-          "create": [Function],
-          "id": "testBottomPanel",
-          "placement": "bottomPanel",
-          "section": "test",
-        },
-        {
-          "create": [Function],
-          "id": "mainBottomPanel",
-          "placement": "bottomPanel",
-        },
-        {
-          "create": [Function],
-          "id": "fooBottomPanel",
-          "placement": "bottomPanel",
-          "section": "foo",
-        },
-      ]
-    }
-    i18n={{}}
-    t={[Function]}
-    tReady={false}
+  <section
+    id="tr__bottom-panel"
   >
-    <section
-      id="tr__bottom-panel"
-    >
-      <div>
-        test
-      </div>
-      <div>
-        Should always be there
-      </div>
-    </section>
-  </BottomPanel>
-</withI18nextTranslation(BottomPanel)>
+    <div>
+      test
+    </div>
+    <div>
+      Should always be there
+    </div>
+  </section>
+</BottomPanel>
 `;
 
 exports[`Active section change 2`] = `
-<withI18nextTranslation(BottomPanel)
+<BottomPanel
   activeSection="other"
   contributions={
     [
@@ -91,42 +63,14 @@ exports[`Active section change 2`] = `
     ]
   }
 >
-  <BottomPanel
-    activeSection="other"
-    contributions={
-      [
-        {
-          "create": [Function],
-          "id": "testBottomPanel",
-          "placement": "bottomPanel",
-          "section": "test",
-        },
-        {
-          "create": [Function],
-          "id": "mainBottomPanel",
-          "placement": "bottomPanel",
-        },
-        {
-          "create": [Function],
-          "id": "fooBottomPanel",
-          "placement": "bottomPanel",
-          "section": "foo",
-        },
-      ]
-    }
-    i18n={{}}
-    t={[Function]}
-    tReady={false}
+  <section
+    id="tr__bottom-panel"
   >
-    <section
-      id="tr__bottom-panel"
-    >
-      <div>
-        Should always be there
-      </div>
-    </section>
-  </BottomPanel>
-</withI18nextTranslation(BottomPanel)>
+    <div>
+      Should always be there
+    </div>
+  </section>
+</BottomPanel>
 `;
 
 exports[`One active section with contribution 1`] = `
@@ -151,9 +95,6 @@ exports[`One active section with contribution and props 1`] = `
   </div>
   <div
     activeSection="foo"
-    i18n={{}}
-    t={[Function]}
-    tReady={false}
   >
     Foo section, with props
   </div>

--- a/packages/chaire-lib-frontend/src/components/forms/auth/anonymous/AnonymousLogin.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/anonymous/AnonymousLogin.tsx
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { withTranslation, WithTranslation } from 'react-i18next';
 import { History, Location } from 'history';
 
 import { startAnonymousLogin } from '../../../../actions/Auth';
@@ -19,9 +18,7 @@ export interface AnonymousLoginProps {
     login?: boolean;
 }
 
-export const AnonymousLogin: React.FunctionComponent<AnonymousLoginProps & WithTranslation> = (
-    props: AnonymousLoginProps & WithTranslation
-) => {
+export const AnonymousLogin: React.FunctionComponent<AnonymousLoginProps> = (props: AnonymousLoginProps) => {
     React.useEffect(() => {
         props.startAnonymousLogin();
     }, []);
@@ -37,4 +34,4 @@ const mapDispatchToProps = (dispatch, props: Omit<AnonymousLoginProps, 'startAno
         dispatch(startAnonymousLogin(props.history, props.location, callback))
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(AnonymousLogin));
+export default connect(mapStateToProps, mapDispatchToProps)(AnonymousLogin);

--- a/packages/chaire-lib-frontend/src/components/forms/auth/anonymous/AnonymousLogin.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/anonymous/AnonymousLogin.tsx
@@ -37,4 +37,4 @@ const mapDispatchToProps = (dispatch, props: Omit<AnonymousLoginProps, 'startAno
         dispatch(startAnonymousLogin(props.history, props.location, callback))
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation('auth')(AnonymousLogin));
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(AnonymousLogin));

--- a/packages/chaire-lib-frontend/src/components/input/DayRange.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/DayRange.tsx
@@ -125,4 +125,4 @@ export class DayRange extends React.Component<DayRangeProps> {
     }
 }
 
-export default withTranslation(['main'])(DayRange);
+export default withTranslation('main')(DayRange);

--- a/packages/chaire-lib-frontend/src/components/input/InputCheckbox.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/InputCheckbox.tsx
@@ -267,6 +267,6 @@ class InputCheckboxBooleanInner extends React.Component<InputCheckboxBoolProps> 
     }
 }
 
-export const InputCheckboxBoolean = withTranslation(['main'])(InputCheckboxBooleanInner);
+export const InputCheckboxBoolean = withTranslation('main')(InputCheckboxBooleanInner);
 
 export default InputCheckbox;

--- a/packages/chaire-lib-frontend/src/components/modal/ConfirmModal.tsx
+++ b/packages/chaire-lib-frontend/src/components/modal/ConfirmModal.tsx
@@ -113,4 +113,4 @@ export class ConfirmModal extends React.Component<ConfirmModalProps> {
     }
 }
 
-export default withTranslation()(ConfirmModal);
+export default withTranslation('main')(ConfirmModal);

--- a/packages/chaire-lib-frontend/src/components/pageParts/CollectionDownloadButtons.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/CollectionDownloadButtons.tsx
@@ -120,4 +120,4 @@ const CollectionDownloadButtons = function (props: CollectionDownloadButtonsProp
     );
 };
 
-export default withTranslation('main')(CollectionDownloadButtons);
+export default withTranslation()(CollectionDownloadButtons);

--- a/packages/chaire-lib-frontend/src/components/pageParts/CollectionDownloadButtons.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/CollectionDownloadButtons.tsx
@@ -8,13 +8,12 @@ import React from 'react';
 import { faFileDownload } from '@fortawesome/free-solid-svg-icons/faFileDownload';
 import moment from 'moment';
 import { unparse } from 'papaparse';
-import { withTranslation, WithTranslation } from 'react-i18next';
 
 import Button from '../input/Button';
 import DownloadsUtils from '../../services/DownloadsService';
 import GenericCollection from 'chaire-lib-common/lib/utils/objects/GenericCollection';
 
-export interface CollectionDownloadButtonsProps extends WithTranslation {
+export interface CollectionDownloadButtonsProps {
     collection: GenericCollection<any>;
 }
 
@@ -120,4 +119,4 @@ const CollectionDownloadButtons = function (props: CollectionDownloadButtonsProp
     );
 };
 
-export default withTranslation()(CollectionDownloadButtons);
+export default CollectionDownloadButtons;

--- a/packages/chaire-lib-frontend/src/components/pageParts/DistanceUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/DistanceUnitFormatter.tsx
@@ -59,4 +59,4 @@ const DistanceUnitFormatter: React.FunctionComponent<DistanceUnitFormatterProps>
     return <span onClick={cycleThroughDestinationUnits}>{formattedValue}</span>;
 };
 
-export default withTranslation([])(DistanceUnitFormatter);
+export default withTranslation('main')(DistanceUnitFormatter);

--- a/packages/chaire-lib-frontend/src/components/pageParts/DurationUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/DurationUnitFormatter.tsx
@@ -65,4 +65,4 @@ const DurationUnitFormatter: React.FunctionComponent<DurationUnitFormatterProps>
     return <span onClick={cycleThroughDestinationUnits}>{formattedValue}</span>;
 };
 
-export default withTranslation([])(DurationUnitFormatter);
+export default withTranslation('main')(DurationUnitFormatter);

--- a/packages/chaire-lib-frontend/src/components/pageParts/FormErrors.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/FormErrors.tsx
@@ -47,4 +47,4 @@ const FormErrors: React.FunctionComponent<FormErrorsProps> = (props: FormErrorsP
     }
 };
 
-export default withTranslation([])(FormErrors);
+export default withTranslation('auth')(FormErrors);

--- a/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
@@ -74,7 +74,7 @@ const UserMenuButton: React.FunctionComponent<UserMenuButtonProps & WithTranslat
         </React.Fragment>
     );
 };
-const TranslatableUserMenuButton = withTranslation('menu')(UserMenuButton);
+const TranslatableUserMenuButton = withTranslation()(UserMenuButton);
 
 interface UserMenuProps {
     user: CliUser;
@@ -115,7 +115,7 @@ const UserMenu: React.FunctionComponent<UserMenuProps & WithTranslation> = (prop
         </div>
     );
 };
-const TranslatableUserMenu = withTranslation('menu')(UserMenu);
+const TranslatableUserMenu = withTranslation()(UserMenu);
 
 const User: React.FunctionComponent<UserProps & WithTranslation> = (props: UserProps & WithTranslation) => {
     const [display, setDisplay] = React.useState('none');

--- a/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
@@ -17,7 +17,7 @@ import appConfiguration, { UserMenuItem } from '../../config/application.config'
 import { History } from 'history';
 import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 
-export interface HeaderProps extends WithTranslation {
+interface HeaderProps {
     user: CliUser;
     path: any;
     startLogout: () => void;
@@ -25,19 +25,17 @@ export interface HeaderProps extends WithTranslation {
     history: History;
 }
 
-interface UserProps {
+interface UserProps extends WithTranslation {
     user: CliUser;
 }
 
-interface UserMenuButtonProps {
+interface UserMenuButtonProps extends WithTranslation {
     menuItem: UserMenuItem;
     modalOpenedCallback: (isOpened: boolean) => void;
     closeMenu: () => void;
 }
 
-const UserMenuButton: React.FunctionComponent<UserMenuButtonProps & WithTranslation> = (
-    props: UserMenuButtonProps & WithTranslation
-) => {
+const UserMenuButton: React.FunctionComponent<UserMenuButtonProps> = (props: UserMenuButtonProps) => {
     const [modalIsOpened, setModalIsOpened] = React.useState(false);
     const toggleModal = (opened: boolean) => {
         setModalIsOpened(opened);
@@ -82,7 +80,7 @@ interface UserMenuProps {
     closeMenu: () => void;
 }
 
-const UserMenu: React.FunctionComponent<UserMenuProps & WithTranslation> = (props: UserMenuProps & WithTranslation) => {
+const UserMenu: React.FunctionComponent<UserMenuProps> = (props: UserMenuProps) => {
     const [hasModalOpened, setHasModalOpened] = React.useState(false);
     React.useLayoutEffect(() => {
         function handleClickOutside(event) {
@@ -115,9 +113,8 @@ const UserMenu: React.FunctionComponent<UserMenuProps & WithTranslation> = (prop
         </div>
     );
 };
-const TranslatableUserMenu = withTranslation()(UserMenu);
 
-const User: React.FunctionComponent<UserProps & WithTranslation> = (props: UserProps & WithTranslation) => {
+const User: React.FunctionComponent<UserProps> = (props: UserProps) => {
     const [display, setDisplay] = React.useState('none');
     const wrapperRef = React.useRef(null);
     return (
@@ -134,7 +131,7 @@ const User: React.FunctionComponent<UserProps & WithTranslation> = (props: UserP
                 {props.user.username || props.user.email || props.t('menu:User')}
             </button>
             {display !== 'none' && (
-                <TranslatableUserMenu wrapperRef={wrapperRef} user={props.user} closeMenu={() => setDisplay('none')} />
+                <UserMenu wrapperRef={wrapperRef} user={props.user} closeMenu={() => setDisplay('none')} />
             )}
         </li>
     );
@@ -142,7 +139,7 @@ const User: React.FunctionComponent<UserProps & WithTranslation> = (props: UserP
 
 const TranslatableUser = withTranslation('menu')(User);
 
-const Header: React.FunctionComponent<HeaderProps> = (props: HeaderProps) => {
+const Header: React.FunctionComponent<HeaderProps & WithTranslation> = (props: HeaderProps & WithTranslation) => {
     const appTitle = config.appTitle;
     const title = config.title[props.i18n.language];
     return (

--- a/packages/chaire-lib-frontend/src/components/pageParts/SelectedObjectButtons.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/SelectedObjectButtons.tsx
@@ -195,4 +195,4 @@ const SelectedObjectButtons: React.FunctionComponent<SelectedObjectButtonsProps<
     );
 };
 
-export default withTranslation([])(SelectedObjectButtons);
+export default withTranslation(['main', 'notifications'])(SelectedObjectButtons);

--- a/packages/chaire-lib-frontend/src/components/pageParts/SpeedUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/SpeedUnitFormatter.tsx
@@ -54,4 +54,4 @@ const SpeedUnitFormatter: React.FunctionComponent<SpeedUnitFormatterProps> = (pr
     return <span onClick={cycleThroughDestinationUnits}>{formattedValue}</span>;
 };
 
-export default withTranslation([])(SpeedUnitFormatter);
+export default withTranslation('main')(SpeedUnitFormatter);

--- a/packages/chaire-lib-frontend/src/components/pageParts/admin/users/UsersComponent.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/admin/users/UsersComponent.tsx
@@ -120,4 +120,4 @@ const UsersComponent: React.FunctionComponent<WithTranslation> = (props: WithTra
     );
 };
 
-export default withTranslation(['admin', 'main'])(UsersComponent);
+export default withTranslation('admin')(UsersComponent);

--- a/packages/chaire-lib-frontend/src/components/pages/MaintenancePage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/MaintenancePage.tsx
@@ -14,10 +14,10 @@ interface MaintenancePageProps extends WithTranslation {
 
 export const MaintenancePage: React.FunctionComponent<MaintenancePageProps> = (props: MaintenancePageProps) => (
     <div>
-        {props.t('Maintenance')}
+        {props.t('auth:Maintenance')}
         <br />
-        <Link to={props.linkPath ? props.linkPath : '/home'}>{props.t('BackToHomePage')}</Link>
+        <Link to={props.linkPath ? props.linkPath : '/home'}>{props.t('auth:BackToHomePage')}</Link>
     </div>
 );
 
-export default withTranslation(['auth'])(MaintenancePage);
+export default withTranslation('auth')(MaintenancePage);

--- a/packages/chaire-lib-frontend/src/components/pages/NotFoundPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/NotFoundPage.tsx
@@ -10,8 +10,8 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 export const NotFoundPage: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => (
     <div>
-        404 - <Link to="/">{props.t('BackToHomePage')}</Link>
+        404 - <Link to="/">{props.t('auth:BackToHomePage')}</Link>
     </div>
 );
 
-export default withTranslation(['auth'])(NotFoundPage);
+export default withTranslation('auth')(NotFoundPage);

--- a/packages/chaire-lib-frontend/src/components/pages/ResetPasswordPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/ResetPasswordPage.tsx
@@ -45,7 +45,7 @@ const SimpleMessage: React.FunctionComponent<SimpleMessageProps> = (props: Simpl
     );
 };
 
-const SimpleMessageWidget = withTranslation()(SimpleMessage);
+const SimpleMessageWidget = withTranslation('auth')(SimpleMessage);
 
 export class ResetPasswordPage extends React.Component<ResetPasswordPageProps, ResetPasswordState> {
     private submitButtonRef;

--- a/packages/chaire-lib-frontend/src/components/pages/UnauthorizedPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/UnauthorizedPage.tsx
@@ -10,8 +10,8 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 
 export const UnauthorizedPage: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => (
     <div>
-        {props.t('Unauthorized')} - <Link to="/login">{props.t('BackToLoginPage')}</Link>
+        {props.t('auth:Unauthorized')} - <Link to="/login">{props.t('auth:BackToLoginPage')}</Link>
     </div>
 );
 
-export default withTranslation(['auth'])(UnauthorizedPage);
+export default withTranslation('auth')(UnauthorizedPage);

--- a/packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/NotFoundPage.test.tsx.snap
+++ b/packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/NotFoundPage.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Should correctly render NotFound page 1`] = `
                 href="/"
                 onClick={[Function]}
               >
-                BackToHomePage
+                auth:BackToHomePage
               </a>
             </LinkAnchor>
           </Link>

--- a/packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/UnauthorizedPage.test.tsx.snap
+++ b/packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/UnauthorizedPage.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Should correctly render Unauthorized page 1`] = `
         tReady={false}
       >
         <div>
-          Unauthorized
+          auth:Unauthorized
            - 
           <Link
             to="/login"
@@ -44,7 +44,7 @@ exports[`Should correctly render Unauthorized page 1`] = `
                 href="/login"
                 onClick={[Function]}
               >
-                BackToLoginPage
+                auth:BackToLoginPage
               </a>
             </LinkAnchor>
           </Link>

--- a/packages/chaire-lib-frontend/src/components/pages/admin/UsersPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/admin/UsersPage.tsx
@@ -5,12 +5,11 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
 import { History } from 'history';
 import Loadable from 'react-loadable';
 import Loader from 'react-spinners/HashLoader';
 
-export interface UsersPageProps extends WithTranslation {
+export interface UsersPageProps {
     isAuthenticated: boolean;
     history: History;
     // TODO Type the user
@@ -44,4 +43,4 @@ class UsersPage extends React.Component<UsersPageProps> {
     }
 }
 
-export default withTranslation()(UsersPage);
+export default UsersPage;

--- a/packages/chaire-lib-frontend/src/services/dashboard/DashboardContribution.ts
+++ b/packages/chaire-lib-frontend/src/services/dashboard/DashboardContribution.ts
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { WithTranslation } from 'react-i18next';
 
 /** These are various locations in the layout where a widget can be drawn.
  *
@@ -23,7 +22,7 @@ export type layoutPieces = 'menu' | 'toolbar' | 'primarySidebar' | 'secondarySid
  * @interface LayoutSectionProps
  * @extends {WithTranslation}
  */
-export interface LayoutSectionProps extends WithTranslation {
+export interface LayoutSectionProps {
     activeSection: string;
     key?: string;
 }

--- a/packages/transition-frontend/src/components/dashboard/TransitionBottomPanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionBottomPanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import TransitPathNodesList from '../forms/path/TransitPathNodeList';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
@@ -32,4 +31,4 @@ const BottomPanel: React.FunctionComponent<LayoutSectionProps> = (props: LayoutS
     return <React.Fragment>{path.path && <TransitPathNodesList selectedPath={path.path} />}</React.Fragment>;
 };
 
-export default withTranslation()(BottomPanel);
+export default BottomPanel;

--- a/packages/transition-frontend/src/components/dashboard/TransitionBottomPanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionBottomPanel.tsx
@@ -32,4 +32,4 @@ const BottomPanel: React.FunctionComponent<LayoutSectionProps> = (props: LayoutS
     return <React.Fragment>{path.path && <TransitPathNodesList selectedPath={path.path} />}</React.Fragment>;
 };
 
-export default withTranslation(['transit', 'main', 'form'])(BottomPanel);
+export default withTranslation()(BottomPanel);

--- a/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
@@ -323,14 +323,7 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
         const Map = this.props.mainMap;
 
         const mapComponent = (
-            <Map
-                i18n={this.props.i18n}
-                t={this.props.t}
-                tReady={this.props.tReady}
-                center={mapCenter}
-                zoom={mapZoom}
-                activeSection={this.state.activeSection}
-            >
+            <Map center={mapCenter} zoom={mapZoom} activeSection={this.state.activeSection}>
                 {this.state.showFullSizePanel && (
                     <FullSizePanel
                         activeSection={this.state.activeSection}

--- a/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
@@ -56,4 +56,4 @@ const FullSizePanel: React.FunctionComponent<LayoutSectionProps> = (props: Layou
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(FullSizePanel);
+export default withTranslation()(FullSizePanel);

--- a/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
@@ -56,4 +55,4 @@ const FullSizePanel: React.FunctionComponent<LayoutSectionProps> = (props: Layou
     );
 };
 
-export default withTranslation()(FullSizePanel);
+export default FullSizePanel;

--- a/packages/transition-frontend/src/components/dashboard/TransitionMenuBar.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionMenuBar.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
@@ -14,7 +14,9 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 // TODO Menu items should not be provided directly by widgets, it should be
 // built from descriptive elements, or contributions should register their own
 // menu. This is just a copy-paste from the legacy workspace.
-const MenuBar: React.FunctionComponent<LayoutSectionProps> = (props: LayoutSectionProps) => {
+const MenuBar: React.FunctionComponent<LayoutSectionProps & WithTranslation> = (
+    props: LayoutSectionProps & WithTranslation
+) => {
     const sectionsConfig = Preferences.get('sections.transition');
 
     const onClickHandler = function (e) {

--- a/packages/transition-frontend/src/components/dashboard/TransitionRightPanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionRightPanel.tsx
@@ -52,4 +52,4 @@ const RightPanel: React.FunctionComponent<RightPanelProps> = (props: RightPanelP
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(RightPanel);
+export default withTranslation()(RightPanel);

--- a/packages/transition-frontend/src/components/dashboard/TransitionRightPanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionRightPanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
 import TransitNodesPanel from '../forms/node/TransitNodePanel';
 import TransitAgenciesPanel from '../forms/agency/TransitAgencyPanel';
@@ -52,4 +51,4 @@ const RightPanel: React.FunctionComponent<RightPanelProps> = (props: RightPanelP
     );
 };
 
-export default withTranslation()(RightPanel);
+export default RightPanel;

--- a/packages/transition-frontend/src/components/dashboard/TransitionToolbar.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionToolbar.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import Menu, { MenuItem } from 'rc-menu';
 
 import 'rc-menu/assets/index.css';
@@ -26,8 +26,8 @@ interface TransitionToolbarState {
     dataNeedsUpdate: boolean;
 }
 
-class Toolbar extends React.Component<LayoutSectionProps, TransitionToolbarState> {
-    constructor(props: LayoutSectionProps) {
+class Toolbar extends React.Component<LayoutSectionProps & WithTranslation, TransitionToolbarState> {
+    constructor(props: LayoutSectionProps & WithTranslation) {
         super(props);
 
         this.state = {

--- a/packages/transition-frontend/src/components/dashboard/TransitionToolbar.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionToolbar.tsx
@@ -400,4 +400,4 @@ class Toolbar extends React.Component<LayoutSectionProps, TransitionToolbarState
     }
 }
 
-export default withTranslation(['transit', 'main'])(Toolbar);
+export default withTranslation(['transit', 'main', 'od', 'notifications'])(Toolbar);

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -466,4 +466,4 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
     }
 }
 
-export default withTranslation(['transit', 'main'])(AccessibilityMapForm);
+export default withTranslation(['transit', 'main', 'form', 'notifications'])(AccessibilityMapForm);

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/widgets/BatchAttributesSelection.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/widgets/BatchAttributesSelection.tsx
@@ -80,4 +80,4 @@ const BatchAttributesSelectionComponent: React.FunctionComponent<BatchAttributes
     );
 };
 
-export default withTranslation(['transit', 'main'])(BatchAttributesSelectionComponent);
+export default withTranslation('main')(BatchAttributesSelectionComponent);

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyButton.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyButton.tsx
@@ -274,4 +274,4 @@ const TransitAgencyButton: React.FunctionComponent<AgencyButtonProps> = (props: 
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitAgencyButton);
+export default withTranslation(['transit', 'main', 'notifications'])(TransitAgencyButton);

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyImportForm.tsx
@@ -46,4 +46,4 @@ const AgenciesImportForm: React.FunctionComponent<AgencyImportFormProps & WithTr
     );
 };
 
-export default withTranslation(['transit', 'main'])(AgenciesImportForm);
+export default withTranslation(['main', 'notifications'])(AgenciesImportForm);

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
@@ -136,4 +136,4 @@ const TransitAgencyList: React.FunctionComponent<AgencyListProps> = (props: Agen
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitAgencyList);
+export default withTranslation('transit')(TransitAgencyList);

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyPanel.tsx
@@ -228,4 +228,4 @@ const AgencyPanel: React.FunctionComponent<AgencyPanelProps> = (props: AgencyPan
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(AgencyPanel);
+export default withTranslation(['transit', 'form'])(AgencyPanel);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
@@ -69,4 +69,4 @@ const BatchCalculationList: React.FunctionComponent<BatchCalculationListProps> =
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(BatchCalculationList);
+export default withTranslation('transit')(BatchCalculationList);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -69,4 +69,4 @@ const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & Wit
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(CalculationPanel);
+export default withTranslation()(CalculationPanel);

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import BatchCalculationList from './BatchCalculationList';
@@ -18,9 +17,7 @@ export interface CalculationPanelPanelProps {
     availableRoutingModes?: string[];
 }
 
-const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & WithTranslation> = (
-    props: CalculationPanelPanelProps & WithTranslation
-) => {
+const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps> = (props: CalculationPanelPanelProps) => {
     const [scenarioCollection, setScenarioCollection] = React.useState<ScenarioCollection | undefined>(
         serviceLocator.collectionManager.get('scenarios')
     );
@@ -69,4 +66,4 @@ const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps & Wit
     );
 };
 
-export default withTranslation()(CalculationPanel);
+export default CalculationPanel;

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
@@ -156,4 +156,4 @@ const ConfigureCalculationParametersForm: React.FunctionComponent<
     );
 };
 
-export default withTranslation(['transit', 'main'])(ConfigureCalculationParametersForm);
+export default withTranslation('transit')(ConfigureCalculationParametersForm);

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsExistingAgencyImport.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsExistingAgencyImport.tsx
@@ -117,4 +117,4 @@ const GtfsExistingAgencyImport: React.FunctionComponent<GtfsExistingAgencyImport
     );
 };
 
-export default withTranslation(['transit', 'main'])(GtfsExistingAgencyImport);
+export default withTranslation('transit')(GtfsExistingAgencyImport);

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsExportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsExportForm.tsx
@@ -155,4 +155,4 @@ class GtfsExportForm extends ChangeEventsForm<WithTranslation, ChangeEventsState
     }
 }
 
-export default withTranslation(['transit', 'main'])(GtfsExportForm);
+export default withTranslation('transit')(GtfsExportForm);

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportAgenciesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportAgenciesComponent.tsx
@@ -67,4 +67,4 @@ const GtfsImportAgenciesComponent: React.FunctionComponent<GtfsImportAgenciesCom
     );
 };
 
-export default withTranslation(['transit', 'main'])(GtfsImportAgenciesComponent);
+export default withTranslation()(GtfsImportAgenciesComponent);

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportAgenciesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportAgenciesComponent.tsx
@@ -11,7 +11,7 @@ import { AgencyImportData } from 'transition-common/lib/services/gtfs/GtfsImport
 import { InputCheckbox } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
 import GtfsExistingAgencyImport from './GtfsExistingAgencyImport';
 
-export interface GtfsImportAgenciesComponentProps extends WithTranslation {
+export interface GtfsImportAgenciesComponentProps {
     id: string;
     disabled?: boolean;
     value?: string[];
@@ -67,4 +67,4 @@ const GtfsImportAgenciesComponent: React.FunctionComponent<GtfsImportAgenciesCom
     );
 };
 
-export default withTranslation()(GtfsImportAgenciesComponent);
+export default GtfsImportAgenciesComponent;

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportForm.tsx
@@ -518,4 +518,4 @@ class GtfsImportForm extends React.Component<GtfsImportProps, GtfsImportState> {
     }
 }
 
-export default withTranslation(['transit', 'main', 'notifications'])(GtfsImportForm);
+export default withTranslation(['transit', 'notifications'])(GtfsImportForm);

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportNodesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportNodesComponent.tsx
@@ -56,4 +56,4 @@ const GtfsImportNodesComponent: React.FunctionComponent<GtfsImportNodesComponent
     );
 };
 
-export default withTranslation(['transit', 'main'])(GtfsImportNodesComponent);
+export default withTranslation('transit')(GtfsImportNodesComponent);

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportServiceComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportServiceComponent.tsx
@@ -74,4 +74,4 @@ const GtfsImportServiceComponent: React.FunctionComponent<GtfsImportServiceCompo
     );
 };
 
-export default withTranslation(['transit', 'main'])(GtfsImportServiceComponent);
+export default withTranslation('main')(GtfsImportServiceComponent);

--- a/packages/transition-frontend/src/components/forms/line/TransitLineButton.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineButton.tsx
@@ -187,4 +187,4 @@ const TransitLineButton: React.FunctionComponent<LineButtonProps> = (props: Line
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitLineButton);
+export default withTranslation(['transit', 'main', 'notifications'])(TransitLineButton);

--- a/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
@@ -467,4 +467,4 @@ class TransitLineEdit extends SaveableObjectForm<Line, LineFormProps, LineFormSt
     }
 }
 
-export default withTranslation(['transit', 'main'])(TransitLineEdit);
+export default withTranslation(['transit', 'form', 'main', 'notifications'])(TransitLineEdit);

--- a/packages/transition-frontend/src/components/forms/line/TransitLineImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineImportForm.tsx
@@ -50,4 +50,4 @@ const LineImportForm: React.FunctionComponent<LineImportFormProps & WithTranslat
     );
 };
 
-export default withTranslation(['transit', 'main'])(LineImportForm);
+export default withTranslation(['main', 'notifications'])(LineImportForm);

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeCollectionEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeCollectionEdit.tsx
@@ -323,4 +323,4 @@ class TransitNodeCollectionEdit extends React.Component<
     }
 }
 
-export default withTranslation(['transit', 'main', 'notifications'])(TransitNodeCollectionEdit);
+export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitNodeCollectionEdit);

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeEdit.tsx
@@ -496,4 +496,4 @@ class TransitNodeEdit extends SaveableObjectForm<Node, NodeFormProps, NodeFormSt
     }
 }
 
-export default withTranslation(['transit', 'main', 'notifications'])(TransitNodeEdit);
+export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitNodeEdit);

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeImportForm.tsx
@@ -51,4 +51,4 @@ const NodesImportForm: React.FunctionComponent<NodeImportFormProps & WithTransla
     );
 };
 
-export default withTranslation(['transit', 'main'])(NodesImportForm);
+export default withTranslation(['notifications', 'main'])(NodesImportForm);

--- a/packages/transition-frontend/src/components/forms/node/TransitNodePanel.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodePanel.tsx
@@ -315,4 +315,4 @@ const NodePanel: React.FunctionComponent<WithTranslation> = (props: WithTranslat
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(NodePanel);
+export default withTranslation(['transit', 'main', 'notifications'])(NodePanel);

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeStatistics.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeStatistics.tsx
@@ -99,4 +99,4 @@ const TransitNodeStatistics: React.FunctionComponent<NodeStatsProps> = (props: N
     );
 };
 
-export default withTranslation(['transit'])(TransitNodeStatistics);
+export default withTranslation('transit')(TransitNodeStatistics);

--- a/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
@@ -254,4 +254,4 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitPathButton);
+export default withTranslation(['transit', 'main', 'notifications'])(TransitPathButton);

--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -859,4 +859,4 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
     }
 }
 
-export default withTranslation(['transit', 'main'])(TransitPathEdit);
+export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitPathEdit);

--- a/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathImportForm.tsx
@@ -60,4 +60,4 @@ const PathsImportForm: React.FunctionComponent<PathImportFormProps & WithTransla
     );
 };
 
-export default withTranslation(['transit', 'main'])(PathsImportForm);
+export default withTranslation(['main', 'notifications'])(PathsImportForm);

--- a/packages/transition-frontend/src/components/forms/path/TransitPathList.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathList.tsx
@@ -54,4 +54,4 @@ const TransitPathList: React.FunctionComponent<PathListProps> = (props: PathList
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitPathList);
+export default withTranslation('transit')(TransitPathList);

--- a/packages/transition-frontend/src/components/forms/path/TransitPathNodeList.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathNodeList.tsx
@@ -96,4 +96,4 @@ const TransitPathNodeList: React.FunctionComponent<PathListProps> = (props: Path
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitPathNodeList);
+export default withTranslation('transit')(TransitPathNodeList);

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
@@ -191,4 +191,4 @@ class PreferencesPanel extends SaveableObjectForm<PreferencesClass, PreferencesP
     }
 }
 
-export default withTranslation(['transit', 'main', 'form'])(PreferencesPanel);
+export default withTranslation('main')(PreferencesPanel);

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesResetToDefaultButton.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesResetToDefaultButton.tsx
@@ -33,4 +33,4 @@ const PreferencesResetToDefaultButton: React.FunctionComponent<PreferencesResetT
     );
 };
 
-export default withTranslation(['main'])(PreferencesResetToDefaultButton);
+export default withTranslation('main')(PreferencesResetToDefaultButton);

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesSectionProps.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesSectionProps.tsx
@@ -5,9 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { PreferencesClass } from 'chaire-lib-common/lib/config/Preferences';
-import { WithTranslation } from 'react-i18next';
 
-interface PreferencesSectionProps extends WithTranslation {
+interface PreferencesSectionProps {
     preferences: PreferencesClass;
     onValueChange: (path: string, newValue: { value: any; valid?: boolean }) => void;
     resetPrefToDefault: (path: string) => void;

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionAccessibility.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionAccessibility.tsx
@@ -29,4 +29,4 @@ const PreferencesSectionTransitRouting: React.FunctionComponent<PreferencesSecti
     </Collapsible>
 );
 
-export default withTranslation(['main', 'transit'])(PreferencesSectionTransitRouting);
+export default withTranslation('transit')(PreferencesSectionTransitRouting);

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionAccessibility.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionAccessibility.tsx
@@ -6,12 +6,12 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 import PreferencesColorComponent from '../PreferencesColorComponent';
 
-const PreferencesSectionTransitRouting: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitRouting: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => (
     <Collapsible trigger={props.t('transit:transitRouting:AccessibilityMap')} open={true} transitionTime={100}>
         <div className="tr__form-section">

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
@@ -41,4 +41,4 @@ const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProp
     );
 };
 
-export default withTranslation(['main', 'transit'])(PreferencesSectionFeatures);
+export default withTranslation('main')(PreferencesSectionFeatures);

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
@@ -6,14 +6,14 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { withTranslation, WithTranslation } from 'react-i18next';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 
-const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import _toString from 'lodash/toString';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
@@ -17,8 +17,8 @@ import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 import moment from 'moment';
 
-const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionRouting.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionRouting.tsx
@@ -54,4 +54,4 @@ const PreferencesSectionTransitRouting: React.FunctionComponent<PreferencesSecti
     </Collapsible>
 );
 
-export default withTranslation(['main', 'transit'])(PreferencesSectionTransitRouting);
+export default withTranslation('transit')(PreferencesSectionTransitRouting);

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionRouting.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionRouting.tsx
@@ -6,12 +6,12 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 import PreferencesColorComponent from '../PreferencesColorComponent';
 
-const PreferencesSectionTransitRouting: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitRouting: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => (
     <Collapsible trigger={props.t('transit:transitRouting:Routing')} open={true} transitionTime={100}>
         <div className="tr__form-section">

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitAgencies.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitAgencies.tsx
@@ -6,14 +6,14 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 
-const PreferencesSectionTransitAgencies: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitAgencies: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import _toString from 'lodash/toString';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
@@ -15,8 +15,8 @@ import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/Input
 import PreferencesSectionLineModeProps from '../PreferencesSectionLineModeProps';
 import { parseIntOrNull, parseFloatOrNull } from 'chaire-lib-common/lib/utils/MathUtils';
 
-const PreferencesSectionTransitLineMode: React.FunctionComponent<PreferencesSectionLineModeProps> = (
-    props: PreferencesSectionLineModeProps
+const PreferencesSectionTransitLineMode: React.FunctionComponent<PreferencesSectionLineModeProps & WithTranslation> = (
+    props: PreferencesSectionLineModeProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
@@ -194,4 +194,4 @@ const PreferencesSectionTransitLineMode: React.FunctionComponent<PreferencesSect
     );
 };
 
-export default withTranslation(['main', 'transit'])(PreferencesSectionTransitLineMode);
+export default withTranslation('transit')(PreferencesSectionTransitLineMode);

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLines.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLines.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
@@ -20,8 +20,8 @@ for (let i = 0, countI = lineModesConfig.length; i < countI; i++) {
     lineModesConfigByMode[lineMode.value] = lineMode;
 }
 
-const PreferencesSectionTransitLines: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitLines: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitNodes.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitNodes.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import _toString from 'lodash/toString';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
@@ -15,8 +15,8 @@ import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 import { parseFloatOrNull } from 'chaire-lib-common/lib/utils/MathUtils';
 
-const PreferencesSectionTransitNodes: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitNodes: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
@@ -5,11 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
-import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
-import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
-import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
+
 import PreferencesSectionProps from '../PreferencesSectionProps';
 
 const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSectionProps> = (
@@ -20,4 +16,4 @@ const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSection
     return null;
 };
 
-export default withTranslation()(PreferencesSectionTransitPaths);
+export default PreferencesSectionTransitPaths;

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
@@ -20,4 +20,4 @@ const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSection
     return null;
 };
 
-export default withTranslation(['main', 'transit'])(PreferencesSectionTransitPaths);
+export default withTranslation()(PreferencesSectionTransitPaths);

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitScenarios.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitScenarios.tsx
@@ -6,15 +6,15 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import _toString from 'lodash/toString';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 
-const PreferencesSectionTransitScenarios: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitScenarios: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitServices.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitServices.tsx
@@ -6,14 +6,14 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
 import PreferencesSectionProps from '../PreferencesSectionProps';
 
-const PreferencesSectionTransitServices: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+const PreferencesSectionTransitServices: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioButton.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioButton.tsx
@@ -90,4 +90,4 @@ const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (pro
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitScenarioButton);
+export default withTranslation(['transit', 'main'])(TransitScenarioButton);

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioEdit.tsx
@@ -355,4 +355,4 @@ class TransitScenarioEdit extends SaveableObjectForm<Scenario, ScenarioFormProps
     }
 }
 
-export default withTranslation(['transit', 'main', 'notifications'])(TransitScenarioEdit);
+export default withTranslation(['transit', 'main', 'form'])(TransitScenarioEdit);

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
@@ -45,4 +45,4 @@ const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps & Wit
     );
 };
 
-export default withTranslation(['transit', 'main'])(ScenariosImportForm);
+export default withTranslation(['main', 'notifications'])(ScenariosImportForm);

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioLinesDetail.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioLinesDetail.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
 import _uniq from 'lodash/uniq';
 
 import Scenario from 'transition-common/lib/services/scenario/Scenario';
@@ -14,7 +13,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Line from 'transition-common/lib/services/line/Line';
 import Agency from 'transition-common/lib/services/agency/Agency';
 
-export interface TransitScenarioLinesDetailProps extends WithTranslation {
+export interface TransitScenarioLinesDetailProps {
     scenario: Scenario;
     paths: GeoJSON.FeatureCollection<GeoJSON.LineString, PathAttributes>;
 }
@@ -56,4 +55,4 @@ const TransitScenarioLinesDetail: React.FunctionComponent<TransitScenarioLinesDe
     );
 };
 
-export default withTranslation()(TransitScenarioLinesDetail);
+export default TransitScenarioLinesDetail;

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioLinesDetail.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioLinesDetail.tsx
@@ -56,4 +56,4 @@ const TransitScenarioLinesDetail: React.FunctionComponent<TransitScenarioLinesDe
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitScenarioLinesDetail);
+export default withTranslation()(TransitScenarioLinesDetail);

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
@@ -69,4 +69,4 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitScenarioList);
+export default withTranslation('transit')(TransitScenarioList);

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioPanel.tsx
@@ -95,4 +95,4 @@ const ScenarioPanel: React.FunctionComponent<WithTranslation> = (props: WithTran
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(ScenarioPanel);
+export default withTranslation('transit')(ScenarioPanel);

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleButton.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleButton.tsx
@@ -94,4 +94,4 @@ const TransitScheduleButton: React.FunctionComponent<ScheduleButtonProps> = (pro
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitScheduleButton);
+export default withTranslation(['transit', 'notifications'])(TransitScheduleButton);

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleEdit.tsx
@@ -631,4 +631,4 @@ class TransitScheduleEdit extends SaveableObjectForm<Schedule, ScheduleFormProps
     }
 }
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitScheduleEdit);
+export default withTranslation(['transit', 'main', 'notifications'])(TransitScheduleEdit);

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleList.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleList.tsx
@@ -125,4 +125,4 @@ const TransitScheduleList: React.FunctionComponent<ScheduleListProps> = (props: 
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitScheduleList);
+export default withTranslation('transit')(TransitScheduleList);

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceButton.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceButton.tsx
@@ -135,4 +135,4 @@ const TransitServiceButton: React.FunctionComponent<ScheduleButtonProps> = (prop
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitServiceButton);
+export default withTranslation(['transit', 'main'])(TransitServiceButton);

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceEdit.tsx
@@ -377,4 +377,4 @@ class TransitServiceEdit extends SaveableObjectForm<Service, ServiceFormProps, S
     }
 }
 
-export default withTranslation(['transit', 'main', 'notifications'])(TransitServiceEdit);
+export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitServiceEdit);

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceFilter.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceFilter.tsx
@@ -145,4 +145,4 @@ const TransitServiceFilter: React.FunctionComponent<TransitServiceFilterProps> =
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitServiceFilter);
+export default withTranslation('transit')(TransitServiceFilter);

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceFilterableList.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceFilterableList.tsx
@@ -52,4 +52,4 @@ const TransitServiceFilterableList: React.FunctionComponent<TransitServiceFilter
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitServiceFilterableList);
+export default withTranslation()(TransitServiceFilterableList);

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceList.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceList.tsx
@@ -117,4 +117,4 @@ const TransitServiceList: React.FunctionComponent<ServiceListProps> = (props: Se
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(TransitServiceList);
+export default withTranslation(['transit', 'main', 'notifications'])(TransitServiceList);

--- a/packages/transition-frontend/src/components/forms/service/TransitServicePanel.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServicePanel.tsx
@@ -104,4 +104,4 @@ const ServicesPanel: React.FunctionComponent<WithTranslation> = (props: WithTran
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(ServicesPanel);
+export default withTranslation('transit')(ServicesPanel);

--- a/packages/transition-frontend/src/components/forms/service/TransitServicesImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServicesImportForm.tsx
@@ -45,4 +45,4 @@ const ServicesImportForm: React.FunctionComponent<ServicesImportFormProps & With
     );
 };
 
-export default withTranslation(['transit', 'main'])(ServicesImportForm);
+export default withTranslation(['main', 'notifications'])(ServicesImportForm);

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationButton.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationButton.tsx
@@ -100,4 +100,4 @@ const SimulationButton: React.FunctionComponent<SimulationButtonProps> = (props:
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(SimulationButton);
+export default withTranslation(['transit', 'main', 'notifications'])(SimulationButton);

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationEdit.tsx
@@ -200,4 +200,4 @@ class SimulationEdit extends SaveableObjectForm<Simulation, SimulationFormProps,
     }
 }
 
-export default withTranslation(['transit', 'main', 'notifications'])(SimulationEdit);
+export default withTranslation(['transit', 'main', 'form'])(SimulationEdit);

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationList.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationList.tsx
@@ -70,4 +70,4 @@ const SimulationList: React.FunctionComponent<SimulationListProps> = (props: Sim
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(SimulationList);
+export default withTranslation('transit')(SimulationList);

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationPanel.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import SimulationCollection from 'transition-common/lib/services/simulation/SimulationCollection';
@@ -21,7 +20,7 @@ interface SimulationPanelState {
     selectedSimulation?: Simulation;
 }
 
-const SimulationsPanel: React.FunctionComponent<WithTranslation> = (props: WithTranslation) => {
+const SimulationsPanel: React.FunctionComponent = () => {
     const serviceCollection = serviceLocator.collectionManager.get('services');
     const agencyCollection = serviceLocator.collectionManager.get('agencies');
     const lineCollection = serviceLocator.collectionManager.get('lines');
@@ -104,4 +103,4 @@ const SimulationsPanel: React.FunctionComponent<WithTranslation> = (props: WithT
     );
 };
 
-export default withTranslation()(SimulationsPanel);
+export default SimulationsPanel;

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationPanel.tsx
@@ -104,4 +104,4 @@ const SimulationsPanel: React.FunctionComponent<WithTranslation> = (props: WithT
     );
 };
 
-export default withTranslation(['transit', 'main', 'form'])(SimulationsPanel);
+export default withTranslation()(SimulationsPanel);

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/BaseSimulationComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/BaseSimulationComponent.tsx
@@ -62,4 +62,4 @@ const BaseSimulationComponent: React.FunctionComponent<BaseSimulationComponentPr
     );
 };
 
-export default withTranslation(['transit', 'main'])(BaseSimulationComponent);
+export default withTranslation('transit')(BaseSimulationComponent);

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationParametersComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationParametersComponent.tsx
@@ -139,4 +139,4 @@ const SimulationParametersComponent: React.FunctionComponent<SimulationParameter
     );
 };
 
-export default withTranslation(['transit', 'main'])(SimulationParametersComponent);
+export default withTranslation('transit')(SimulationParametersComponent);

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunButton.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunButton.tsx
@@ -127,4 +127,4 @@ const SimulationRunButton: React.FunctionComponent<SimulationRunButtonProps> = (
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(SimulationRunButton);
+export default withTranslation(['transit', 'notifications'])(SimulationRunButton);

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunDetail.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunDetail.tsx
@@ -65,4 +65,4 @@ const SimulationRunDetail: React.FunctionComponent<SimulationRunDetailProps> = (
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(SimulationRunDetail);
+export default withTranslation('transit')(SimulationRunDetail);

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunList.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunList.tsx
@@ -61,4 +61,4 @@ const SimulationRunList: React.FunctionComponent<SimulationRunListProps> = (prop
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(SimulationRunList);
+export default withTranslation('transit')(SimulationRunList);

--- a/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
+++ b/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
@@ -57,7 +57,7 @@ function CsvAttributeSelectionWidgetBase<T extends object>(
     );
 }
 
-export const CsvAttributeSelectionWidget = withTranslation(['transit', 'main'])(
+export const CsvAttributeSelectionWidget = withTranslation('transit')(
     CsvAttributeSelectionWidgetBase
 ) as unknown as <T extends object>(props: BatchCsvAttributeSelectionComponentProps<T>) => JSX.Element;
 
@@ -92,7 +92,7 @@ function BooleanAttributeSelectionWidgetBase<T extends object>(
 }
 
 // we need to add as unknown since
-export const BooleanAttributeSelectionWidget = withTranslation(['transit', 'main'])(
+export const BooleanAttributeSelectionWidget = withTranslation('transit')(
     BooleanAttributeSelectionWidgetBase
 ) as unknown as <T extends object>(props: BatchAttributeSelectionComponentProps<T>) => JSX.Element;
 
@@ -138,7 +138,7 @@ function TimeAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsv
     );
 }
 
-export const TimeAttributeSelectionWidget = withTranslation(['transit', 'main'])(TimeAttributeSelectionWidgetBase);
+export const TimeAttributeSelectionWidget = withTranslation('transit')(TimeAttributeSelectionWidgetBase);
 
 function TimeFormatAttributeSelectionWidgetBase<T extends Partial<TransitDemandFromCsvAttributes>>(
     props: BatchAttributeSelectionComponentProps<T> & WithTranslation
@@ -172,6 +172,6 @@ function TimeFormatAttributeSelectionWidgetBase<T extends Partial<TransitDemandF
     );
 }
 
-export const TimeFormatAttributeSelectionWidget = withTranslation(['transit', 'main'])(
+export const TimeFormatAttributeSelectionWidget = withTranslation('transit')(
     TimeFormatAttributeSelectionWidgetBase
 );

--- a/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
+++ b/packages/transition-frontend/src/components/forms/transitCalculation/widgets/AttributeSelectionWidget.tsx
@@ -57,9 +57,11 @@ function CsvAttributeSelectionWidgetBase<T extends object>(
     );
 }
 
-export const CsvAttributeSelectionWidget = withTranslation('transit')(
-    CsvAttributeSelectionWidgetBase
-) as unknown as <T extends object>(props: BatchCsvAttributeSelectionComponentProps<T>) => JSX.Element;
+export const CsvAttributeSelectionWidget = withTranslation('transit')(CsvAttributeSelectionWidgetBase) as unknown as <
+    T extends object
+>(
+    props: BatchCsvAttributeSelectionComponentProps<T>
+) => JSX.Element;
 
 function BooleanAttributeSelectionWidgetBase<T extends object>(
     props: BatchAttributeSelectionComponentProps<T> & WithTranslation
@@ -172,6 +174,4 @@ function TimeFormatAttributeSelectionWidgetBase<T extends Partial<TransitDemandF
     );
 }
 
-export const TimeFormatAttributeSelectionWidget = withTranslation('transit')(
-    TimeFormatAttributeSelectionWidgetBase
-);
+export const TimeFormatAttributeSelectionWidget = withTranslation('transit')(TimeFormatAttributeSelectionWidgetBase);

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -115,4 +115,4 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
     );
 };
 
-export default withTranslation(['transit', 'main'])(RoutingResults);
+export default withTranslation()(RoutingResults);

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React, { useState } from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons/faAngleRight';
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons/faAngleLeft';
 
@@ -26,7 +25,7 @@ export interface RoutingResultStatus {
     activeStepIndex: number | null;
 }
 
-export interface TransitRoutingResultsProps extends WithTranslation {
+export interface TransitRoutingResultsProps {
     result: RoutingResult;
     request: TransitRoutingAttributes;
 }
@@ -115,4 +114,4 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
     );
 };
 
-export default withTranslation()(RoutingResults);
+export default RoutingResults;

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultsComponent.tsx
@@ -64,4 +64,4 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
     );
 };
 
-export default withTranslation(['transit', 'main'])(RoutingResults);
+export default withTranslation('transit')(RoutingResults);

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingBatchForm.tsx
@@ -65,4 +65,4 @@ class TransitRoutingBatchForm extends ChangeEventsForm<
 
 // ** File upload
 //export default FileUploaderHOC(TransitRoutingForm, null, false);
-export default withTranslation(['transit', 'main'])(TransitRoutingBatchForm);
+export default withTranslation('transit')(TransitRoutingBatchForm);

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -493,4 +493,4 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
     }
 }
 
-export default withTranslation(['transit', 'main'])(TransitRoutingForm);
+export default withTranslation(['transit', 'main', 'form'])(TransitRoutingForm);

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/BatchAttributesSelection.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/BatchAttributesSelection.tsx
@@ -84,4 +84,4 @@ const BatchAttributesSelectionComponent: React.FunctionComponent<BatchAttributes
     );
 };
 
-export default withTranslation(['transit', 'main'])(BatchAttributesSelectionComponent);
+export default withTranslation('main')(BatchAttributesSelectionComponent);

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/BatchSaveToDb.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/BatchSaveToDb.tsx
@@ -122,7 +122,7 @@ const SaveToDbChoiceComponent: React.FunctionComponent<SaveToDbChoiceComponentPr
     );
 };
 
-const SaveToDbChoiceComponentTranslated = withTranslation(['transit', 'main'])(SaveToDbChoiceComponent);
+const SaveToDbChoiceComponentTranslated = withTranslation('transit')(SaveToDbChoiceComponent);
 
 const BatchSaveToDbComponent: React.FunctionComponent<BatchAttributesSelectionComponentProps> = (
     props: BatchAttributesSelectionComponentProps
@@ -167,4 +167,4 @@ const BatchSaveToDbComponent: React.FunctionComponent<BatchAttributesSelectionCo
     );
 };
 
-export default withTranslation(['transit', 'main'])(BatchSaveToDbComponent);
+export default withTranslation('transit')(BatchSaveToDbComponent);

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/ODCoordinatesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/ODCoordinatesComponent.tsx
@@ -284,4 +284,4 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
     }
 }
 
-export default withTranslation(['transit', 'main'])(ODCoordinatesComponent);
+export default withTranslation('transit')(ODCoordinatesComponent);

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/TimeOfTripComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/TimeOfTripComponent.tsx
@@ -48,4 +48,4 @@ const TimeOfTripComponent: React.FunctionComponent<TimeOfTripComponentProps> = (
     );
 };
 
-export default withTranslation(['transit', 'main'])(TimeOfTripComponent);
+export default withTranslation('transit')(TimeOfTripComponent);

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/TransitRoutingBaseComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/TransitRoutingBaseComponent.tsx
@@ -100,4 +100,4 @@ const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseCom
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitRoutingBaseComponent);
+export default withTranslation('transit')(TransitRoutingBaseComponent);

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
-import { withTranslation } from 'react-i18next';
+import { WithTranslation, withTranslation } from 'react-i18next';
 import MapboxGL from 'mapbox-gl';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { default as elementResizedEvent, unbind as removeResizeListener } from 'element-resize-event';
@@ -54,7 +54,7 @@ interface MainMapState {
  * chaire-lib and offer the possibility to pass the application modules when the
  * API for it has stabilised.
  */
-class MainMap extends React.Component<MainMapProps, MainMapState> {
+class MainMap extends React.Component<MainMapProps & WithTranslation, MainMapState> {
     private layerManager: MapLayerManager;
     private pathLayerManager: PathMapLayerManager;
     private defaultZoomArray: [number];
@@ -65,7 +65,7 @@ class MainMap extends React.Component<MainMapProps, MainMapState> {
     private mapContainer;
     private draw: MapboxDraw | undefined;
 
-    constructor(props: MainMapProps) {
+    constructor(props: MainMapProps & WithTranslation) {
         super(props);
 
         this.state = {

--- a/packages/transition-frontend/src/components/parts/Button.tsx
+++ b/packages/transition-frontend/src/components/parts/Button.tsx
@@ -109,4 +109,4 @@ const Button: React.FunctionComponent<ButtonProps> = (props: ButtonProps) => {
     );
 };
 
-export default withTranslation(['transit', 'main', 'form', 'notifications'])(Button);
+export default withTranslation('main')(Button);

--- a/packages/transition-frontend/src/components/parts/DocumentationTooltip.tsx
+++ b/packages/transition-frontend/src/components/parts/DocumentationTooltip.tsx
@@ -83,4 +83,4 @@ const DocumentationTooltip: React.FunctionComponent<DocumentationTooltipProps> =
     }
 };
 
-export default withTranslation(['transit'])(DocumentationTooltip);
+export default withTranslation('transit')(DocumentationTooltip);

--- a/packages/transition-frontend/src/components/parts/FileImportForm.tsx
+++ b/packages/transition-frontend/src/components/parts/FileImportForm.tsx
@@ -80,7 +80,4 @@ const FileImportForm: React.FunctionComponent<FileImportFormProps & WithTranslat
     );
 };
 
-export default FileUploaderHOC(
-    withTranslation(['transit', 'main', 'form', 'notifications'])(FileImportForm),
-    ImporterValidator
-);
+export default FileUploaderHOC(withTranslation('main')(FileImportForm), ImporterValidator);


### PR DESCRIPTION
Many of the uses of withTranslation() had outdated arguments, either missing translation files or not including needed ones.

This PR updates them to correctly match the current content of the files. Also removes brackets in case of 1 file in the argument.

Also removes the instance of withTranslation() that have 0 arguments, updating some props types that extend WithTranslation along the way.