### PR TITLE
nodes: remove the `data` field from geojson collection

### DIFF
--- a/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
@@ -94,7 +94,6 @@ const geojsonCollection = async (
             'name', name,
             'description', description,
             'geography', ST_AsGeoJSON(geography)::jsonb, 
-            'data', data,
             'is_enabled', is_enabled,
             'integer_id', integer_id,
             'routing_radius_meters', routing_radius_meters,


### PR DESCRIPTION
This improves the time and memory necessary to retrieve the node geojson collection and it does not appear to have side effects.

On a large instance (all the greater Montreal area) this divides by 3 the query time to get the node geojson collection and can reduce the memory usage in the browser by 100 MB.

Tested in the UI:

* Node edits
* Multiple node edits
* Path creation and routing