### PR TITLE
Add an TripTimeChoice enum to python library to validate the paramete…

### DIFF
--- a/pyTransition/README.md
+++ b/pyTransition/README.md
@@ -237,7 +237,7 @@ def get_transition_acessibility_map():
     # Call the API
     accessibility_map_data = transition_instance.request_accessibility_map(
                 coordinates=[-73.4727, 45.5383],
-                departure_or_arrival_choice="Departure",
+                departure_or_arrival_choice=TripTimeChoice.DEPARTURE,
                 departure_or_arrival_time=time(8,0), # Create a new time object representing 8:00
                 n_polygons=3,
                 delta_minutes=15,

--- a/pyTransition/examples/accessibility_map.py
+++ b/pyTransition/examples/accessibility_map.py
@@ -1,5 +1,5 @@
 from test_credentials import username, password
-from pyTransition.transition import Transition
+from pyTransition.transition import Transition, TripTimeChoice
 from datetime import time
 import json
 
@@ -16,7 +16,7 @@ def get_transition_acessibility_map():
     # Call the API
     accessibility_map_data = transition_instance.request_accessibility_map(
                 coordinates=[-73.4727, 45.5383],
-                departure_or_arrival_choice="Departure",
+                departure_or_arrival_choice=TripTimeChoice.DEPARTURE,
                 departure_or_arrival_time=time(8,0), # Create a new time object representing 8:00
                 n_polygons=3,
                 delta_minutes=15,

--- a/pyTransition/pyTransition/__init__.py
+++ b/pyTransition/pyTransition/__init__.py
@@ -4,7 +4,7 @@ pyTransition
 A python package to interact with the Transition API.
 """
 
-from .transition import Transition
+from .transition import Transition, TripTimeChoice
 
 __version__ = "0.1.0"
 __author__ = "Transition City"

--- a/pyTransition/pyTransition/transition.py
+++ b/pyTransition/pyTransition/transition.py
@@ -126,6 +126,21 @@ class Transition:
 
         return headers
 
+    def __check_response_status(response, is_error_json = False):
+        """ Wrapper around Response.raise_for_status to add the return content to the
+        exception error message
+        """
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            details = ""
+            if is_error_json:
+                details = str(e.response.json())
+            else:
+                details = e.response.text
+            e.response.reason = f"{e.response.reason}: {details}"
+            raise
+
     def __request_token(self, username, password):
         """Authenticates the user with the Transition api to obtain an API authentication token.
 
@@ -138,7 +153,7 @@ class Transition:
         """
         body = self.__build_authentication_body(username, password)
         response = requests.post(self.build_url('/token'), json=body)
-        response.raise_for_status()
+        Transition.__check_response_status(response)
         return response.text
 
     def is_token_valid(self):
@@ -165,7 +180,7 @@ class Transition:
         """
         headers = self.__build_headers()
         response = requests.get(self.build_url('/api/v1/paths'), headers=headers)
-        response.raise_for_status()
+        Transition.__check_response_status(response)
         return response.json()
 
     def get_nodes(self):
@@ -176,7 +191,7 @@ class Transition:
         """
         headers = self.__build_headers()
         response = requests.get(self.build_url('/api/v1/nodes'), headers=headers)
-        response.raise_for_status()
+        Transition.__check_response_status(response)
         return response.json()
 
     def get_scenarios(self):
@@ -187,7 +202,7 @@ class Transition:
         """
         headers = self.__build_headers()
         response = requests.get(self.build_url('/api/v1/scenarios'), headers=headers)
-        response.raise_for_status()
+        Transition.__check_response_status(response)
         return response.json()
 
     def get_routing_modes(self):
@@ -198,7 +213,7 @@ class Transition:
         """
         headers = self.__build_headers()
         response = requests.get(self.build_url('/api/v1/routing-modes'), headers=headers)
-        response.raise_for_status()
+        Transition.__check_response_status(response)
         return json.loads(response.text)
 
     def request_routing_result(
@@ -280,7 +295,8 @@ class Transition:
         response = requests.post(
             self.build_url('/api/v1/route', params=params), headers=headers, json=body
         )
-        response.raise_for_status()
+
+        Transition.__check_response_status(response)
         return response.json()
 
     def request_accessibility_map(
@@ -367,5 +383,5 @@ class Transition:
         response = requests.post(
             self.build_url('/api/v1/accessibility', params=params), headers=headers, json=body
         )
-        response.raise_for_status()
+        Transition.__check_response_status(response)
         return response.json()

--- a/pyTransition/pyTransition/transition.py
+++ b/pyTransition/pyTransition/transition.py
@@ -24,7 +24,13 @@ import requests
 from datetime import time
 import json
 from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
+from enum import Enum
 
+class TripTimeChoice(Enum):
+    """Type for trip time
+    """
+    DEPARTURE = "Departure"
+    ARRIVAL = "Arrival"
 
 class Transition:
     def __init__(self, url, username, password, token=None):
@@ -201,7 +207,7 @@ class Transition:
         origin,
         destination,
         scenario_id,
-        departure_or_arrival_choice,
+        departure_or_arrival_choice: TripTimeChoice,
         departure_or_arrival_time,
         max_travel_time_minutes,
         min_waiting_time_minutes,
@@ -218,7 +224,7 @@ class Transition:
             origin (List[float]): Coordinates of the route origin as [longitude, latitude]
             destination (List[float]): Coordinates of the route destination as [longitude, latitude]
             scenario_id (string): ID of the used scenario as loaded in Transition application.
-            departure_or_arrival_choice (string): Specifies whether the used time is "Departure" or "Arrival". Possible values are "Departure" or "Arrival".
+            departure_or_arrival_choice (TripTimeChoice): Specifies whether the used time is "Departure" or "Arrival". Possible values are DEPARTURE or ARRIVAL.
             departure_or_arrival_time (time): Departure or arrival time of the trip
             max_travel_time_minutes (int): Maximum travel time including access, in minutes
             min_waiting_time_minutes (int): Minimum waiting time, in minutes
@@ -236,11 +242,14 @@ class Transition:
             + departure_or_arrival_time.minute * 60
             + departure_or_arrival_time.second
         )
+        # Insure we have the right type for departure_or_arrival_choice
+        departure_or_arrival_choice = TripTimeChoice(departure_or_arrival_choice)
+
         departure_time = (
-            departure_or_arrival_time if departure_or_arrival_choice == "Departure" else None
+            departure_or_arrival_time if departure_or_arrival_choice == TripTimeChoice.DEPARTURE else None
         )
         arrival_time = (
-            departure_or_arrival_time if departure_or_arrival_choice == "Arrival" else None
+            departure_or_arrival_time if departure_or_arrival_choice == TripTimeChoice.ARRIVAL else None
         )
 
         body = {
@@ -278,7 +287,7 @@ class Transition:
         self,
         coordinates,
         scenario_id,
-        departure_or_arrival_choice,
+        departure_or_arrival_choice: TripTimeChoice,
         departure_or_arrival_time,
         n_polygons,
         delta_minutes,
@@ -296,7 +305,7 @@ class Transition:
         Args:
             coordinates (List[float]): Coordinates of the map origin as [longitude, latitude]
             scenario_id (string): ID of the used scenario as loaded in Transition application.
-            departure_or_arrival_choice (string): Specifies whether the used time is "Departure" or "Arrival". Possible values are "Departure" or "Arrival".
+            departure_or_arrival_choice (TripTimeChoice): Specifies whether the used time is "Departure" or "Arrival". Possible values are DEPARTURE or ARRIVAL.
             departure_or_arrival_time (time): Departure or arrival time of the trip
             n_polygons (int): Number of polygons to be calculated
             delta_minutes (int): Baseline delta used for average accessibility map calculations
@@ -317,14 +326,18 @@ class Transition:
             + departure_or_arrival_time.minute * 60
             + departure_or_arrival_time.second
         )
+
+        # Insure we have the right type for departure_or_arrival_choice
+        departure_or_arrival_choice = TripTimeChoice(departure_or_arrival_choice)
+
         departure_time_seconds = (
             departure_or_arrival_time_seconds_from_midnight
-            if departure_or_arrival_choice == "Departure"
+            if departure_or_arrival_choice == TripTimeChoice.DEPARTURE
             else None
         )
         arrival_time_seconds = (
             departure_or_arrival_time_seconds_from_midnight
-            if departure_or_arrival_choice == "Arrival"
+            if departure_or_arrival_choice == TripTimeChoice.ARRIVAL
             else None
         )
 


### PR DESCRIPTION
…r departure_or_arrival_choice

Adding the enum insure that we don't fiddle with string and risk miswriting them. We now have a clear DEPARTURE and ARRIVAL type. Since we use the same value as before for the enum, script that will use the right strings will still work

Updated one of the example and added unittests

Issue: #1177