### PR TITLE
accessibility map: check that data is defined for accessiblePlaces

### DIFF
--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
@@ -135,10 +135,14 @@ export class TransitAccessibilityMapResultByNode {
                 continue;
             }
 
+            // FIXME node's 'data' field is not accessible in the frontend
+            // anymore, at least when retrieved from the node collection, so
+            // this feature will not work anymore as long as it is calculated in
+            // the frontend
             const nodeAccessiblePlacesByCategory =
-                nodeAttributes.data.accessiblePlaces?.walking?.placesByTravelTimeByCategory; // TODO: allow stats for other modes
+                nodeAttributes.data?.accessiblePlaces?.walking?.placesByTravelTimeByCategory; // TODO: allow stats for other modes
             const nodeAccessiblePlacesByDetailedCategory =
-                nodeAttributes.data.accessiblePlaces?.walking?.placesByTravelTimeByDetailedCategory;
+                nodeAttributes.data?.accessiblePlaces?.walking?.placesByTravelTimeByDetailedCategory;
             for (let timeMinutes = avgRemainingTimeMinutes; timeMinutes >= 0; timeMinutes--) {
                 if (nodeAccessiblePlacesByCategory) {
                     const accessiblePlacesForTravelTimeByCategory = nodeAccessiblePlacesByCategory[timeMinutes];


### PR DESCRIPTION
Now that the NodeCollection does not return the 'data' field, when nodes are retrieved from this collection, the data field will be undefined, so we make sure to undefined-check it before trying to read accessiblePlaces data.