### PR TITLE
Remove Lint warnings from transition-common

### DIFF
--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/EvolutionaryAlgorithm.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/EvolutionaryAlgorithm.ts
@@ -33,7 +33,7 @@ export const evolutionaryAlgorithmFactory: SimulationAlgorithmFactory<EvolutionA
     simulationRun: SimulationRun
 ): EvolutionaryAlgorithm => new EvolutionaryAlgorithm(options, simulationRun);
 
-export class EvolutionaryAlgorithm implements SimulationAlgorithm<EvolutionAlgorithmOptions> {
+export class EvolutionaryAlgorithm implements SimulationAlgorithm {
     private currentIteration = 1;
 
     constructor(

--- a/packages/transition-backend/src/services/simulation/SimulationExecution.ts
+++ b/packages/transition-backend/src/services/simulation/SimulationExecution.ts
@@ -23,9 +23,8 @@ import config from 'chaire-lib-backend/lib/config/server.config';
  *
  * @export
  * @interface SimulationAlgorithm
- * @template T The type of options
  */
-export type SimulationAlgorithmFactory<T> = (options: T, simulationRun: SimulationRun) => SimulationAlgorithm<T>;
+export type SimulationAlgorithmFactory<T> = (options: T, simulationRun: SimulationRun) => SimulationAlgorithm;
 
 const ALGORITHMS_FACTORY: { [key: string]: SimulationAlgorithmFactory<any> } = {};
 export const registerAlgorithmFactory = (name: string, algorithmFactory: SimulationAlgorithmFactory<any>): void => {

--- a/packages/transition-backend/src/services/simulation/__tests__/SimulationAlgorithmDescriptorStub.ts
+++ b/packages/transition-backend/src/services/simulation/__tests__/SimulationAlgorithmDescriptorStub.ts
@@ -12,7 +12,7 @@ interface AlgorithmStubOptions {
     booleanOption?: boolean;
 }
 
-export class SimulationAlgorithmStub implements SimulationAlgorithm<AlgorithmStubOptions> {
+export class SimulationAlgorithmStub implements SimulationAlgorithm {
 
     constructor(private options: AlgorithmStubOptions) {
 

--- a/packages/transition-common/jest.config.js
+++ b/packages/transition-common/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
@@ -15,7 +15,6 @@ import {
     PlaceDetailedCategory
 } from 'chaire-lib-common/lib/config/osm/osmMappingDetailedCategoryToCategory';
 import NodeCollection from '../nodes/NodeCollection';
-import { placesInWalkingTravelTimeRadiusSeconds } from '../nodes/NodeGeographyUtils';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 export interface TransitAccessibilityMapResult {

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 
 import { featureCollection as turfFeatureCollection, point as turfPoint } from '@turf/turf';
@@ -13,7 +12,7 @@ import { GenericAttributes } from 'chaire-lib-common/lib/utils/objects/GenericOb
 import { ObjectWithHistory } from 'chaire-lib-common/lib/utils/objects/ObjectWithHistory';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { _toInteger, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { validateTrQueryAttributes } from '../transitRouting/TransitRoutingQueryAttributes';
 import { TransitQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
 

--- a/packages/transition-common/src/services/agency/Agency.ts
+++ b/packages/transition-common/src/services/agency/Agency.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
 import { Agency as GtfsAgency } from 'gtfs-types';
 
 import * as Status from 'chaire-lib-common/lib/utils/Status';
@@ -303,7 +302,7 @@ export class Agency extends ObjectWithHistory<AgencyAttributes> implements Savea
             const firstLine = this.getLines()[0];
             const customCachePath = firstLine ? firstLine.getData('customCachePath', null) : undefined;
 
-            return new Promise((resolve, reject) => {
+            return new Promise((resolve, _reject) => {
                 socket.emit('transitLine.deleteMultipleCache', lineIds, customCachePath, (linesCacheDeleteResponse) => {
                     if (!linesCacheDeleteResponse.error) {
                         SaveUtils.delete(this, socket, 'transitAgency', this._collectionManager?.get('agencies')).then(

--- a/packages/transition-common/src/services/agency/AgencyCollection.ts
+++ b/packages/transition-common/src/services/agency/AgencyCollection.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
-
 import Agency from './Agency';
 import CollectionCacheable from 'chaire-lib-common/lib/services/objects/CollectionCacheable';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';

--- a/packages/transition-common/src/services/agency/AgencyDuplicator.ts
+++ b/packages/transition-common/src/services/agency/AgencyDuplicator.ts
@@ -4,9 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-
 import { Agency, AgencyAttributes } from './Agency';
 import { duplicateService } from '../service/ServiceDuplicator';
 import { duplicateLine } from '../line/LineDuplicator';

--- a/packages/transition-common/src/services/gtfs/GtfsExporter.ts
+++ b/packages/transition-common/src/services/gtfs/GtfsExporter.ts
@@ -4,9 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
-import _cloneDeep from 'lodash/cloneDeep';
-
 import { GenericAttributes } from 'chaire-lib-common/lib/utils/objects/GenericObject';
 import { ObjectWithHistory } from 'chaire-lib-common/lib/utils/objects/ObjectWithHistory';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';

--- a/packages/transition-common/src/services/line/Line.ts
+++ b/packages/transition-common/src/services/line/Line.ts
@@ -166,7 +166,8 @@ export class Line extends ObjectWithHistory<LineAttributes> implements Saveable 
         */
     }
 
-    async calculateDeadHeadTravelTimesBetweenPaths(socket) {
+    //TODO: Add functionality to the _socket argument, or remove it.
+    async calculateDeadHeadTravelTimesBetweenPaths(_socket) {
         this.refreshPaths();
         const completePaths = this.getCompletePaths();
         const deadHeadTravelTimesBetweenPathsByPathId = {};

--- a/packages/transition-common/src/services/line/LineDuplicator.ts
+++ b/packages/transition-common/src/services/line/LineDuplicator.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-
 import { Line } from './Line';
 import { Path as TransitPath } from '../path/Path';
 import { duplicateService } from '../service/ServiceDuplicator';

--- a/packages/transition-common/src/services/nodes/Node.ts
+++ b/packages/transition-common/src/services/nodes/Node.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
 import _get from 'lodash/get';
 import _isEqual from 'lodash/isEqual';
 import * as turf from '@turf/turf';
@@ -13,7 +12,6 @@ import * as GtfsTypes from 'gtfs-types';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { GenericPlace, GenericPlaceAttributes } from 'chaire-lib-common/lib/utils/objects/GenericPlace';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import TrError from 'chaire-lib-common/lib/utils/TrError';
 import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -219,7 +217,8 @@ export class Node extends GenericPlace<NodeAttributes> implements Saveable {
         return routingRadiusInPixels;
     }
 
-    calculateOdTripsWeight(dataSourceId) {
+    //TODO: Implement this function, or remove it.
+    calculateOdTripsWeight(_dataSourceId) {
         // Nothing to do. Why?
     }
 
@@ -275,9 +274,9 @@ export class Node extends GenericPlace<NodeAttributes> implements Saveable {
     }
 
     async getIsochroneGeojson(
-        socket,
-        mode = 'walking',
-        durationsMinutes = [5, 10, 15, 20]
+        _socket,
+        _mode = 'walking',
+        _durationsMinutes = [5, 10, 15, 20]
     ): Promise<{ [key: string]: any }> {
         return {};
         /* TODO Disabled since valhalla is broken
@@ -463,7 +462,7 @@ export class Node extends GenericPlace<NodeAttributes> implements Saveable {
     }
 
     async delete(socket: EventEmitter): Promise<Status.Status<{ id: string | undefined }>> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             SaveUtils.delete(this, socket, 'transitNode', this._collectionManager?.get('nodes')).then(
                 (response: Status.Status<{ id: string | undefined }>) => {
                     if (

--- a/packages/transition-common/src/services/nodes/NodeCollection.ts
+++ b/packages/transition-common/src/services/nodes/NodeCollection.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
 import snakeCase from 'lodash/snakeCase';
 import camelCase from 'lodash/camelCase';
 
@@ -67,7 +66,7 @@ export class NodeCollection extends GenericPlaceCollection<NodeAttributes, Node>
     }
 
     updateOdTripsWeights(socket, dataSourceId): Promise<void> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             socket.emit('nodes.calculateOdTripsWeights', dataSourceId, () => {
                 resolve();
             });
@@ -75,7 +74,7 @@ export class NodeCollection extends GenericPlaceCollection<NodeAttributes, Node>
     }
 
     updateOdTripsAccessibleNodes(socket, dataSourceId): Promise<void> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             socket.emit('odTrips.updateAccessibleNodes', dataSourceId, () => {
                 resolve();
             });
@@ -88,7 +87,7 @@ export class NodeCollection extends GenericPlaceCollection<NodeAttributes, Node>
 
     setNetworkTravelTimesForBirdDistanceAccessibleNodes(object, geojson, prefix, mode: RoutingMode = 'walking') {
         // geojson: origin or destination geojson
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             if (_isBlank(geojson) && typeof object.toGeojson === 'function') {
                 geojson = object.toGeojson();
             }

--- a/packages/transition-common/src/services/nodes/NodeGeographyUtils.ts
+++ b/packages/transition-common/src/services/nodes/NodeGeographyUtils.ts
@@ -187,7 +187,7 @@ export const proposeNames = async (
     let radiusAroundMeters = 100;
     const nodeGeojson = node.toGeojson();
     while (intersectionNames !== undefined && intersectionNames.length < 2 && radiusAroundMeters <= maxRadiusMeters) {
-        intersectionNames = await new Promise((resolve, reject) => {
+        intersectionNames = await new Promise((resolve, _reject) => {
             socket.emit(
                 'osm.streetsAroundPoint',
                 nodeGeojson,

--- a/packages/transition-common/src/services/odTrip/BaseOdTripCollection.ts
+++ b/packages/transition-common/src/services/odTrip/BaseOdTripCollection.ts
@@ -57,7 +57,8 @@ class BaseOdTripCollection extends GenericObjectCollection<BaseOdTrip> implement
         });
     }
 
-    newObject(attribs: Partial<GenericAttributes>, isNew = false, collectionManager?: CollectionManager): BaseOdTrip {
+    //TODO: Add functionality to the _collectionManager argument, or remove it.
+    newObject(attribs: Partial<GenericAttributes>, isNew = false, _collectionManager?: CollectionManager): BaseOdTrip {
         return new BaseOdTrip(attribs, isNew);
     }
 

--- a/packages/transition-common/src/services/path/Path.ts
+++ b/packages/transition-common/src/services/path/Path.ts
@@ -1364,7 +1364,7 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
     }
 
     delete(socket): Promise<Status.Status<{ id: string | undefined }>> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             const line: any = this.getLine();
             SaveUtils.delete(this, socket, 'transitPath', this._collectionManager?.get('paths')).then(
                 (response: Status.Status<{ id: string | undefined }>) => {
@@ -1375,7 +1375,7 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
                             });
                             line.refreshPaths();
                             line.refreshStats();
-                            line.save(socket).then((lineSaveResponse) => {
+                            line.save(socket).then((_lineSaveResponse) => {
                                 resolve(response);
                             });
                         } else {
@@ -1392,7 +1392,7 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
     public async save(socket: EventEmitter) {
         if (this.hasChanged() || this.isNew()) {
             this.refreshStats();
-            return new Promise((resolve, reject) => {
+            return new Promise((resolve, _reject) => {
                 const line: any = this.getLine();
                 this.attributes.mode = this.getMode(); // force add mode since it could have been removed when updating
                 SaveUtils.save(this, socket, 'transitPath', this._collectionManager?.get('paths')).then(
@@ -1409,7 +1409,7 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
                                 // TODO Use an update callback
                                 line.refreshPaths();
                                 line.refreshStats();
-                                line.save(socket).then((lineSaveResponse) => {
+                                line.save(socket).then((_lineSaveResponse) => {
                                     resolve(response);
                                 });
                             } else {

--- a/packages/transition-common/src/services/path/PathCollection.ts
+++ b/packages/transition-common/src/services/path/PathCollection.ts
@@ -4,18 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
-import geobuf from 'geobuf';
-import Pbf from 'pbf';
-
 import { Path, PathAttributes } from './Path';
 import CollectionCacheable from 'chaire-lib-common/lib/services/objects/CollectionCacheable';
 import CollectionLoadable from 'chaire-lib-common/lib/services/objects/CollectionLoadable';
 import GenericMapObjectCollection from 'chaire-lib-common/lib/utils/objects/GenericMapObjectCollection';
 import Progressable from 'chaire-lib-common/lib/utils/objects/Progressable';
 import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import TrError from 'chaire-lib-common/lib/utils/TrError';
 
 /**
  * A collection of transit paths

--- a/packages/transition-common/src/services/path/PathGeographyUtils.ts
+++ b/packages/transition-common/src/services/path/PathGeographyUtils.ts
@@ -161,7 +161,7 @@ class PathGeographyUtils {
         let routingSegmentGeojson: FeatureCollection<Point> = this.initializePointGeojsonCollection();
         let lastRoutingType = routingEngine;
 
-        nodesAndWaypointsGeojsons.features.forEach((geojson, geojsonIndex) => {
+        nodesAndWaypointsGeojsons.features.forEach((geojson, _geojsonIndex) => {
             const nodeRoutingType = routingEngine === 'manual' ? 'manual' : geojson.properties?.type || lastRoutingType;
 
             if (nodeRoutingType !== lastRoutingType && routingSegmentGeojson.features.length > 0) {

--- a/packages/transition-common/src/services/places/Place.ts
+++ b/packages/transition-common/src/services/places/Place.ts
@@ -56,7 +56,7 @@ export class Place extends GenericPlace<PlaceAttributes> implements Saveable {
     }
 
     async delete(socket: EventEmitter): Promise<Status.Status<{ id: string | undefined }>> {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve, _reject) => {
             SaveUtils.delete(this, socket, 'Place', this._collectionManager?.get('places')).then(
                 (response: Status.Status<{ id: string | undefined }>) => {
                     if (

--- a/packages/transition-common/src/services/schedules/Schedule.ts
+++ b/packages/transition-common/src/services/schedules/Schedule.ts
@@ -138,7 +138,6 @@ class Schedule extends ObjectWithHistory<ScheduleAttributes> implements Saveable
         // todo
         const period = this.getPeriod(periodShortname);
         if (period) {
-            const minInterval = Infinity;
             const trips = period.trips;
             if (trips && trips.length > 0) {
                 for (let i = 0, count = trips.length; i < count - 1; i++) {
@@ -366,7 +365,7 @@ class Schedule extends ObjectWithHistory<ScheduleAttributes> implements Saveable
                 unitReadyAt: unit.isReadyAtTimeSeconds
             };
             return trip;
-        } catch (error) {
+        } catch {
             throw `The path ${path.getId()} for line ${path.getLine()?.getAttributes().shortname} (${
                 path.attributes.line_id
             }) is not valid. Please recalculate routing for this path`;

--- a/packages/transition-common/src/services/schedules/ScheduleDuplicator.ts
+++ b/packages/transition-common/src/services/schedules/ScheduleDuplicator.ts
@@ -4,9 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
 import { v4 as uuidV4 } from 'uuid';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 
 import Schedule from './Schedule';
 

--- a/packages/transition-common/src/services/service/Service.ts
+++ b/packages/transition-common/src/services/service/Service.ts
@@ -15,7 +15,6 @@ import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
 import { GenericAttributes } from 'chaire-lib-common/lib/utils/objects/GenericObject';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import Line from '../line/Line';
 
 export const serviceDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];

--- a/packages/transition-common/src/services/service/ServiceCollection.ts
+++ b/packages/transition-common/src/services/service/ServiceCollection.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
-
 import Service from './Service';
 import CollectionCacheable from 'chaire-lib-common/lib/services/objects/CollectionCacheable';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';

--- a/packages/transition-common/src/services/service/ServiceDuplicator.ts
+++ b/packages/transition-common/src/services/service/ServiceDuplicator.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
-
 import Service from './Service';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import ServiceCollection from './ServiceCollection';

--- a/packages/transition-common/src/services/simulation/Simulation.ts
+++ b/packages/transition-common/src/services/simulation/Simulation.ts
@@ -12,7 +12,6 @@ import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionMan
 import { ObjectWithHistory } from 'chaire-lib-common/lib/utils/objects/ObjectWithHistory';
 import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GenericAttributes } from 'chaire-lib-common/lib/utils/objects/GenericObject';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { validateTrBaseAttributes } from '../transitRouting/TransitRoutingQueryAttributes';
@@ -172,12 +171,10 @@ class Simulation extends ObjectWithHistory<SimulationAttributes> implements Save
         if (shortname) {
             return slugify(`${shortname}${showId ? '_' + this.id : ''}`, {
                 replacement: '_',
-                remove: /[/^*=;:#$%?&\|\[\]{}\+~.\(\)'"!\\@]/g
+                remove: /[/^*=;:#$%?&|[\]{}+~.()'"!\\@]/g
             }); // regex for valid filenames
         }
-        return showId
-            ? slugify(this.id, { replacement: '_', remove: /[/^*=;:#$%?&\|\[\]{}\+~.\(\)'"!\\@]/g })
-            : undefined; // regex for valid filenames
+        return showId ? slugify(this.id, { replacement: '_', remove: /[/^*=;:#$%?&|[\]{}+~.()'"!\\@]/g }) : undefined; // regex for valid filenames
     }
 
     getAlgorithmDescriptor(): SimulationAlgorithmDescriptor<any> | undefined {

--- a/packages/transition-common/src/services/simulation/SimulationAlgorithm.ts
+++ b/packages/transition-common/src/services/simulation/SimulationAlgorithm.ts
@@ -14,9 +14,10 @@ import ServiceCollection from '../service/ServiceCollection';
  *
  * @export
  * @interface SimulationAlgorithm
- * @template T The type of options
  */
-export interface SimulationAlgorithm<T> {
+// This interface used to have a type variable <T> that was documented as "The type of options".
+// This was completely unused so it was removed, but a comment is left here in case we ever want to implement it again.
+export interface SimulationAlgorithm {
     run: (
         socket: EventEmitter,
         collections: { lines: LineCollection; agencies: AgencyCollection; services: ServiceCollection }

--- a/packages/transition-common/src/services/simulation/SimulationRun.ts
+++ b/packages/transition-common/src/services/simulation/SimulationRun.ts
@@ -10,7 +10,6 @@ import { EventEmitter } from 'events';
 
 import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GenericAttributes, GenericObject } from 'chaire-lib-common/lib/utils/objects/GenericObject';
 import { AlgorithmConfiguration } from './Simulation';
 import { SimulationParameters } from './SimulationParameters';

--- a/packages/transition-common/src/services/simulation/__tests__/SimulationAlgorithmStub.ts
+++ b/packages/transition-common/src/services/simulation/__tests__/SimulationAlgorithmStub.ts
@@ -12,7 +12,7 @@ interface AlgorithmStubOptions {
     booleanOption?: boolean;
 }
 
-export class SimulationAlgorithmStub implements SimulationAlgorithm<AlgorithmStubOptions> {
+export class SimulationAlgorithmStub implements SimulationAlgorithm {
 
     constructor(private options: AlgorithmStubOptions) {
 

--- a/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
+++ b/packages/transition-common/src/services/transitDemand/TransitOdDemandFromCsv.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
-
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import DataSourceCollection from 'chaire-lib-common/lib/services/dataSource/DataSourceCollection';

--- a/packages/transition-common/src/services/transitRouting/TransitRouting.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRouting.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 import GeoJSON from 'geojson';
 

--- a/packages/transition-common/src/services/transitRouting/TransitRoutingResult.ts
+++ b/packages/transition-common/src/services/transitRouting/TransitRoutingResult.ts
@@ -4,8 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _get from 'lodash/get';
-
 import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
 import PathCollection from '../path/PathCollection';
 import { SegmentToGeoJSON, StepGeojsonProperties } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';

--- a/packages/transition-common/src/tasks/populationSynthesis/dataImport/importPlacesAndResidences.task.ts
+++ b/packages/transition-common/src/tasks/populationSynthesis/dataImport/importPlacesAndResidences.task.ts
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /** This file is probably deprecated. It was written initially, but was later replaced by the files in chaire-lib-common/lib/tasks/dataImport */
-import { validate as uuidValidate, v4 as uuidV4 } from 'uuid';
 import inquirer from 'inquirer';
 import inquirerFileTreeSelection from 'inquirer-file-tree-selection-prompt';
 
@@ -31,7 +30,7 @@ async function getOsmData(preAnswers, fileManager) {
                 console.error('Invalid geojson polygon to fetch osm data in file', preAnswers.polygonGeojson);
                 return { osmRawData, osmGeojsonData };
             }
-        } catch (error) {
+        } catch {
             console.error(
                 'Error reading geojson polygon file. Verify that the file contains a geojson Polygon or a feature collection with the first feature as a polygon',
                 preAnswers.polygonGeojson
@@ -53,7 +52,6 @@ async function getOsmData(preAnswers, fileManager) {
 }
 
 async function run(fileManager: any) {
-    const dataSources = []; //serviceLocator.collectionManager.get('dataSources').getFeatures();
     console.log('running');
 
     //choose data source shortname and name:

--- a/packages/transition-common/src/tasks/populationSynthesis/dataImport/importResidentialData.ts
+++ b/packages/transition-common/src/tasks/populationSynthesis/dataImport/importResidentialData.ts
@@ -329,7 +329,7 @@ export class ResidentialDataImporter {
             residentialBuildingsGeojson = overlappingBuildings.notOverlapping;
 
             // First create homes from the OSM residential buildings, removing their corresponding entry in the land role
-            const { residences, remainingLandRole, mismatchCount } = await this.createHomesFromOsmBuildings(
+            const { residences, remainingLandRole } = await this.createHomesFromOsmBuildings(
                 dataSourceName,
                 overlappingBuildings.overlapping,
                 landRoleSplit.overlapping


### PR DESCRIPTION
The lint warnings from transition-common (other than "unexpected any") have been removed.

65 warnings got removed (143 to 78)