### PR TITLE
Streamify import and process osm data task

### DIFF
--- a/packages/chaire-lib-common/src/tasks/dataImport/OsmDataPreparationNonResidential.ts
+++ b/packages/chaire-lib-common/src/tasks/dataImport/OsmDataPreparationNonResidential.ts
@@ -156,12 +156,15 @@ export default class OsmDataPreparationNonResidential {
         const allPoIBuildings: PoiBuilding[] = osmGeojsonService.getGeojsonsFromRawData(
             this._osmGeojsonData,
             allOsmBuildings,
-            { generateNodesIfNotFound: true }
+            { generateNodesIfNotFound: true, continueOnMissingGeojson: false }
         );
 
         const allBuildingPartsRaw = this._osmRawData.queryOr(queryBuildingPartsFromOsm);
         const allBuildingParts: SingleGeoFeature[] = osmGeojsonService
-            .getGeojsonsFromRawData(this._osmGeojsonData, allBuildingPartsRaw, { generateNodesIfNotFound: true })
+            .getGeojsonsFromRawData(this._osmGeojsonData, allBuildingPartsRaw, {
+                generateNodesIfNotFound: true,
+                continueOnMissingGeojson: false
+            })
             .map((part) => part.geojson);
 
         console.log('=== Map shop and main entrances to each building... ===');
@@ -176,7 +179,10 @@ export default class OsmDataPreparationNonResidential {
                 entrances.length === 0
                     ? undefined
                     : osmGeojsonService
-                        .getGeojsonsFromRawData(this._osmGeojsonData, entrances, { generateNodesIfNotFound: true })
+                        .getGeojsonsFromRawData(this._osmGeojsonData, entrances, {
+                            generateNodesIfNotFound: true,
+                            continueOnMissingGeojson: true
+                        })
                         .map((entrance) => entrance.geojson as GeoJSON.Feature<GeoJSON.Point>);
             // Get building parts
             building.parts = findOverlappingFeatures(building.geojson, allBuildingParts);
@@ -197,7 +203,8 @@ export default class OsmDataPreparationNonResidential {
             .filter((poi) => getCategoryFromProperty(poi.tags || {}).length !== 0);
         const allOsmPoisGeojson = osmGeojsonService
             .getGeojsonsFromRawData(this._osmGeojsonData, allOsmPoisFeatures, {
-                generateNodesIfNotFound: true
+                generateNodesIfNotFound: true,
+                continueOnMissingGeojson: true
             })
             .map((poi) => poi.geojson);
 
@@ -279,7 +286,8 @@ export default class OsmDataPreparationNonResidential {
             }
             return toPoi(
                 osmGeojsonService.getGeojsonsFromRawData(this._osmGeojsonData, [entrances[0]], {
-                    generateNodesIfNotFound: true
+                    generateNodesIfNotFound: true,
+                    continueOnMissingGeojson: false
                 })[0].geojson.geometry as GeoJSON.Point,
                 poi,
                 {
@@ -365,7 +373,8 @@ export default class OsmDataPreparationNonResidential {
             }
             return toPoi(
                 osmGeojsonService.getGeojsonsFromRawData(this._osmGeojsonData, [entrances[0]], {
-                    generateNodesIfNotFound: true
+                    generateNodesIfNotFound: true,
+                    continueOnMissingGeojson: false
                 })[0].geojson.geometry as GeoJSON.Point,
                 poi,
                 {

--- a/packages/chaire-lib-common/src/tasks/dataImport/OsmDataPreparationResidential.ts
+++ b/packages/chaire-lib-common/src/tasks/dataImport/OsmDataPreparationResidential.ts
@@ -73,7 +73,8 @@ export default class OsmDataPreparationResidential {
         const allOsmResidentialBuildings = osmRawData.queryOr(queryResidentialBuildingsFromOsm);
         const residentialBuildings = osmGeojsonService.getGeojsonsFromRawData(
             osmGeojsonData,
-            allOsmResidentialBuildings
+            allOsmResidentialBuildings,
+            { generateNodesIfNotFound: false, continueOnMissingGeojson: true }
         );
 
         // For each building, get its entrances

--- a/packages/chaire-lib-common/src/tasks/dataImport/data/__tests__/osmGeojsonService.test.ts
+++ b/packages/chaire-lib-common/src/tasks/dataImport/data/__tests__/osmGeojsonService.test.ts
@@ -83,7 +83,7 @@ describe('getGeojsonsFromRawData', () => {
             { type: 'node' as const, id: '1234', lon: -73, lat: 45 },
             { type: 'node' as const, id: '2345', lon: -73.1, lat: 45.1, tags: { test: ['foo'], abc: ['foo', 'bar'] } }
         ]
-        expect(osmGeojsonService.getGeojsonsFromRawData(geojsonData, rawData, { generateNodesIfNotFound: true })).toEqual([
+        expect(osmGeojsonService.getGeojsonsFromRawData(geojsonData, rawData, { generateNodesIfNotFound: true, continueOnMissingGeojson: false })).toEqual([
             {
                 geojson:
                 {

--- a/packages/chaire-lib-common/src/tasks/dataImport/data/dataOsmRaw.ts
+++ b/packages/chaire-lib-common/src/tasks/dataImport/data/dataOsmRaw.ts
@@ -249,7 +249,7 @@ export class DataFileOsmRaw extends DataOsmRaw {
 
 // Instead of reading the entire file at once, this class streams it asynchronously. This allows for large files to be read without crashing the application.
 export class DataStreamOsmRaw extends DataOsmRaw {
-    private _fileData: OsmRawDataType[] | undefined = undefined;
+    private _fileData: OsmRawDataType[] = [];
     private _filename: string;
     private _dataInitialized: boolean;
 
@@ -260,7 +260,9 @@ export class DataStreamOsmRaw extends DataOsmRaw {
     }
 
     // Factory method so that we can create the class while calling an async function.
-    static async Create(filename: string): Promise<DataStreamOsmRaw> {
+    // The proper way to do this would be to do it in getData(), but making that method async would force us to modify every class this inherits from, so we use this factory workaround.
+    // TODO: Rewrite the class from scratch so that it accepts an async getData().
+    static async create(filename: string): Promise<DataStreamOsmRaw> {
         const instance = new DataStreamOsmRaw(filename);
         await instance.streamDataFromFile();
         return instance;
@@ -268,9 +270,12 @@ export class DataStreamOsmRaw extends DataOsmRaw {
 
     protected getData(): OsmRawDataType[] {
         if (!this._dataInitialized) {
-            console.error('The raw OSM data has not been properly initialized.');
+            console.error(
+                'The raw OSM data has not been properly initialized. The create() method must be called before anything else in the DataStreamOsmRaw class.'
+            );
+            throw 'OSM data not initialized.';
         }
-        return this._fileData || [];
+        return this._fileData;
     }
 
     private async streamDataFromFile(): Promise<void> {

--- a/packages/chaire-lib-common/src/tasks/dataImport/prepareOsmDataForImport.ts
+++ b/packages/chaire-lib-common/src/tasks/dataImport/prepareOsmDataForImport.ts
@@ -5,8 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import GenericDataImportTask from './genericDataImportTask';
-import { DataFileOsmRaw } from './data/dataOsmRaw';
-import { DataFileGeojson } from './data/dataGeojson';
+import { DataStreamOsmRaw } from './data/dataOsmRaw';
+import { DataStreamGeojson } from './data/dataGeojson';
 import OsmDataPreparationResidential from './OsmDataPreparationResidential';
 import OsmDataPreparationNonResidential from './OsmDataPreparationNonResidential';
 
@@ -46,14 +46,8 @@ export default class PrepareOsmDataForImport extends GenericDataImportTask {
         const absoluteDsDir = this._importDir + dataSourceDirectory + '/';
         this.assertDataDownloaded(absoluteDsDir);
 
-        const osmRawData = new DataFileOsmRaw(
-            absoluteDsDir + GenericDataImportTask.OSM_RAW_DATA_FILE,
-            this.fileManager
-        );
-        const osmGeojsonData = new DataFileGeojson(
-            absoluteDsDir + GenericDataImportTask.OSM_GEOJSON_FILE,
-            this.fileManager
-        );
+        const osmRawData = await DataStreamOsmRaw.Create(absoluteDsDir + GenericDataImportTask.OSM_RAW_DATA_FILE);
+        const osmGeojsonData = await DataStreamGeojson.Create(absoluteDsDir + GenericDataImportTask.OSM_GEOJSON_FILE);
 
         // Calculate residential data if required
         const entrancesDataFile = absoluteDsDir + GenericDataImportTask.RESIDENTIAL_ENTRANCES_FILE;

--- a/packages/chaire-lib-common/src/tasks/dataImport/prepareOsmDataForImport.ts
+++ b/packages/chaire-lib-common/src/tasks/dataImport/prepareOsmDataForImport.ts
@@ -46,8 +46,8 @@ export default class PrepareOsmDataForImport extends GenericDataImportTask {
         const absoluteDsDir = this._importDir + dataSourceDirectory + '/';
         this.assertDataDownloaded(absoluteDsDir);
 
-        const osmRawData = await DataStreamOsmRaw.Create(absoluteDsDir + GenericDataImportTask.OSM_RAW_DATA_FILE);
-        const osmGeojsonData = await DataStreamGeojson.Create(absoluteDsDir + GenericDataImportTask.OSM_GEOJSON_FILE);
+        const osmRawData = await DataStreamOsmRaw.create(absoluteDsDir + GenericDataImportTask.OSM_RAW_DATA_FILE);
+        const osmGeojsonData = await DataStreamGeojson.create(absoluteDsDir + GenericDataImportTask.OSM_GEOJSON_FILE);
 
         // Calculate residential data if required
         const entrancesDataFile = absoluteDsDir + GenericDataImportTask.RESIDENTIAL_ENTRANCES_FILE;


### PR DESCRIPTION
Change the import and process osm data task so that it reads the source files with an asynchronous stream. Also adds an option in one of the functions used by the task so that it will not halt if just one geojson is missing compared to the raw OSM data.