### PR TITLE
Add a Docker environment for development (#45)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ node_modules
 **/node_modules
 **/runtime
 services/**/target
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,18 +28,8 @@ COPY packages/transition-frontend packages/transition-frontend
 RUN yarn config set network-timeout 300000
 RUN yarn install
 
-# Copy the rest. (node_modules are excluded in .dockerignore)
-COPY . /app
-
 # Setup the example as a default configuration for the image
 COPY .env.docker /app/.env
-
-#TODO evaluate if any of those commands are necessary
-#RUN yarn setup
-#RUN yarn setup && yarn migrate && yarn create-user
-#RUN yarn compile && yarn build:dev
-RUN yarn compile
-#RUN yarn compile && yarn build:prod
 
 #TODO We probably need to do something different for the projects configuration directories
 # the docker-compose file have an example of using volume for part of a project
@@ -64,6 +54,14 @@ RUN /usr/local/bin/osrm-extract --help && \
     /usr/local/bin/osrm-contract --help && \
     /usr/local/bin/osrm-partition --help && \
     /usr/local/bin/osrm-customize --help
+
+# Copy the necessary files for compilation   
+COPY ./configs /app/configs
+COPY ./packages /app/packages
+RUN yarn compile
+
+# Copy the rest. (node_modules are excluded in .dockerignore)
+COPY . /app
 
 # Start json2capnp -> Relies on manually creating cache directory before
 # Start Node app

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Open your browser and navigate to `http://localhost:8080` to access the Transiti
 ## Using Docker
 You can easily launch the whole transition system using Docker and thus not having to install all the dependencies directly.
 
+For developing using Docker, a separate tutorial is available [here (devWithDocker.md)](./docs/devWithDocker.md).
+
 ### Building the image
 `docker build -t testtransition .`
 (You can replace testtransition with your prefered image name. Don't forget to update any other command and compose file if you do so)

--- a/docker-dev/docker-compose.override.yml
+++ b/docker-dev/docker-compose.override.yml
@@ -1,0 +1,78 @@
+# Docker compose override file to map the code directories inside the 
+# container, allowing the app to rebuild dynamically
+
+# To start the docker dev environment, run this command from the root folder : 
+# docker compose -f docker-compose.yml -f docker-dev/docker-compose.override.yml up
+
+services:
+  transition-www:
+    command:
+      - /bin/sh 
+      - /app/docker-dev/entrypoint-dev.sh
+    volumes:
+      # Bind mounts on the package directories. These enable instant code changes on the container without entirely rebuilding the image   
+      # It is necessary to bind individually every file in every package, and not just the package. This is because during compilation,
+      # when each package is compiled, the container creates a lib/ folder that's needed to build and run the app. 
+      # Binding the whole package would overwrite this lib/ folder.
+      - ${PWD}/packages/chaire-lib-backend/src:/app/packages/chaire-lib-backend/src
+      - ${PWD}/packages/chaire-lib-backend/.eslintignore:/app/packages/chaire-lib-backend/.eslintignore
+      - ${PWD}/packages/chaire-lib-backend/.eslintrc.json:/app/packages/chaire-lib-backend/.eslintrc.json
+      - ${PWD}/packages/chaire-lib-backend/.prettierignore:/app/packages/chaire-lib-backend/.prettierignore
+      - ${PWD}/packages/chaire-lib-backend/.prettierrc.js:/app/packages/chaire-lib-backend/.prettierrc.js
+      - ${PWD}/packages/chaire-lib-backend/jest.config.js:/app/packages/chaire-lib-backend/jest.config.js
+      - ${PWD}/packages/chaire-lib-backend/jest.sequential.config.js:/app/packages/chaire-lib-backend/jest.sequential.config.js
+      - ${PWD}/packages/chaire-lib-backend/jestSetup.ts:/app/packages/chaire-lib-backend/jestSetup.ts
+      - ${PWD}/packages/chaire-lib-backend/package.json:/app/packages/chaire-lib-backend/package.json
+      - ${PWD}/packages/chaire-lib-backend/tsconfig.json:/app/packages/chaire-lib-backend/tsconfig.json
+
+      - ${PWD}/packages/chaire-lib-common/src:/app/packages/chaire-lib-common/src
+      - ${PWD}/packages/chaire-lib-common/.eslintignore:/app/packages/chaire-lib-common/.eslintignore
+      - ${PWD}/packages/chaire-lib-common/.eslintrc.json:/app/packages/chaire-lib-common/.eslintrc.json
+      - ${PWD}/packages/chaire-lib-common/.prettierignore:/app/packages/chaire-lib-common/.prettierignore
+      - ${PWD}/packages/chaire-lib-common/.prettierrc.js:/app/packages/chaire-lib-common/.prettierrc.js
+      - ${PWD}/packages/chaire-lib-common/jest.config.js:/app/packages/chaire-lib-common/jest.config.js
+      - ${PWD}/packages/chaire-lib-common/package.json:/app/packages/chaire-lib-common/package.json
+      - ${PWD}/packages/chaire-lib-common/tsconfig.json:/app/packages/chaire-lib-common/tsconfig.json
+            
+      - ${PWD}/packages/chaire-lib-frontend/src:/app/packages/chaire-lib-frontend/src
+      - ${PWD}/packages/chaire-lib-frontend/assets:/app/packages/chaire-lib-frontend/assets
+      - ${PWD}/packages/chaire-lib-frontend/.eslintignore:/app/packages/chaire-lib-frontend/.eslintignore
+      - ${PWD}/packages/chaire-lib-frontend/.eslintrc.json:/app/packages/chaire-lib-frontend/.eslintrc.json
+      - ${PWD}/packages/chaire-lib-frontend/.prettierignore:/app/packages/chaire-lib-frontend/.prettierignore
+      - ${PWD}/packages/chaire-lib-frontend/.prettierrc.js:/app/packages/chaire-lib-frontend/.prettierrc.js
+      - ${PWD}/packages/chaire-lib-frontend/jest.config.js:/app/packages/chaire-lib-frontend/jest.config.js
+      - ${PWD}/packages/chaire-lib-frontend/jestSetup.ts:/app/packages/chaire-lib-frontend/jestSetup.ts
+      - ${PWD}/packages/chaire-lib-frontend/package.json:/app/packages/chaire-lib-frontend/package.json
+      - ${PWD}/packages/chaire-lib-frontend/tsconfig.json:/app/packages/chaire-lib-frontend/tsconfig.json
+
+      - ${PWD}/packages/transition-backend/src:/app/packages/transition-backend/src
+      - ${PWD}/packages/transition-backend/file:/app/packages/transition-backend/file
+      - ${PWD}/packages/transition-backend/.eslintignore:/app/packages/transition-backend/.eslintignore
+      - ${PWD}/packages/transition-backend/.eslintrc.json:/app/packages/transition-backend/.eslintrc.json
+      - ${PWD}/packages/transition-backend/.prettierignore:/app/packages/transition-backend/.prettierignore
+      - ${PWD}/packages/transition-backend/.prettierrc.js:/app/packages/transition-backend/.prettierrc.js
+      - ${PWD}/packages/transition-backend/jest.config.js:/app/packages/transition-backend/jest.config.js
+      - ${PWD}/packages/transition-backend/jest.sequential.config.js:/app/packages/transition-backend/jest.sequential.config.js
+      - ${PWD}/packages/transition-backend/jestSetup.ts:/app/packages/transition-backend/jestSetup.ts
+      - ${PWD}/packages/transition-backend/package.json:/app/packages/transition-backend/package.json
+      - ${PWD}/packages/transition-backend/tsconfig.json:/app/packages/transition-backend/tsconfig.json
+
+      - ${PWD}/packages/transition-common/src:/app/packages/transition-common/src
+      - ${PWD}/packages/transition-common/.eslintignore:/app/packages/transition-common/.eslintignore
+      - ${PWD}/packages/transition-common/.eslintrc.json:/app/packages/transition-common/.eslintrc.json
+      - ${PWD}/packages/transition-common/.prettierignore:/app/packages/transition-common/.prettierignore
+      - ${PWD}/packages/transition-common/.prettierrc.js:/app/packages/transition-common/.prettierrc.js
+      - ${PWD}/packages/transition-common/jest.config.js:/app/packages/transition-common/jest.config.js
+      - ${PWD}/packages/transition-common/jestSetup.ts:/app/packages/transition-common/jestSetup.ts
+      - ${PWD}/packages/transition-common/package.json:/app/packages/transition-common/package.json
+      - ${PWD}/packages/transition-common/tsconfig.json:/app/packages/transition-common/tsconfig.json
+            
+      - ${PWD}/packages/transition-frontend/src:/app/packages/transition-frontend/src
+      - ${PWD}/packages/transition-frontend/.eslintignore:/app/packages/transition-frontend/.eslintignore
+      - ${PWD}/packages/transition-frontend/.eslintrc.json:/app/packages/transition-frontend/.eslintrc.json
+      - ${PWD}/packages/transition-frontend/.prettierignore:/app/packages/transition-frontend/.prettierignore
+      - ${PWD}/packages/transition-frontend/.prettierrc.js:/app/packages/transition-frontend/.prettierrc.js
+      - ${PWD}/packages/transition-frontend/jest.config.js:/app/packages/transition-frontend/jest.config.js
+      - ${PWD}/packages/transition-frontend/package.json:/app/packages/transition-frontend/package.json
+      - ${PWD}/packages/transition-frontend/tsconfig.json:/app/packages/transition-frontend/tsconfig.json
+      - ${PWD}/packages/transition-frontend/webpack.config.js:/app/packages/transition-frontend/webpack.config.js

--- a/docker-dev/entrypoint-dev.sh
+++ b/docker-dev/entrypoint-dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/sh
+
+/app/services/json2capnp/json2capnp 2000 /app/examples/runtime/cache/demo_transition > /app/json2capnp.log &
+
+yarn compile:dev&
+yarn build:dev&
+yarn start

--- a/docs/devWithDocker.md
+++ b/docs/devWithDocker.md
@@ -1,0 +1,80 @@
+# Transition Docker installation for development
+
+This tutorial is intended towards developers who want to setup Transition inside a Docker container. Any code modification will be applied instantly to the container, so you don't need to rebuild the image each time. 
+
+### 1. Install Docker for desktop if needed
+
+Follow [the docker for desktop](https://www.docker.com/products/docker-desktop/) for instructions to install the docker for desktop application locally.
+
+If you are already familiar with docker and can run container and scripts easily, you don't have to install docker for desktop.
+
+### 2. Get a mapbox access token
+
+* Go to [Mapbox](http://mapbox.com) and sign up
+* Go to your account dashboard, then generate a new access token
+
+Keep this access token for the next step.
+
+
+### 3. Add your mapbox token to the .env.docker file
+
+The `.env.docker` file is required to contain some environment variables that are not yet available through the configuration. The file has already been created for you, you simply need to finish the configuration. [It's located at the root of the `transition` repo](../.env.docker).
+
+In order for the map to be displayed correctly, simply modify the field `MAPBOX_ACCESS_TOKEN` with the key you've acquired in the previous section. You must not push your key to the remote repo.
+```
+MAPBOX_ACCESS_TOKEN=<paste_your_key_here>
+```
+> Note: You can modify other fields in this file if needed. This is only the base configuration needed to run the app.
+
+
+### 4. Add your custom polygon for your region
+
+In order to have routing data to calculate the routes, the data must be fetched from OpenStreetMap for a given polygon. If you have a geojson file containing the geojson polygon to fetch, add this file to the `transition` directory. There is [an example file](../examples/polygon_rtl_area.geojson) in this repo.
+
+It is not required, but if not set, routing won't be able to follow the road network.
+
+If you don't have a `.geojson` polygon, use the [example file](../examples/polygon_rtl_area.geojson).
+
+### 5. Run for the first time
+
+Some initialization scripts need to be executed on the very first run of Transition, to set up the database and download the road network. 
+
+First, launch Transition by opening a Terminal in the `transition/` root folder, and by using the command 
+```
+docker compose -f docker-compose.yml -f docker-dev/docker-compose.override.yml up -d --build
+```
+This will first build the app's image (that usually takes a few minutes). Once the command exits, the app has been launched.
+
+Now, with the same terminal you've just opened, run this command to copy your GeoJSON file to the runtime of the app. 
+> Note: If you're using another GeoJSON file than the one provided as an example (`examples/polygon_rtl_area.geojson`), you need to modify the path specified in the first argument of the command
+
+```
+docker cp ./examples/polygon_rtl_area.geojson docker-dev-transition-www-1:/app/examples/runtime/imports/polygon.geojson
+```
+
+Then, in  Docker Desktop, select **Containers** on the left, then click on `docker-dev-transition-www-1` and go to the `Terminal` tab. Run the following commands.
+
+> Note: You can also use `docker exec -it docker-dev-transition-www-1` to run these commands without Docker Desktop
+
+```
+yarn setup && yarn migrate
+```
+```
+yarn node --max-old-space-size=4096 /app/packages/chaire-lib-backend/lib/scripts/osrm/downloadOsmNetworkData.task.js --polygon-file /app/examples/runtime/imports/polygon.geojson
+```
+For the following command, you will need to choose the transportation types you'd like to import. You should ideally at least select `walking`, `driving` and `bus_urban`, but it's not essential for running the app.
+```
+yarn node --max-old-space-size=4096 /app/packages/chaire-lib-backend/lib/scripts/osrm/prepareOsmNetworkData.task.js
+```
+    
+Finally, in the same terminal, create your transition user. Run this command and follow the instructions.
+```
+yarn create-user 
+```
+
+The setup is now complete. To finish the configuration, you need to restart the app. You can either use the stop/play buttons in Docker Desktop, or run `docker compose -f docker-compose.yml docker-dev/docker-compose.override.yml restart` in your terminal.
+
+### 5.1 Run the application
+
+Once the app is setup, you only need to run `docker compose -f docker-compose.yml -f docker-dev/docker-compose.override.yml up` to launch it. If you make code changes, the app should rebuild itself automatically.
+ 


### PR DESCRIPTION
New docker development environment for quick code updates.
>Note: Debugging with breakpoints has not been tested yet

Created a new `docker-dev/` folder with its own `Dockerfile` and `docker-compose.yml`
* The new `Dockerfile` is optimized to rebuild the image faster in case of a code change 
  * Moved `COPY . /app` to the last possible moment. This way, the docker image doesn't need to be rebuilt entirely for every file change. Some directories did still need to be copied earlier though.
  * Moved `yarn compile` right before 1. . This also keeps from rebuilding almost the entire stack when editing code.
  * Changed the `CMD` that starts the app. It now executes the file `entrypoint-dev.sh` (see below)
* `docker-dev/docker-compose.yml` has new bind-mounts to map volumes from the source code of the host to the container. This allows for quick code changes without rebuilding the image 

Added a separate start bash script to keep from opening 4 terminals to launch the app (`entrypoint-dev.sh`)

Added new documentation in `docs/devWithDocker.md` containing a tutorial on setting up the dev environment


