### PR TITLE
docs: Add link to Transition public API documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+This directory contains various documentation for developers and end users.
+
+Additionnally, further documentation is available:
+
+* Transition's public API [documentation](https://chairemobilite.github.io/transition/). Using the public API requires an account on a Transition server.
+* A [tutorial](https://github.com/chairemobilite/transition-docs/tree/main/tutorial) to get started with Transition.

--- a/pyTransition/README.md
+++ b/pyTransition/README.md
@@ -1,6 +1,6 @@
 # pyTransition
 pyTransition is a Python package designed to interact with the public API of the transit planning application Transition. It allows users to retrieve and request geographic and routing data from the app.\
-The documentation for the Transition public API used by this library can be found [here](https://mathildebrosseau.github.io/transition-api/)
+The documentation for the Transition public API used by this library can be found [here](https://chairemobilite.github.io/transition/)
 
 ## Install and import pyTransition
 To install pyTransition, use the following command :


### PR DESCRIPTION
Add a readme in the `docs` folder, with links to the transition's public API documentation and Transition tutorial.

Fix the link in `pyTransition` to go to the right doc page.