### PR TITLE
nodes db: return an empty data field for the geojson collection

### DIFF
--- a/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
@@ -216,6 +216,10 @@ describe(`${objectName}`, () => {
         expect(collection[1].properties.id).toBe(_newObjectAttributes2.id);
         expect(collection[1].properties).toMatchObject(_newObjectAttributes2);
 
+        // data fields should be empty, but present
+        expect(collection[0].properties.data).toEqual({});
+        expect(collection[1].properties.data).toEqual({});
+
     });
 
     test('should read a subset geojson collection from database', async () => {

--- a/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitNodes.db.queries.ts
@@ -80,6 +80,7 @@ const geojsonCollection = async (
     // TODO: we should not fetch the whole data content, we should read node when modifying one instead of creating a Node from the geojson
     try {
         const { nodeIds } = params;
+        // FIXME: The data field is mandatory, so we initialize it with an empty object. It should not be mandatory in the first place.
         const innerQuery = knex(tableName)
             .select(
                 'id',
@@ -92,6 +93,7 @@ const geojsonCollection = async (
             'is_frozen', is_frozen,
             'code', code,
             'name', name,
+            'data', '{}'::jsonb,
             'description', description,
             'geography', ST_AsGeoJSON(geography)::jsonb, 
             'is_enabled', is_enabled,

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
@@ -134,14 +134,10 @@ export class TransitAccessibilityMapResultByNode {
                 continue;
             }
 
-            // FIXME node's 'data' field is not accessible in the frontend
-            // anymore, at least when retrieved from the node collection, so
-            // this feature will not work anymore as long as it is calculated in
-            // the frontend
             const nodeAccessiblePlacesByCategory =
-                nodeAttributes.data?.accessiblePlaces?.walking?.placesByTravelTimeByCategory; // TODO: allow stats for other modes
+                nodeAttributes.data.accessiblePlaces?.walking?.placesByTravelTimeByCategory; // TODO: allow stats for other modes
             const nodeAccessiblePlacesByDetailedCategory =
-                nodeAttributes.data?.accessiblePlaces?.walking?.placesByTravelTimeByDetailedCategory;
+                nodeAttributes.data.accessiblePlaces?.walking?.placesByTravelTimeByDetailedCategory;
             for (let timeMinutes = avgRemainingTimeMinutes; timeMinutes >= 0; timeMinutes--) {
                 if (nodeAccessiblePlacesByCategory) {
                     const accessiblePlacesForTravelTimeByCategory = nodeAccessiblePlacesByCategory[timeMinutes];


### PR DESCRIPTION
The `data` field is mandatory in the `NodesAttributes`, but it was just dropped from the geojson collection. We instead return an empty object for data, to make sure it exists.