### PR TITLE
auth: remove redundant AuthAction type declaration

### DIFF
--- a/packages/chaire-lib-frontend/src/store/auth/__tests__/reducer.test.ts
+++ b/packages/chaire-lib-frontend/src/store/auth/__tests__/reducer.test.ts
@@ -40,14 +40,16 @@ test('Test a login status', () => {
 
 test('Test a logout status', () => {
     const action = {
-        type: 'LOGOUT' as any,
+        type: AuthActionTypes.LOGOUT as const,
         user: null,
-        isAuthenticated: false
+        isAuthenticated: false,
+        register: false
     };
 
     const result =  {
         user: null,
-        isAuthenticated: false
+        isAuthenticated: false,
+        register: false
     };
 
     expect(authReducer({

--- a/packages/chaire-lib-frontend/src/store/auth/reducer.ts
+++ b/packages/chaire-lib-frontend/src/store/auth/reducer.ts
@@ -5,25 +5,12 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { Reducer } from 'redux';
-import { AuthState, AuthActionTypes } from './types';
-import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
+import { AuthState, AuthActionTypes, AuthAction } from './types';
 
 // Type-safe initialState!
 export const initialState: AuthState = {
     isAuthenticated: false
 };
-
-type AuthAction =
-    | {
-          type: AuthActionTypes.LOGIN;
-          user: CliUser | null;
-          isAuthenticated: boolean;
-          register?: boolean;
-          login?: boolean;
-      }
-    | { type: AuthActionTypes.LOGOUT; user: null; isAuthenticated: false; register?: boolean }
-    | { type: AuthActionTypes.FORGOT; forgot: boolean; emailExists: boolean; message: string }
-    | { type: AuthActionTypes.RESET; status: string };
 
 // Thanks to Redux 4's much simpler typings, we can take away a lot of typings on the reducer side,
 // everything will remain type-safe.


### PR DESCRIPTION
The `AuthAction` type is defined in the `types` file and does not need to be re-declared in the reducer. This double declaration causes compilation errors in packages using it.