### PR TITLE
Remove Lint warnings from chaire-lib-backend

### DIFF
--- a/packages/chaire-lib-backend/jest.config.js
+++ b/packages/chaire-lib-backend/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 // Ignore db.queries.test files

--- a/packages/chaire-lib-backend/jest.sequential.config.js
+++ b/packages/chaire-lib-backend/jest.sequential.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 // Run the db and integration tests

--- a/packages/chaire-lib-backend/src/api/admin.routes.ts
+++ b/packages/chaire-lib-backend/src/api/admin.routes.ts
@@ -47,7 +47,7 @@ router.get('/usersList', async (req, res) => {
                 permissions
             }))
         });
-    } catch (error) {
+    } catch {
         return res.status(500).json({ status: 'Error' });
     }
 });
@@ -73,7 +73,7 @@ router.post('/updateUser', async (req, res) => {
             status: 'success',
             uuid
         });
-    } catch (error) {
+    } catch {
         return res.status(500).json({ status: 'Error' });
     }
 });

--- a/packages/chaire-lib-backend/src/api/auth.routes.ts
+++ b/packages/chaire-lib-backend/src/api/auth.routes.ts
@@ -131,7 +131,7 @@ export default <U extends IUserModel>(app: express.Express, authModel: IAuthMode
             return res.status(200).json({
                 status: response
             });
-        } catch (error) {
+        } catch {
             return res.status(200).json({
                 status: 'Error'
             });

--- a/packages/chaire-lib-backend/src/api/routing.socketRoutes.ts
+++ b/packages/chaire-lib-backend/src/api/routing.socketRoutes.ts
@@ -5,8 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 // This file contains socket routes to access the routing services
-import _cloneDeep from 'lodash/cloneDeep';
-import _merge from 'lodash/merge';
 import { EventEmitter } from 'events';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
@@ -14,7 +12,8 @@ import { validateAndCreateTripRoutingAttributes } from 'chaire-lib-common/lib/se
 import { TripRoutingQueryAttributes, RoutingResultsByMode } from 'chaire-lib-common/lib/services/routing/types';
 import { Routing } from '../services/routing/Routing';
 
-export default function (socket: EventEmitter, userId: number) {
+//TODO: The userId parameter is unused. Either remove it or implement a use for it.
+export default function (socket: EventEmitter, _userId: number) {
     socket.on(
         'routing.calculate',
         async (

--- a/packages/chaire-lib-backend/src/api/trRouting.routes.ts
+++ b/packages/chaire-lib-backend/src/api/trRouting.routes.ts
@@ -4,7 +4,6 @@ import { isLoggedIn } from '../services/auth/authorization';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import trRoutingService from '../utils/trRouting/TrRoutingServiceBackend';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
 
 const router = express.Router();
 

--- a/packages/chaire-lib-backend/src/config/server.config.ts
+++ b/packages/chaire-lib-backend/src/config/server.config.ts
@@ -395,7 +395,7 @@ try {
         );
     }
     setProjectConfiguration(configFromFile);
-} catch (error) {
+} catch {
     console.error(`Error loading server configuration in file ${configFileNormalized}`);
 }
 

--- a/packages/chaire-lib-backend/src/scripts/database/token-cleanup.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/database/token-cleanup.task.ts
@@ -10,7 +10,7 @@ import tokensDbQueries from '../../models/db/tokens.db.queries';
 import { GenericTask } from 'chaire-lib-common/lib/tasks/genericTask';
 
 class CleanupApiTokenRun implements GenericTask {
-    async run(argv: { [key: string]: unknown }): Promise<void> {
+    async run(_argv: { [key: string]: unknown }): Promise<void> {
         console.log('CleanupApiToken..');
         await tokensDbQueries.cleanExpiredApiTokens();
     }

--- a/packages/chaire-lib-backend/src/services/auth/anonymousLoginStrategy.ts
+++ b/packages/chaire-lib-backend/src/services/auth/anonymousLoginStrategy.ts
@@ -15,7 +15,8 @@ class AnonymousLoginStrategy<A> {
         // Nothing to do
     }
 
-    async authenticate(this: StrategyCreatedStatic & AnonymousLoginStrategy<A>, req: Request): Promise<void> {
+    //TODO: The req parameter is unused. Either remove it or implement a use for it.
+    async authenticate(this: StrategyCreatedStatic & AnonymousLoginStrategy<A>, _req: Request): Promise<void> {
         console.log('anonymous login');
         try {
             let randomId: string | undefined = undefined;

--- a/packages/chaire-lib-backend/src/services/auth/authModel.ts
+++ b/packages/chaire-lib-backend/src/services/auth/authModel.ts
@@ -115,7 +115,7 @@ export abstract class AuthModelBase<U extends UserModelBase> implements IAuthMod
                 actionCallback(user);
             }
             return 'Confirmed';
-        } catch (error) {
+        } catch {
             return 'NotFound';
         }
     };

--- a/packages/chaire-lib-backend/src/services/files/SocketFileUploader.ts
+++ b/packages/chaire-lib-backend/src/services/files/SocketFileUploader.ts
@@ -6,7 +6,6 @@
  */
 import SocketIO from 'socket.io';
 import SocketIOFile from 'socket.io-file';
-import { directoryManager } from '../../utils/filesystem/directoryManager';
 
 const BYTES_IN_MB = Math.pow(1024, 2);
 

--- a/packages/chaire-lib-backend/src/services/prompt/CliPromptGeojsonPolygonService.ts
+++ b/packages/chaire-lib-backend/src/services/prompt/CliPromptGeojsonPolygonService.ts
@@ -68,7 +68,7 @@ export class CliPromptGeojsonPolygonService implements PromptGeojsonPolygonServi
                 throw new TypeError('Invalid geojson polygon to fetch osm data in file' + fileName);
             }
             return geojsonPolygon;
-        } catch (error) {
+        } catch {
             throw new Error(
                 'Error reading geojson polygon file. Verify that the file contains a geojson Polygon or a feature collection with the first feature as a polygon: ' +
                     fileName
@@ -99,7 +99,7 @@ export class CliPromptGeojsonPolygonService implements PromptGeojsonPolygonServi
                 throw new TypeError('Invalid geojson feature collection to fetch osm data in file' + fileName);
             }
             return geojsonPolygon;
-        } catch (error) {
+        } catch {
             throw new Error(
                 'Error reading geojson feature collection file. Verify that the file contains a geojson feature collection: ' +
                     fileName

--- a/packages/chaire-lib-backend/src/services/routing/Routing.ts
+++ b/packages/chaire-lib-backend/src/services/routing/Routing.ts
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-import _cloneDeep from 'lodash/cloneDeep';
 import GeoJSON from 'geojson';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 

--- a/packages/chaire-lib-backend/src/services/users/users.ts
+++ b/packages/chaire-lib-backend/src/services/users/users.ts
@@ -42,7 +42,8 @@ export default class Users {
      * @returns The maximum size, in bytes, allowed in the user's data
      * directory.
      */
-    static getUserQuota = (userId: number): number => {
+    // TODO: The userId argument is unused. Either remove it or implement a use for it.
+    static getUserQuota = (_userId: number): number => {
         const quota = bytes.parse(config.userDiskQuota);
         return quota === null ? 0 : quota;
     };

--- a/packages/chaire-lib-backend/src/tasks/user/createUser.ts
+++ b/packages/chaire-lib-backend/src/tasks/user/createUser.ts
@@ -41,7 +41,7 @@ export class CreateUser implements GenericTask {
     private existingUsernames: string[] = [];
 
     private validateUsername = (username: string): boolean | string =>
-        validator.matches(username, /^[a-zA-Z0-9_\-]+$/) && this.existingUsernames.indexOf(username) <= -1
+        validator.matches(username, /^[a-zA-Z0-9_-]+$/) && this.existingUsernames.indexOf(username) <= -1
             ? true
             : 'Username must be composed of digits, letters, underscores or dashes and must be unique.';
 

--- a/packages/chaire-lib-backend/src/utils/osrm/OSRMService.ts
+++ b/packages/chaire-lib-backend/src/utils/osrm/OSRMService.ts
@@ -4,14 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
-
 import osrm from 'osrm';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { transitionRouteOptions, transitionMatchOptions } from 'chaire-lib-common/lib/api/OSRMRouting';
 import * as RoutingService from 'chaire-lib-common/lib/services/routing/RoutingService';
-import { RoutingMode, routingModes } from 'chaire-lib-common/lib/config/routingModes';
+import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
 
 import OSRMMode from './OSRMMode';
 

--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMProcessManager.ts
@@ -139,7 +139,7 @@ const start = function (parameters = {} as any): Promise<any> {
     const tagName = 'osrm';
     const osrmDirectoryPath = getOsrmDirectoryPathForMode(mode, parameters.directoryPrefix);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         const command = 'osrm-routed';
         const commandArgs = getOsrmRoutedStartArgs(osrmDirectoryPath, mode, port);
         const waitString = 'running and waiting for requests';
@@ -157,7 +157,7 @@ const stop = function (parameters): Promise<any> {
     const serviceName = getServiceName(mode, port);
     const tagName = 'osrm';
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         resolve(ProcessManager.stopProcess(tagName, serviceName));
     });
 };
@@ -170,7 +170,7 @@ const restart = function (parameters): Promise<any> {
     const tagName = 'osrm';
     const osrmDirectoryPath = getOsrmDirectoryPathForMode(mode, parameters.directoryPrefix);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         const command = 'osrm-routed';
         const commandArgs = getOsrmRoutedStartArgs(osrmDirectoryPath, mode, port);
         const waitString = 'running and waiting for requests';

--- a/packages/chaire-lib-backend/src/utils/processManagers/OSRMServicePreparation.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/OSRMServicePreparation.ts
@@ -30,7 +30,7 @@ const extract = function (parameters: {
 
     fileManager.directoryManager.createDirectoryIfNotExistsAbsolute(osrmDirectoryPath);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         console.log(`osrm: extracting osm data for mode ${mode} from file ${osmFilePath}`);
 
         try {
@@ -116,7 +116,7 @@ const contract = function (parameters = {} as any): Promise<any> {
     const mode = parameters.mode || 'walking';
     const osrmDirectoryPath = getOsrmDirectoryPathForMode(mode, parameters.directoryPrefix);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         console.log(`osrm: contracting osrm data for mode ${mode} from directory ${osrmDirectoryPath}`);
 
         // contract parameter need to match the prefix of the osm file passed to extract

--- a/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
+++ b/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
@@ -4,13 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
+
 //TODO replace this fetch-retry library with one compatible with TS
 const fetch = require('@zeit/fetch-retry')(require('node-fetch'));
 
 import ServerConfig from '../../config/ServerConfig';
 import * as TrRoutingApi from 'chaire-lib-common/lib/api/TrRouting';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 /**
  * A class that wraps the calls to the trRouting service API


### PR DESCRIPTION
Removed lint warnings from the chaire-lib-backend package, except for "unexpected type any" and require() related ones.

30 warnings got removed (152 to 122)