### PR TITLE
Remove Lint warnings from transition-frontend

### DIFF
--- a/packages/transition-frontend/jest.config.js
+++ b/packages/transition-frontend/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/transition-frontend/src/app-transition.tsx
+++ b/packages/transition-frontend/src/app-transition.tsx
@@ -8,13 +8,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { I18nextProvider } from 'react-i18next';
-import { BrowserRouter, Router } from 'react-router';
+import { BrowserRouter } from 'react-router';
 
 import i18n from 'chaire-lib-frontend/lib/config/i18n.config';
 import TransitionRouter from './components/routers/TransitionRouter';
 import MainMap from './components/map/TransitionMainMap';
 import configureStore from 'chaire-lib-frontend/lib/store/configureStore';
-import { login, logout } from 'chaire-lib-frontend/lib/actions/Auth';
 import { LoadingPage } from 'chaire-lib-frontend/lib/components/pages';
 import config from 'chaire-lib-frontend/lib/config/project.config';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';

--- a/packages/transition-frontend/src/components/dashboard/TransitionBottomPanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionBottomPanel.tsx
@@ -11,7 +11,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Path from 'transition-common/lib/services/path/Path';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
 
-const BottomPanel: React.FunctionComponent<LayoutSectionProps> = (props: LayoutSectionProps) => {
+const BottomPanel: React.FunctionComponent<LayoutSectionProps> = (_props: LayoutSectionProps) => {
     const [path, setPath] = React.useState<{ path: Path | undefined }>({
         path: serviceLocator.selectedObjectsManager.get('path')
     });

--- a/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
@@ -218,7 +218,7 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
         }
     };
 
