### PR TITLE
users: fix `UsersPage` component with new React

### DIFF
--- a/packages/chaire-lib-frontend/src/components/pages/admin/UsersPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/admin/UsersPage.tsx
@@ -4,17 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { CliUser } from 'chaire-lib-common/lib/services/user/userType';
 import React from 'react';
 import Loadable from 'react-loadable';
-import { useNavigate } from 'react-router';
 import Loader from 'react-spinners/HashLoader';
-
-export type UsersPageProps = {
-    isAuthenticated: boolean;
-    // TODO Type the user
-    user: CliUser;
-};
 
 const loader = function Loading() {
     return <Loader size={30} color={'#aaaaaa'} loading={true} />;
@@ -25,23 +17,10 @@ const UsersComponent = Loadable({
     loading: loader
 });
 
-class UsersPage extends React.Component<UsersPageProps> {
-    constructor(props: UsersPageProps) {
-        const navigate = useNavigate();
-        super(props);
-
-        if (this.props.isAuthenticated && this.props.user.is_admin) {
-            navigate('/admin/users');
-        }
-    }
-
-    render() {
-        return (
-            <div className="admin">
-                <UsersComponent />
-            </div>
-        );
-    }
-}
+const UsersPage: React.FC = () => (
+    <div className="admin">
+        <UsersComponent />
+    </div>
+);
 
 export default UsersPage;


### PR DESCRIPTION
This page caused errors, with an invalid hook call to useNavigate in a constructor. We convert the page to a function component instead.