### PR TITLE
readme: Update broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See http://transition.city/
 
 [Definitions and symbols used in the code and in the interface](https://www.overleaf.com/read/dtxfhttxgjrx)
 
-For Ubuntu users: [complete step-by-step development environment setup procedure](docs/setupDevEnvironmentUbuntu20.04.md)
+For Ubuntu users: [complete step-by-step development environment setup procedure](docs/setupDevEnvironmentUbuntu.md)
 
 ## Stand alone Desktop installation
 


### PR DESCRIPTION
The 7b55bee commit has renamed the `docs/setupDevEnvironmentUbuntu20.04.md` file into `docs/setupDevEnvironmentUbuntu.md`. Unfortunately the link in the README file was pointing to the previous version.

The current commit replaces the old link with the new one.

--- 

By the way (and not in the commit message), I love your project ;) 