### PR TITLE
path: fix schedule update on line when a path is deleted

### DIFF
--- a/packages/transition-backend/src/models/db/migrations/20250212104000_schedulePeriodOnDeleteSetNull.ts
+++ b/packages/transition-backend/src/models/db/migrations/20250212104000_schedulePeriodOnDeleteSetNull.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const tableName = 'tr_transit_schedule_periods';
+
+/**
+ * This migration sets the foreign key constraint on inbound and outbound path
+ * id to null on delete instead of cascade. Otherwise, deleting a single path
+ * used as inbound or outbound would delete the schedule period and all other
+ * trips associated with this service. We want to keep the trips that are not
+ * deleted
+ *
+ * @param knex The database configuration object
+ * @returns
+ */
+export async function up(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.dropForeign('outbound_path_id');
+        table.dropForeign('inbound_path_id');
+        table.foreign('outbound_path_id').references('tr_transit_paths.id').onDelete('SET NULL');
+        table.foreign('inbound_path_id').references('tr_transit_paths.id').onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.dropForeign('outbound_path_id');
+        table.dropForeign('inbound_path_id');
+        table.foreign('outbound_path_id').references('tr_transit_paths.id').onDelete('CASCADE');
+        table.foreign('inbound_path_id').references('tr_transit_paths.id').onDelete('CASCADE');
+    });
+}

--- a/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
+++ b/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
@@ -188,8 +188,16 @@ function createDataHandlers(): Record<string, TransitObjectDataHandler> {
                     }
                     if (transitClassConfig.cacheQueries.objectToCache) {
                         try {
+                            // Re-read the object from the database to update the cache
+                            // FIXME: Make sure that all read objects contain
+                            // all necessary to send to cache. Currently, only
+                            // the lines use this code path, nodes use the
+                            // `transitNode.save` socket route instead. And
+                            // lines read the schedule so it's ok. But should anything
+                            // else implement this, it should be checked.
+                            const updatedObject = await transitClassConfig.dbQueries.read(updatedId);
                             await transitClassConfig.cacheQueries.objectToCache(
-                                attributes,
+                                updatedObject.attributes ? updatedObject.attributes : updatedObject,
                                 attributes.data.customCachePath
                             );
                             return {

--- a/packages/transition-common/src/services/path/Path.ts
+++ b/packages/transition-common/src/services/path/Path.ts
@@ -1373,10 +1373,13 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
                             line.attributes.path_ids = line.attributes.path_ids.filter((pathId) => {
                                 return pathId !== this.id;
                             });
+                            // FIXME This should be one method only, to refresh the line from server
                             line.refreshPaths();
                             line.refreshStats();
-                            line.save(socket).then((_lineSaveResponse) => {
-                                resolve(response);
+                            line.refreshSchedules(socket).then(() => {
+                                line.save(socket).then((_lineSaveResponse) => {
+                                    resolve(response);
+                                });
                             });
                         } else {
                             resolve(response);


### PR DESCRIPTION
fixes #1237 

Add a "set null" contraints on the schedule period's outbound_path_id and inbound_path_id to avoid deleting all trips if one of the path is deleted.

Refresh a line's schedule after deleting a path

Read the object from database after saving it.