-    onPreferencesChange = (updates: any) => {
+    onPreferencesChange = (_updates: any) => {
         const infoPanelPosition = Preferences.get('infoPanelPosition');
         this.setState({ infoPanelPosition });
     };

--- a/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
@@ -17,7 +17,7 @@ interface TransitionFSPanelState {
     selectedSchedule?: Schedule;
 }
 
-const FullSizePanel: React.FunctionComponent<LayoutSectionProps> = (props: LayoutSectionProps) => {
+const FullSizePanel: React.FunctionComponent<LayoutSectionProps> = (_props: LayoutSectionProps) => {
     const [state, setState] = React.useState<TransitionFSPanelState>({
         selectedLine: serviceLocator.selectedObjectsManager.get('line'),
         selectedSchedule: serviceLocator.selectedObjectsManager.get('schedule')
@@ -25,11 +25,13 @@ const FullSizePanel: React.FunctionComponent<LayoutSectionProps> = (props: Layou
 
     React.useEffect(() => {
         const onSelectedLineUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ selectedLine, ...rest }) => ({
                 ...rest,
                 selectedLine: serviceLocator.selectedObjectsManager.get('line')
             }));
         const onSelectedScheduleUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ selectedSchedule, ...rest }) => ({
                 ...rest,
                 selectedSchedule: serviceLocator.selectedObjectsManager.get('schedule')

--- a/packages/transition-frontend/src/components/dashboard/TransitionToolbar.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionToolbar.tsx
@@ -78,7 +78,7 @@ class Toolbar extends React.Component<LayoutSectionProps & WithTranslation, Tran
         serviceLocator.layerManager._enabledLayers.forEach((layerName) => {
             layersVisibility[layerName] = serviceLocator.layerManager.layerIsVisible(layerName);
         });
-        this.setState((oldState) => {
+        this.setState((_oldState) => {
             return {
                 layersVisibility
             };

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -10,11 +10,8 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import Loader from 'react-spinners/BeatLoader';
 
 import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload';
-import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 import _toString from 'lodash/toString';
-import { parseCsvFile } from 'chaire-lib-common/lib/utils/files/CsvFile';
-import slugify from 'slugify';
 
 import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
@@ -132,7 +129,7 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
         // ** File upload
 
         // upload csv file to server:
-        const uploadIds = this.props.fileUploader.upload(this.props.fileImportRef.current, {
+        this.props.fileUploader.upload(this.props.fileImportRef.current, {
             uploadTo: 'imports',
             data: {
                 objects: 'csv',
@@ -142,7 +139,7 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
 
         this.state.object.updateRoutingPrefs();
 
-        this.setState((oldState) => {
+        this.setState((_oldState) => {
             return {
                 csvUploadedToServer: true
             };
@@ -202,8 +199,6 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
             !_isBlank(accessMapRouting.attributes.timeAttribute) &&
             !_isBlank(accessMapRouting.attributes.timeFormat) &&
             !_isBlank(accessMapRouting.attributes.timeAttributeDepartureOrArrival);
-
-        const slugifiedCalculationName = slugify(accessMapRouting.attributes.calculationName || '');
 
         const errors = this.state.errors;
         const warnings = this.state.warnings;

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -34,7 +34,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import DownloadsUtils from 'chaire-lib-frontend/lib/services/DownloadsService';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
-import { _toInteger, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import {
     secondsSinceMidnightToTimeStr,
     secondsToMinutes,
@@ -135,7 +135,7 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                 return;
             }
             this.polygonCalculated(currentResult);
-        } catch (error) {
+        } catch {
             this.setState({
                 routingErrors: ['main:errors:ErrorCalculatingAccessibilityMap']
             });

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapStatsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapStatsComponent.tsx
@@ -7,7 +7,6 @@
 import React, { JSX } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 export interface AccessibilityMapStatsComponentProps extends WithTranslation {
     accessibilityPolygons: GeoJSON.FeatureCollection;
 }

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import MathJax from 'react-mathjax';
-import _get from 'lodash/get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 
 import Button from 'chaire-lib-frontend/lib/components/input/Button';

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyPanel.tsx
@@ -10,7 +10,6 @@ import Collapsible from 'react-collapsible';
 import { faFileUpload } from '@fortawesome/free-solid-svg-icons/faFileUpload';
 
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionDownloadButtons from 'chaire-lib-frontend/lib/components/pageParts/CollectionDownloadButtons';
 import CollectionSaveToCacheButtons from '../../parts/CollectionSaveToCacheButtons';
@@ -64,36 +63,43 @@ const AgencyPanel: React.FunctionComponent<AgencyPanelProps> = (props: AgencyPan
 
     React.useEffect(() => {
         const onAgencyCollectionUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ agencyCollection, ...rest }) => ({
                 ...rest,
                 agencyCollection: serviceLocator.collectionManager.get('agencies')
             }));
         const onSelectedAgencyUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ selectedAgency, ...rest }) => ({
                 ...rest,
                 selectedAgency: serviceLocator.selectedObjectsManager.get('agency')
             }));
         const onLineCollectionUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ lineCollection, ...rest }) => ({
                 ...rest,
                 lineCollection: serviceLocator.collectionManager.get('lines')
             }));
         const onSelectedLineUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ selectedLine, ...rest }) => ({
                 ...rest,
                 selectedLine: serviceLocator.selectedObjectsManager.get('line')
             }));
         const onPathCollectionUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ pathCollection, ...rest }) => ({
                 ...rest,
                 pathCollection: serviceLocator.collectionManager.get('paths')
             }));
         const onSelectedPathUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ selectedPath, ...rest }) => ({
                 ...rest,
                 selectedPath: serviceLocator.selectedObjectsManager.get('path')
             }));
         const onSelectedScheduleUpdate = () =>
+            /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
             setState(({ selectedSchedule, ...rest }) => ({
                 ...rest,
                 selectedSchedule: serviceLocator.selectedObjectsManager.get('schedule')

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _get from 'lodash/get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
@@ -56,7 +55,7 @@ const BatchCalculationList: React.FunctionComponent<BatchCalculationListProps> =
                     icon={faPlus}
                     iconClass="_icon"
                     label={props.t('transit:batchCalculation:New')}
-                    onClick={(e) => props.onNewAnalysis()}
+                    onClick={() => props.onNewAnalysis()}
                 />
             </div>
             {errors.length > 0 && <FormErrors errors={errors} />}

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationPanel.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import BatchCalculationList from './BatchCalculationList';
-import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import BatchCalculationForm from './BatchCalculationForm';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
@@ -18,9 +17,11 @@ export interface CalculationPanelPanelProps {
 }
 
 const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps> = (props: CalculationPanelPanelProps) => {
-    const [scenarioCollection, setScenarioCollection] = React.useState<ScenarioCollection | undefined>(
-        serviceLocator.collectionManager.get('scenarios')
-    );
+    // TODO: scenarioCollection is never read. Implement a use for it, or remove the hook and onScenarioCollectionUpdate() entirely.
+    // const [scenarioCollection, setScenarioCollection] = React.useState<ScenarioCollection | undefined>(
+    //     serviceLocator.collectionManager.get('scenarios')
+    // );
+
     const [isNewAnalysis, setIsNewAnalysis] = React.useState(false);
     const [initialValues, setInitialValues] = React.useState<
         | {
@@ -32,7 +33,7 @@ const CalculationPanel: React.FunctionComponent<CalculationPanelPanelProps> = (p
     >(undefined);
 
     const onScenarioCollectionUpdate = () => {
-        setScenarioCollection(serviceLocator.collectionManager.get('scenarios'));
+        //setScenarioCollection(serviceLocator.collectionManager.get('scenarios'));
     };
 
     const onNewAnalysis = (parameters?: {

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsExportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsExportForm.tsx
@@ -4,10 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React, { JSX } from 'react';
+import React from 'react';
 import { faFileDownload } from '@fortawesome/free-solid-svg-icons/faFileDownload';
 import { faTasks } from '@fortawesome/free-solid-svg-icons/faTasks';
-import _get from 'lodash/get';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import slugify from 'slugify';
 import { v4 as uuidV4 } from 'uuid';
@@ -19,7 +18,6 @@ import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors'
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import GtfsExporter from 'transition-common/lib/services/gtfs/GtfsExporter';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GtfsConstants, GtfsExportStatus } from 'transition-common/lib/api/gtfs';
 
 class GtfsExportForm extends ChangeEventsForm<WithTranslation, ChangeEventsState<GtfsExporter>> {

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportAgenciesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportAgenciesComponent.tsx
@@ -5,7 +5,6 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
 
 import { AgencyImportData } from 'transition-common/lib/services/gtfs/GtfsImportTypes';
 import { InputCheckbox } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportForm.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload';
 import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
-import _get from 'lodash/get';
 import Loader from 'react-spinners/BeatLoader';
 import SocketIOFileClient from 'socket.io-file-client';
 import { withTranslation, WithTranslation } from 'react-i18next';
@@ -248,8 +247,9 @@ class GtfsImportForm extends React.Component<GtfsImportProps, GtfsImportState> {
         }
     };
 
-    importGtfsData = (e) => {
+    importGtfsData = (_e) => {
         const validator = this.state.validator;
+        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
         const { periodsGroupShortname, ...rest } = this.state.availableImportData;
         // import
         if (this.state.operationInProgress) {
@@ -336,7 +336,7 @@ class GtfsImportForm extends React.Component<GtfsImportProps, GtfsImportState> {
                             id={`formFieldTransitGtfsImporterFile${validatorId}`}
                             accept=".zip"
                             inputRef={this._fileImportRef}
-                            onChange={(e) => {
+                            onChange={() => {
                                 this.setState({
                                     validator: new GtfsValidator({}),
                                     uploadError: false

--- a/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import Collapsible from 'react-collapsible';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
-import _get from 'lodash/get';
 
 import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
 import InputText from 'chaire-lib-frontend/lib/components/input/InputText';

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeCollectionEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeCollectionEdit.tsx
@@ -20,7 +20,7 @@ import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { _isBlank, _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeEdit.tsx
@@ -10,7 +10,6 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import _cloneDeep from 'lodash/cloneDeep';
 import _toString from 'lodash/toString';
 import { featureCollection as turfFeatureCollection } from '@turf/turf';
-import _uniq from 'lodash/uniq';
 
 import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
 import InputText from 'chaire-lib-frontend/lib/components/input/InputText';

--- a/packages/transition-frontend/src/components/forms/node/TransitNodePanel.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodePanel.tsx
@@ -11,7 +11,6 @@ import { faFileUpload } from '@fortawesome/free-solid-svg-icons/faFileUpload';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
 
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionDownloadButtons from 'chaire-lib-frontend/lib/components/pageParts/CollectionDownloadButtons';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeStatistics.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeStatistics.tsx
@@ -8,26 +8,11 @@ import React from 'react';
 import _uniq from 'lodash/uniq';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
 import Node from 'transition-common/lib/services/nodes/Node';
 import Line from 'transition-common/lib/services/line/Line';
 import Path from 'transition-common/lib/services/path/Path';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-
-const SimpleRow: React.FunctionComponent<{ header: string; value?: string | number; isHeader?: boolean }> = ({
-    header,
-    value = '',
-    isHeader = false
-}) => {
-    return (
-        <tr>
-            <th className={isHeader ? '_header' : ''}>{header}</th>
-            <td>{value}</td>
-        </tr>
-    );
-};
 
 const SingleColumn: React.FunctionComponent<{ header: string; values?: string[] | number[]; isHeader?: boolean }> = ({
     header,

--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -32,7 +32,6 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import PathStatistics from './TransitPathStatistics';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import lineModesConfig from 'transition-common/lib/config/lineModes';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { SaveableObjectForm, SaveableObjectState } from 'chaire-lib-frontend/lib/components/forms/SaveableObjectForm';
 import { parseIntOrNull, parseFloatOrNull } from 'chaire-lib-common/lib/utils/MathUtils';
 import Path, { pathDirectionArray } from 'transition-common/lib/services/path/Path';
@@ -235,7 +234,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
             layerName: 'transitPathWaypointsSelected',
             data: turfFeatureCollection([waypointGeojson])
         });
-        this.setState((oldState) => {
+        this.setState((_oldState) => {
             return {
                 waypointDraggingAfterNodeIndex: waypointGeojson.properties.afterNodeIndex,
                 waypointDraggingIndex: waypointGeojson.properties.waypointIndex
@@ -294,7 +293,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                     this.state.waypointDraggingAfterNodeIndex || 0,
                     this.state.waypointDraggingIndex || 0
                 )
-                .then((response) => {
+                .then((_response) => {
                     this.props.path.validate();
                     serviceLocator.selectedObjectsManager.update('path', this.props.path);
                     serviceLocator.eventManager.emit('selected.updateLayers.path');
@@ -737,7 +736,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                         progress: 0.0
                                     });
                                     path.updateGeography()
-                                        .then((response) => {
+                                        .then((_response) => {
                                             serviceLocator.selectedObjectsManager.update('path', path);
                                             this.updateLayers();
                                             serviceLocator.eventManager.emit('progress', {
@@ -774,7 +773,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                                     name: 'SavingPath',
                                                     progress: 0.0
                                                 });
-                                                path.save(serviceLocator.socketEventManager).then((response) => {
+                                                path.save(serviceLocator.socketEventManager).then((_response) => {
                                                     serviceLocator.selectedObjectsManager.deselect('path');
                                                     line.refreshPaths();
                                                     serviceLocator.eventManager.emit('progress', {

--- a/packages/transition-frontend/src/components/forms/path/TransitPathStatistics.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathStatistics.tsx
@@ -9,7 +9,6 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import MathJax from 'react-mathjax';
 
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
 import SpeedUnitFormatter from 'chaire-lib-frontend/lib/components/pageParts/SpeedUnitFormatter';
 import DistanceUnitFormatter from 'chaire-lib-frontend/lib/components/pageParts/DistanceUnitFormatter';
 import DurationUnitFormatter from 'chaire-lib-frontend/lib/components/pageParts/DurationUnitFormatter';

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
@@ -6,13 +6,11 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _cloneDeep from 'lodash/cloneDeep';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { PreferencesClass, default as preferences } from 'chaire-lib-common/lib/config/Preferences';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import { SaveableObjectForm, SaveableObjectState } from 'chaire-lib-frontend/lib/components/forms/SaveableObjectForm';
-import { _toInteger, _toBool, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import SelectedObjectButtons from 'chaire-lib-frontend/lib/components/pageParts/SelectedObjectButtons';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import PreferencesSectionGeneral from './sections/PreferencesSectionGeneral';
@@ -84,7 +82,6 @@ class PreferencesPanel extends SaveableObjectForm<PreferencesClass, PreferencesP
     }
 
     render() {
-        const prefs = this.state.object.getAttributes();
         const errors = this.state.object.getErrors() || [];
 
         return (

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesResetToDefaultButton.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesResetToDefaultButton.tsx
@@ -27,7 +27,7 @@ const PreferencesResetToDefaultButton: React.FunctionComponent<PreferencesResetT
             }
             iconPath={'/dist/images/icons/interface/gear_reset_white.svg'}
             iconClass="_icon-alone"
-            onClick={(e) => props.resetPrefToDefault(props.path)}
+            onClick={() => props.resetPrefToDefault(props.path)}
             title={props.t('main:preferences:ResetToDefault')}
         />
     );

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
@@ -15,8 +15,6 @@ import PreferencesSectionProps from '../PreferencesSectionProps';
 const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
     props: PreferencesSectionProps & WithTranslation
 ) => {
-    const prefs = props.preferences.getAttributes();
-
     return (
         <Collapsible trigger={props.t('main:preferences:ExperimentalFeatures')} open={true} transitionTime={100}>
             <div className="tr__form-section">

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
@@ -13,7 +13,7 @@ import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper'
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import PreferencesSectionLineModeProps from '../PreferencesSectionLineModeProps';
-import { parseIntOrNull, parseFloatOrNull } from 'chaire-lib-common/lib/utils/MathUtils';
+import { parseFloatOrNull } from 'chaire-lib-common/lib/utils/MathUtils';
 
 const PreferencesSectionTransitLineMode: React.FunctionComponent<PreferencesSectionLineModeProps & WithTranslation> = (
     props: PreferencesSectionLineModeProps & WithTranslation

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
@@ -8,11 +8,10 @@ import React from 'react';
 
 import PreferencesSectionProps from '../PreferencesSectionProps';
 
+// TODO: Implement this component or delete it.
 const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSectionProps> = (
-    props: PreferencesSectionProps
+    _props: PreferencesSectionProps
 ) => {
-    const prefs = props.preferences.getAttributes();
-
     return null;
 };
 

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitScenarios.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitScenarios.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import Collapsible from 'react-collapsible';
 import { WithTranslation, withTranslation } from 'react-i18next';
-import _toString from 'lodash/toString';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioEdit.tsx
@@ -73,7 +73,7 @@ class TransitScenarioEdit extends SaveableObjectForm<Scenario, ScenarioFormProps
                         }
                     );
                     this.setState({ paths });
-                } catch (_error) {
+                } catch {
                     (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>(
                         'map.updateLayer',
                         {

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
@@ -6,7 +6,6 @@
  */
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _get from 'lodash/get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 
 import TransitScenario from 'transition-common/lib/services/scenario/Scenario';

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioPanel.tsx
@@ -9,7 +9,6 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import { faFileUpload } from '@fortawesome/free-solid-svg-icons/faFileUpload';
 
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionDownloadButtons from 'chaire-lib-frontend/lib/components/pageParts/CollectionDownloadButtons';
 import CollectionSaveToCacheButtons from '../../parts/CollectionSaveToCacheButtons';

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceList.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceList.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useState } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _get from 'lodash/get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
 

--- a/packages/transition-frontend/src/components/forms/service/TransitServicePanel.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServicePanel.tsx
@@ -9,7 +9,6 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 import { faFileUpload } from '@fortawesome/free-solid-svg-icons/faFileUpload';
 
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionDownloadButtons from 'chaire-lib-frontend/lib/components/pageParts/CollectionDownloadButtons';
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
@@ -33,7 +32,6 @@ const ServicesPanel: React.FunctionComponent<WithTranslation> = (props: WithTran
         serviceCollection: serviceLocator.collectionManager.get('services'),
         selectedService: serviceLocator.selectedObjectsManager.get('service')
     });
-    const [_servicesReloaded, setServiceReloaded] = React.useState(false);
 
     const onServiceCollectionUpdate = () =>
         setState(({ selectedService }) => ({
@@ -52,11 +50,7 @@ const ServicesPanel: React.FunctionComponent<WithTranslation> = (props: WithTran
         serviceLocator.eventManager.on('selected.deselect.service', onSelectedServiceUpdate);
         // Reload the service collections at mount time, to make sure it is up to date
         if (state.serviceCollection) {
-            state.serviceCollection
-                .loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager)
-                .then(() => {
-                    setServiceReloaded(true);
-                });
+            state.serviceCollection.loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager);
         }
         return () => {
             serviceLocator.eventManager.off('collection.update.services', onServiceCollectionUpdate);

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationList.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationList.tsx
@@ -4,9 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _get from 'lodash/get';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 
 import Simulation from 'transition-common/lib/services/simulation/Simulation';
@@ -23,8 +22,6 @@ interface SimulationListProps extends WithTranslation {
 }
 
 const SimulationList: React.FunctionComponent<SimulationListProps> = (props: SimulationListProps) => {
-    const [showModal, setShowModal] = useState(false);
-
     const newSimulation = function () {
         const defaultColor = Preferences.get('transit.simulations.defaultColor', '#0086FF');
         const newSimulation = new Simulation({ color: defaultColor }, true, serviceLocator.collectionManager);

--- a/packages/transition-frontend/src/components/forms/simulation/SimulationPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/SimulationPanel.tsx
@@ -31,7 +31,6 @@ const SimulationsPanel: React.FunctionComponent = () => {
     const [dataLoaded, setDataLoaded] = React.useState(
         serviceCollection !== undefined && agencyCollection !== undefined && lineCollection !== undefined
     );
-    const [_simulationReloaded, setSimulationReloaded] = React.useState(false);
 
     const onSimulationCollectionUpdate = () =>
         setState(({ selectedSimulation }) => ({
@@ -63,11 +62,10 @@ const SimulationsPanel: React.FunctionComponent = () => {
         serviceLocator.eventManager.on('selected.deselect.simulation', onSelectedSimulationUpdate);
         // Reload the service collections at mount time, to make sure it is up to date
         if (state.simulationCollection) {
-            state.simulationCollection
-                .loadFromServer(serviceLocator.socketEventManager, serviceLocator.collectionManager)
-                .then(() => {
-                    setSimulationReloaded(true);
-                });
+            state.simulationCollection.loadFromServer(
+                serviceLocator.socketEventManager,
+                serviceLocator.collectionManager
+            );
         }
         if (!dataLoaded) {
             serviceLocator.eventManager.on('collection.update.agencies', onOtherCollectionUpdate);

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunButton.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunButton.tsx
@@ -108,7 +108,7 @@ const SimulationRunButton: React.FunctionComponent<SimulationRunButtonProps> = (
                         cancel: {
                             label: props.t('transit:simulation:SimulationRunDeleteCancel'),
                             color: 'grey',
-                            action: (e) => setDeleteCascadeModalIsOpen(false)
+                            action: (_e) => setDeleteCascadeModalIsOpen(false)
                         },
                         ignore: {
                             label: props.t('transit:simulation:SimulationRunDeleteNoCascade'),

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunList.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/SimulationRunList.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useState } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import _get from 'lodash/get';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Simulation from 'transition-common/lib/services/simulation/Simulation';

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -10,7 +10,6 @@ import { faAngleLeft } from '@fortawesome/free-solid-svg-icons/faAngleLeft';
 
 import TransitRoutingResults from './TransitRoutingResultComponent';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { RoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultsComponent.tsx
@@ -4,11 +4,10 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
 import RoutingResultComponent from './RoutingResultComponent';
 import { TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
@@ -50,7 +49,7 @@ const RoutingResults: React.FunctionComponent<TransitRoutingResultsProps> = (pro
         <React.Fragment>
             <Tabs
                 selectedIndex={props.selectedMode !== undefined ? selectedRoutingModes.indexOf(props.selectedMode) : 0}
-                onSelect={function (index, lastIndex, e) {
+                onSelect={function (index, lastIndex, _e) {
                     if (index !== lastIndex) {
                         // check if selection changed
                         props.setSelectedMode(selectedRoutingModes[index]);

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -407,7 +407,7 @@ class TransitRoutingForm extends ChangeEventsForm<TransitRoutingFormProps, Trans
                                         size="small"
                                         label={this.props.t('transit:transitRouting:SaveTrip')}
                                         color="blue"
-                                        onClick={(e) => this.saveRoutingForBatch(routing)}
+                                        onClick={() => this.saveRoutingForBatch(routing)}
                                     />
                                 </div>
                                 {this.state.object.getAttributes().savedForBatch.length > 0 && (

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingResultComponent.tsx
@@ -13,7 +13,6 @@ import RouteButton from './RouteButton';
 import DistanceUnitFormatter from 'chaire-lib-frontend/lib/components/pageParts/DistanceUnitFormatter';
 import DurationUnitFormatter from 'chaire-lib-frontend/lib/components/pageParts/DurationUnitFormatter';
 import { secondsToMinutes, secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
 import { Route } from 'chaire-lib-common/lib/services/routing/RoutingService';
 import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -347,7 +347,7 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
             (polygon) => {
                 this.handleDrawPolygonService(polygon);
             },
-            (polygon) => {
+            (_polygon) => {
                 /* Nothing to do */
             }
         );
@@ -428,7 +428,7 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         const selectedNodes = serviceLocator.selectedObjectsManager.get('selectedNodes');
 
         deleteUnusedNodes(selectedNodes.map((n) => n.getId()))
-            .then((response) => {
+            .then((_response) => {
                 serviceLocator.selectedObjectsManager.deselect('node');
                 serviceLocator.collectionManager.refresh('nodes');
                 serviceLocator.eventManager.emit('map.updateLayers', {

--- a/packages/transition-frontend/src/components/parts/CollectionSaveToCacheButtons.tsx
+++ b/packages/transition-frontend/src/components/parts/CollectionSaveToCacheButtons.tsx
@@ -10,7 +10,6 @@ import { faArchive } from '@fortawesome/free-solid-svg-icons/faArchive';
 
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import GenericCollection from 'chaire-lib-common/lib/utils/objects/GenericCollection';
 
 interface CollectionSaveToCacheProps extends WithTranslation {

--- a/packages/transition-frontend/src/components/parts/FileImportForm.tsx
+++ b/packages/transition-frontend/src/components/parts/FileImportForm.tsx
@@ -12,7 +12,6 @@ import { faUpload } from '@fortawesome/free-solid-svg-icons/faUpload';
 
 import InputFile from 'chaire-lib-frontend/lib/components/input/InputFile';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import FileUploaderHOC, { FileUploaderHOCProps } from 'chaire-lib-frontend/lib/components/input/FileUploaderHOC';
 
 interface FileImportFormProps extends FileUploaderHOCProps {
@@ -26,8 +25,6 @@ interface FileImportFormProps extends FileUploaderHOCProps {
 const FileImportForm: React.FunctionComponent<FileImportFormProps & WithTranslation> = (
     props: FileImportFormProps & WithTranslation
 ) => {
-    const [fileSelected, setFileSelected] = React.useState(false);
-
     return (
         <form
             id={`tr__form-transit-${props.pluralizedObjectsName}-import`}
@@ -41,7 +38,6 @@ const FileImportForm: React.FunctionComponent<FileImportFormProps & WithTranslat
                         id={`formField${_upperFirst(props.pluralizedObjectsName)}ImporterFile`}
                         accept={props.acceptsExtension}
                         inputRef={props.fileImportRef}
-                        onChange={() => setFileSelected(true)}
                     />
                 </div>
             </div>
@@ -61,7 +57,7 @@ const FileImportForm: React.FunctionComponent<FileImportFormProps & WithTranslat
                         color="blue"
                         onClick={() => {
                             // upload
-                            const uploadIds = props.fileUploader.upload(props.fileImportRef.current, {
+                            props.fileUploader.upload(props.fileImportRef.current, {
                                 uploadTo: 'imports',
                                 data: {
                                     objects: props.pluralizedObjectsName,

--- a/packages/transition-frontend/src/components/parts/executableJob/ExecutableJobComponent.tsx
+++ b/packages/transition-frontend/src/components/parts/executableJob/ExecutableJobComponent.tsx
@@ -66,7 +66,7 @@ const cancelJobFromServer = (id: number): Promise<Status.Status<boolean>> => {
 };
 
 const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProps & WithTranslation> = (
-    props: ExecutableJobComponentProps & WithTranslation
+    componentProps: ExecutableJobComponentProps & WithTranslation
 ) => {
     // We'll start our table without any data
     const [data, setData] = React.useState<ReturnedJobAttributes[]>([]);
@@ -86,7 +86,7 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
         setLoading(true);
 
         try {
-            const status = await fetchFromSocket({ jobType: props.jobType, pageSize, pageIndex });
+            const status = await fetchFromSocket({ jobType: componentProps.jobType, pageSize, pageIndex });
 
             if (fetchId !== fetchIdRef.current) {
                 // There was another query since, ignore
@@ -131,13 +131,13 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
     const columns = React.useMemo(() => {
         const columns = [
             {
-                Header: props.t('transit:jobs:Date'),
+                Header: componentProps.t('transit:jobs:Date'),
                 accessor: 'created_at',
                 width: 100,
                 Cell: (props) => moment(props.value).format(Preferences.get('dateTimeFormat'))
             },
             {
-                Header: props.t('transit:jobs:EndTime'),
+                Header: componentProps.t('transit:jobs:EndTime'),
                 accessor: 'updated_at',
                 width: 100,
                 Cell: (cellProps) =>
@@ -146,17 +146,17 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                         : null
             },
             {
-                Header: props.t('transit:jobs:Status'),
+                Header: componentProps.t('transit:jobs:Status'),
                 accessor: 'status',
                 width: 70,
                 Cell: (cellProps) => (
                     <div className={`status_${cellProps.value}`}>
-                        {props.t(`transit:jobs:Status_${cellProps.value}`)}
+                        {componentProps.t(`transit:jobs:Status_${cellProps.value}`)}
                     </div>
                 )
             },
             {
-                Header: props.t('transit:jobs:Data'),
+                Header: componentProps.t('transit:jobs:Data'),
                 accessor: 'data',
                 Cell: (cellProps) => (
                     <ExpandableText textToShorten={JSON.stringify(cellProps.value)}>
@@ -171,14 +171,14 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                 )
             },
             {
-                Header: props.t('transit:jobs:Resources'),
+                Header: componentProps.t('transit:jobs:Resources'),
                 accessor: 'hasFiles',
                 Cell: (cellProps) =>
                     cellProps.value !== true ? (
                         '--'
                     ) : (
                         <ExpandableFiles
-                            showFileText={props.t('transit:jobs:ShowFiles')}
+                            showFileText={componentProps.t('transit:jobs:ShowFiles')}
                             jobId={cellProps.row.original.id}
                         />
                     )
@@ -195,8 +195,8 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                             flushActionButtons={true}
                             onDelete={{
                                 handler: () => deleteJob(cellProps.value),
-                                message: props.t('transit:jobs:ConfirmDelete'),
-                                altText: props.t('transit:jobs:Delete')
+                                message: componentProps.t('transit:jobs:ConfirmDelete'),
+                                altText: componentProps.t('transit:jobs:Delete')
                             }}
                         >
                             {(cellProps.row.original.status === 'pending' ||
@@ -204,21 +204,21 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                                 <ButtonCellWithConfirm
                                     alignment="flush"
                                     onClick={() => cancelJob(cellProps.value)}
-                                    title={props.t('transit:jobs:Cancel')}
-                                    message={props.t('transit:jobs:ConfirmCancel')}
-                                    confirmButtonText={props.t('transit:jobs:Cancel')}
+                                    title={componentProps.t('transit:jobs:Cancel')}
+                                    message={componentProps.t('transit:jobs:ConfirmCancel')}
+                                    confirmButtonText={componentProps.t('transit:jobs:Cancel')}
                                 >
                                     <FontAwesomeIcon icon={faStopCircle} />
                                 </ButtonCellWithConfirm>
                             )}
-                            {props.customActions !== undefined &&
-                                props.customActions.length > 0 &&
-                                props.customActions.map((action, index) => (
+                            {componentProps.customActions !== undefined &&
+                                componentProps.customActions.length > 0 &&
+                                componentProps.customActions.map((action, index) => (
                                     <ButtonCell
                                         key={`execJob_customAction${index}`}
                                         alignment="flush"
                                         onClick={() => action.callback(cellProps.value)}
-                                        title={props.t(action.title)}
+                                        title={componentProps.t(action.title)}
                                     >
                                         <FontAwesomeIcon icon={action.icon} />
                                     </ButtonCell>
@@ -228,14 +228,14 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                 )
             }
         ] as Column<ReturnedJobAttributes>[];
-        if (props.jobType === undefined) {
+        if (componentProps.jobType === undefined) {
             columns.push({
-                Header: props.t('transit:jobs:JobType') as string,
+                Header: componentProps.t('transit:jobs:JobType') as string,
                 accessor: 'name'
             });
         }
         return columns;
-    }, [props.t, props.jobType]);
+    }, [componentProps.t, componentProps.jobType]);
 
     return (
         <div className="admin">
@@ -246,8 +246,8 @@ const ExecutableJobComponent: React.FunctionComponent<ExecutableJobComponentProp
                 loading={loading}
                 pageCount={pageCount}
                 itemCount={totalCount}
-                defaultPageSize={props.defaultPageSize}
-                jobType={props.jobType}
+                defaultPageSize={componentProps.defaultPageSize}
+                jobType={componentProps.jobType}
             />
         </div>
     );

--- a/packages/transition-frontend/src/components/parts/executableJob/ExpandableFileWidget.tsx
+++ b/packages/transition-frontend/src/components/parts/executableJob/ExpandableFileWidget.tsx
@@ -47,7 +47,7 @@ const ExpandableFileWidget: React.FunctionComponent<ExpandableFileProps & WithTr
     if (!expanded) {
         return (
             <div
-                onClick={(e) => {
+                onClick={() => {
                     setExpanded(true);
                     setLoadRequested(true);
                 }}
@@ -59,7 +59,7 @@ const ExpandableFileWidget: React.FunctionComponent<ExpandableFileProps & WithTr
     }
     return (
         <div>
-            <FontAwesomeIcon onClick={(e) => setExpanded(false)} icon={faChevronUp} />
+            <FontAwesomeIcon onClick={() => setExpanded(false)} icon={faChevronUp} />
             {files &&
                 Object.keys(files).map((fileName, fileIdx) => (
                     <p key={`jobFile${props.jobId}_${fileIdx}`}>

--- a/packages/transition-frontend/src/components/parts/executableJob/ExpandableText.tsx
+++ b/packages/transition-frontend/src/components/parts/executableJob/ExpandableText.tsx
@@ -19,14 +19,14 @@ const ExpandableText: React.FunctionComponent<React.PropsWithChildren<Expandable
     if (expanded) {
         return (
             <div>
-                <FontAwesomeIcon onClick={(e) => setExpanded(false)} icon={faChevronUp} />
+                <FontAwesomeIcon onClick={() => setExpanded(false)} icon={faChevronUp} />
                 {props.children}
             </div>
         );
     }
     const stringToShorten = props.textToShorten || '';
     const shortenedText = stringToShorten.length <= 20 ? stringToShorten : `${stringToShorten.substring(0, 20)}...`;
-    return <div onClick={(e) => setExpanded(true)}>{shortenedText}</div>;
+    return <div onClick={() => setExpanded(true)}>{shortenedText}</div>;
 };
 
 export default ExpandableText;

--- a/packages/transition-frontend/src/components/path/TransitPathHelp.tsx
+++ b/packages/transition-frontend/src/components/path/TransitPathHelp.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useState } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';

--- a/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
+++ b/packages/transition-frontend/src/services/accessibilityMap/BatchAccessibilityMapCalculator.ts
@@ -58,8 +58,7 @@ export class BatchAccessibilityMapCalculator {
 
     static async calculate(
         accessMap: TransitBatchAccessibilityMap,
-        updatePreferences = false,
-        options = {}
+        updatePreferences = false
     ): Promise<TransitBatchCalculationResult> {
         if (!accessMap.validate()) {
             const trError = new TrError(

--- a/packages/transition-frontend/src/services/definitions/DefinitionsService.ts
+++ b/packages/transition-frontend/src/services/definitions/DefinitionsService.ts
@@ -7,7 +7,6 @@
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
-import { de } from 'date-fns/locale';
 import { Dictionary } from 'lodash';
 
 // Cache the definitions once they are fetched. This is to avoid fetching the

--- a/packages/transition-frontend/src/services/map/events/NodeSectionMapEvents.ts
+++ b/packages/transition-frontend/src/services/map/events/NodeSectionMapEvents.ts
@@ -5,12 +5,9 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import MapboxGL from 'mapbox-gl';
-import _uniq from 'lodash/uniq';
 
 import { MapEventHandlerDescription } from 'chaire-lib-frontend/lib/services/map/IMapEventHandler';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
-import { metersToPixels } from 'chaire-lib-common/lib/utils/geometry/ConversionUtils';
-import { permutationsWithRepetition } from 'chaire-lib-common/lib/utils/MathUtils';
 import TransitNode from 'transition-common/lib/services/nodes/Node';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 
@@ -37,7 +34,6 @@ const onNodeSectionMapClick = (e: MapboxGL.MapMouseEvent) => {
         { layers: ['transitNodes'] }
     );
 
-    const map = e.target;
     // TODO: If there are multiple selected features, offer the choice instead of editing the first one
     const selectedFeature = features.length > 0 ? features[0] : undefined;
 
@@ -54,7 +50,7 @@ const onNodeSectionMapClick = (e: MapboxGL.MapMouseEvent) => {
         const attributes = selectedFeature.properties || {};
         serviceLocator.socketEventManager.emit('transitNode.read', attributes.id, null, (response) => {
             const transitNodeEdit = new TransitNode({ ...response.node }, false, serviceLocator.collectionManager);
-            transitNodeEdit.loadFromCache(serviceLocator.socketEventManager).then((response) => {
+            transitNodeEdit.loadFromCache(serviceLocator.socketEventManager).then((_response) => {
                 transitNodeEdit.startEditing();
                 serviceLocator.selectedObjectsManager.select('node', transitNodeEdit);
             });

--- a/packages/transition-frontend/src/services/map/events/PathSectionMapEvents.ts
+++ b/packages/transition-frontend/src/services/map/events/PathSectionMapEvents.ts
@@ -139,7 +139,7 @@ const onPathSectionMapClick = async (e: MapboxGL.MapMouseEvent) => {
         ) {
             const attributes = features[clickedWaypointIndex].properties || {};
             const path = selectedPath as TransitPath;
-            path.removeWaypoint(attributes.afterNodeIndex, attributes.waypointIndex).then((response) => {
+            path.removeWaypoint(attributes.afterNodeIndex, attributes.waypointIndex).then((_response) => {
                 serviceLocator.selectedObjectsManager.update('path', path);
                 serviceLocator.eventManager.emit('selected.updateLayers.path');
             });
@@ -153,7 +153,7 @@ const onPathSectionMapClick = async (e: MapboxGL.MapMouseEvent) => {
             const waypointType = path.getAttributes().data.temporaryManualRouting
                 ? 'manual'
                 : path.getData('routingEngine', 'engine');
-            path.insertWaypoint(e.lngLat.toArray(), waypointType, null, null).then((response) => {
+            path.insertWaypoint(e.lngLat.toArray(), waypointType, null, null).then((_response) => {
                 path.validate();
                 serviceLocator.selectedObjectsManager.update('path', path);
                 serviceLocator.eventManager.emit('selected.updateLayers.path');

--- a/packages/transition-frontend/src/services/routing/RoutingUtils.ts
+++ b/packages/transition-frontend/src/services/routing/RoutingUtils.ts
@@ -4,7 +4,6 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import _cloneDeep from 'lodash/cloneDeep';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { RoutingResultsByMode } from 'chaire-lib-common/lib/services/routing/types';

--- a/packages/transition-frontend/src/services/transitService/TransitServiceUtils.ts
+++ b/packages/transition-frontend/src/services/transitService/TransitServiceUtils.ts
@@ -79,7 +79,7 @@ export const serviceMatches = (
             if (serviceName && !(serviceName.includes(filter.name) || serviceName.match(filter.name))) {
                 return false;
             }
-        } catch (error) {
+        } catch {
             console.error(`Error interpreting regular expression ${filter.name}. Returning false`);
             return false;
         }

--- a/packages/transition-frontend/src/types/global.d.ts
+++ b/packages/transition-frontend/src/types/global.d.ts
@@ -122,6 +122,7 @@ declare module 'react-table' {
             UseResizeColumnsColumnProps<D>,
             UseSortByColumnProps<D> {}
 
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     export interface Cell<D extends Record<string, unknown> = Record<string, unknown>, V = any>
         extends UseGroupByCellProps<D>,
             UseRowStateCellProps<D> {}


### PR DESCRIPTION
The lint warnings from transition-frontend (other than "unexpected any") have been removed.

112 warnings got removed (223 to 111).