### PR TITLE
Remove Lint warnings from chaire-lib-frontend

### DIFF
--- a/packages/chaire-lib-frontend/jest.config.js
+++ b/packages/chaire-lib-frontend/jest.config.js
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 /* eslint-disable n/no-unpublished-require */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const baseConfig = require('../../tests/jest.config.base');
 
 module.exports = {

--- a/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/CaptchaComponent.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/CaptchaComponent.tsx
@@ -9,7 +9,6 @@ import { withTranslation, WithTranslation } from 'react-i18next';
 // FIXME Using the NoReload captcha (which can pose problems to users) because the "Reload Captcha" text is hardcoded in english. Switch when https://github.com/masroorejaz/react-simple-captcha/pull/2 is accepted
 import {
     loadCaptchaEnginge,
-    LoadCanvasTemplate,
     LoadCanvasTemplateNoReload,
     validateCaptcha as validateCaptchaMain
 } from 'react-simple-captcha';

--- a/packages/chaire-lib-frontend/src/components/input/DayRange.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/DayRange.tsx
@@ -19,8 +19,6 @@ export type DayRangeProps = WithTranslation & {
     showPeriodDropdown?: boolean;
 };
 
-type dayRangeType = 'custom' | 'week' | 'week-end' | 'all';
-
 const periodsGroupValues = {
     week: [0, 1, 2, 3, 4],
     'week-end': [5, 6],

--- a/packages/chaire-lib-frontend/src/components/input/InputCheckbox.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/InputCheckbox.tsx
@@ -32,11 +32,6 @@ export type InputCheckboxProps = InputCheckboxCommonProps & {
     allowSelectAll?: boolean;
 };
 
-type defaultInputType = {
-    name: string;
-    disabled?: boolean;
-};
-
 class InputCheckboxInner extends React.Component<InputCheckboxProps> {
     static defaultProps: Partial<InputCheckboxProps> = {
         defaultValue: [],
@@ -54,13 +49,8 @@ class InputCheckboxInner extends React.Component<InputCheckboxProps> {
         this.selectAll = this.selectAll.bind(this);
     }
 
-    onContainerClick(value, e) {
+    onContainerClick(_value, e) {
         e.stopPropagation();
-        const clickEvent = new MouseEvent('click', {
-            view: window,
-            bubbles: true,
-            cancelable: false
-        });
         // this.onCheckboxInputChange({target: {value: value}})
     }
 

--- a/packages/chaire-lib-frontend/src/components/input/InputStringFormatted.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/InputStringFormatted.tsx
@@ -94,6 +94,7 @@ export class InputStringFormatted extends React.Component<InputStringFormattedPr
     }
 
     render(): React.ReactNode {
+        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
         const { onValueUpdated, onValueChange, stringToValue, valueToString, value, ...inputProps } = this.props;
         return <InputString onValueUpdated={this.handleChange} value={this.state.strValue} {...inputProps} />;
     }

--- a/packages/chaire-lib-frontend/src/components/pageParts/SelectedObjectButtons.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/SelectedObjectButtons.tsx
@@ -15,7 +15,7 @@ import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import Button from '../input/Button';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { ObjectWithHistory } from 'chaire-lib-common/lib/utils/objects/ObjectWithHistory';
-import { Saveable, isSaveable } from 'chaire-lib-common/lib/utils/objects/Saveable';
+import { isSaveable } from 'chaire-lib-common/lib/utils/objects/Saveable';
 
 export type SelectedObjectButtonsProps<T extends ObjectWithHistory<any>> = WithTranslation & {
     object: T;

--- a/packages/chaire-lib-frontend/src/components/pageParts/admin/users/TableFilters.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/admin/users/TableFilters.tsx
@@ -6,13 +6,23 @@
  */
 import React from 'react';
 
+type DefaultColumnFilterProps = {
+    column: {
+        filterValue: any;
+        _preFilteredRows: any;
+        setFilter: any;
+    };
+};
+
 /**
  * Textbox input for column filter
  *
  * @param param0 description of the filtered column
  * @returns
  */
-export const DefaultColumnFilter = ({ column: { filterValue, _preFilteredRows, setFilter } }) => {
+export const DefaultColumnFilter = ({
+    column: { filterValue, _preFilteredRows, setFilter }
+}: DefaultColumnFilterProps) => {
     return (
         <input
             value={filterValue || ''}

--- a/packages/chaire-lib-frontend/src/components/pageParts/admin/users/UsersComponent.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/admin/users/UsersComponent.tsx
@@ -87,8 +87,8 @@ const UsersComponent: React.FC = () => {
             {
                 Header: t('admin:user:isAdmin'),
                 accessor: 'is_admin',
-                Cell: (props) => (
-                    <input type="checkbox" className={'_input-checkbox'} disabled={true} checked={props.value} />
+                Cell: (cellProps) => (
+                    <input type="checkbox" className={'_input-checkbox'} disabled={true} checked={cellProps.value} />
                 )
             }
         ];
@@ -96,11 +96,11 @@ const UsersComponent: React.FC = () => {
             columns.push({
                 Header: t('admin:user:roles'),
                 accessor: 'permissions',
-                Cell: (props) => (
+                Cell: (cellProps) => (
                     <WidgetChangePermission
                         roles={roles}
-                        currentValues={props.value}
-                        userUuid={props.row.original.uuid}
+                        currentValues={cellProps.value}
+                        userUuid={cellProps.row.original.uuid}
                     />
                 )
             });

--- a/packages/chaire-lib-frontend/src/components/pageParts/admin/users/react-table-config.d.ts
+++ b/packages/chaire-lib-frontend/src/components/pageParts/admin/users/react-table-config.d.ts
@@ -122,6 +122,7 @@ declare module 'react-table' {
             UseResizeColumnsColumnProps<D>,
             UseSortByColumnProps<D> {}
 
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     export interface Cell<D extends Record<string, unknown> = Record<string, unknown>, V = any>
         extends UseGroupByCellProps<D>,
             UseRowStateCellProps<D> {}

--- a/packages/chaire-lib-frontend/src/components/pages/ForgotPasswordPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/ForgotPasswordPage.tsx
@@ -19,9 +19,9 @@ type ForgotPasswordPageProps = {
 };
 
 const emailRegex =
-    /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-const ForgotPasswordPage: React.FC<ForgotPasswordPageProps> = ({ config }) => {
+const ForgotPasswordPage: React.FC<ForgotPasswordPageProps> = () => {
     const { t } = useTranslation('auth');
     const dispatch = useDispatch<ThunkDispatch<RootState, unknown, Action>>();
 

--- a/packages/chaire-lib-frontend/src/components/pages/LoadingPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/LoadingPage.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import Loader from 'react-spinners/HashLoader';
 
-const LoadingPage = function (props) {
+const LoadingPage = function (props: { message?: string }) {
     return (
         <div className="_fill" style={{ flexDirection: 'column' }}>
             {typeof props.message !== 'undefined' && <h1>{props.message}</h1>}

--- a/packages/chaire-lib-frontend/src/components/pages/LoginPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/LoginPage.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import appConfiguration from '../../config/application.config';
 import LoginForm from '../forms/auth/localLogin/LoginForm';
-import { redirect, useNavigate, NavigateFunction } from 'react-router';
+import { useNavigate, NavigateFunction } from 'react-router';
 
 export type LoginPageProps = {
     isAuthenticated?: boolean;

--- a/packages/chaire-lib-frontend/src/components/pages/ResetPasswordPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/ResetPasswordPage.tsx
@@ -38,7 +38,6 @@ const ResetPasswordPage: React.FC = () => {
     const { token } = useParams<{ token: string }>();
     const submitButtonRef = React.useRef<HTMLButtonElement>(null);
 
-    const isAuthenticated = useSelector((state: RootState) => state.auth.isAuthenticated);
     const status = useSelector((state: RootState) => state.auth.status as Status);
 
     const [formState, setFormState] = React.useState({

--- a/packages/chaire-lib-frontend/src/components/routers/PrivateRoute.tsx
+++ b/packages/chaire-lib-frontend/src/components/routers/PrivateRoute.tsx
@@ -19,7 +19,7 @@ export type PrivateRouteProps = RouteProps & {
     config?: { [key: string]: unknown };
 } & PropsWithChildren;
 
-const PrivateRoute = ({ permissions, component: Component, children, ...rest }: PrivateRouteProps) => {
+const PrivateRoute = ({ permissions, component: Component, children: _children, ...rest }: PrivateRouteProps) => {
     return rest.isAuthenticated ? (
         permissions ? (
             rest.user.isAuthorized(permissions) ? (

--- a/packages/chaire-lib-frontend/src/components/routers/PublicRoute.tsx
+++ b/packages/chaire-lib-frontend/src/components/routers/PublicRoute.tsx
@@ -21,7 +21,7 @@ type PublicRouteProps = RouteProps & {
     config?: { [key: string]: unknown };
 } & PropsWithChildren;
 
-const PublicRoute = ({ component: Component, children, ...rest }: PublicRouteProps) => {
+const PublicRoute = ({ component: Component, children: _children, ...rest }: PublicRouteProps) => {
     return (
         <React.Fragment>
             <Header path={rest.path as string} appName={rest.config?.appName as string} />

--- a/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
+++ b/packages/chaire-lib-frontend/src/services/map/events/GlobalMapEvents.ts
@@ -6,7 +6,7 @@
  */
 import MapboxGL from 'mapbox-gl';
 import _debounce from 'lodash/debounce';
-import { lineString, bboxPolygon, bbox, feature } from '@turf/turf';
+import { lineString, bboxPolygon, bbox } from '@turf/turf';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';


### PR DESCRIPTION
The lint warnings from chaire-lib-frontend (other than "unexpected any") have been removed.

29 warnings got removed (122 to 93).