### PR TITLE
paths: update layers when TransitPathEdit component is mounted

### DIFF
--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -101,6 +101,8 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
         serviceLocator.eventManager.on('waypoint.update', this.onUpdateWaypoint);
         serviceLocator.eventManager.on('waypoint.replaceByNodeId', this.onReplaceWaypointByNodeId);
         serviceLocator.eventManager.on('selected.updateLayers.path', this.updateLayers);
+        // Call the updateLayers method to display the path on the map, as the event may have been emitted before the listener was added
+        this.updateLayers();
         serviceLocator.keyboardManager.on('m', this.toggleTemporaryManualRouting);
     }
 


### PR DESCRIPTION
fixes #1178

The upgrade to React 19 seemingly changed the handling of events in such a way that the path selection event is now handled before the `TransitPathEdit` component is mounted, while it was handled after in the React 16 version. So we call the `updateLayers` method at mount to display the selected path.