### PR TITLE
Enhance Service View with Line Display and Filtering

### DIFF
--- a/packages/transition-frontend/src/components/forms/line/__tests__/TransitLineButton.test.tsx
+++ b/packages/transition-frontend/src/components/forms/line/__tests__/TransitLineButton.test.tsx
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import * as React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import TransitLineButton from '../TransitLineButton';
+import Line from 'transition-common/lib/services/line/Line';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { duplicateLine } from 'transition-common/lib/services/line/LineDuplicator';
+
+
+jest.mock('react-markdown', () => 'Markdown');
+jest.mock('remark-gfm', () => 'remark-gfm');
+
+jest.mock('transition-common/lib/services/line/LineDuplicator', () => ({
+    duplicateLine: jest.fn(),
+}));
+
+jest.mock('chaire-lib-common/lib/utils/ServiceLocator', () => ({
+    socketEventManager: {
+        emit: jest.fn(),
+        on: jest.fn(),
+        off: jest.fn(),
+    },
+    selectedObjectsManager: {
+        select: jest.fn(),
+        unselect: jest.fn(),
+    },
+}));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    
+    serviceLocator.selectedObjectsManager = {
+        select: jest.fn(),
+        unselect: jest.fn(),
+    };
+
+    serviceLocator.socketEventManager = {
+        emit: jest.fn(),
+        on: jest.fn(),
+        off: jest.fn(),
+    };
+
+});
+
+// Wrap tests in a describe block
+describe('TransitLineButton', () => {
+
+    test('Minimal props', () => {
+        const mockLine = new Line({ some: "attributes" }, true);
+        const { container } = render(
+            <TransitLineButton
+                line={mockLine}
+                lineIsHidden={false}
+            >
+                test
+            </TransitLineButton>
+        );
+
+        expect(container).toMatchSnapshot();
+    });
+
+    test('All props', () => {
+        const mockLine = new Line({ some: "attributes" }, true);
+        const mockOnObjectSelected = (objectId: string) => {};
+        const { container } = render(
+            <TransitLineButton
+                line={mockLine} 
+                selectedLine={mockLine} 
+                lineIsHidden={false} 
+                onObjectSelected={mockOnObjectSelected}
+            >
+                test
+            </TransitLineButton>
+        );
+
+        expect(container).toMatchSnapshot();
+    });
+
+    test('onSelect should call refreshSchedules, startEditing, and onObjectSelected', async () => {
+
+        const mockLine = new Line({ some: "attributes" }, true);
+        // const mockOnObjectSelected = (objectId: string) => {};
+        const mockOnObjectSelected = jest.fn();
+
+        const { getByText } = render(
+            <TransitLineButton
+                line={mockLine} 
+                selectedLine={mockLine} 
+                lineIsHidden={false} 
+                onObjectSelected={mockOnObjectSelected}
+            >
+                test
+            </TransitLineButton>
+        );
+
+        jest.spyOn(mockLine, 'refreshSchedules').mockResolvedValue(undefined);
+        jest.spyOn(mockLine, 'getId').mockReturnValue("fake_line_id_1");
+        jest.spyOn(mockLine, 'startEditing').mockImplementation(() => {});
+        jest.spyOn(mockLine, 'refreshPaths').mockImplementation(() => {});
+        
+        const button = document.querySelector('._list-element');
+        if (button) fireEvent.click(button);
+
+        await waitFor(() => {
+            expect(mockLine.refreshSchedules).toHaveBeenCalledWith(serviceLocator.socketEventManager);
+            expect(mockLine.startEditing).toHaveBeenCalled();
+            expect(mockOnObjectSelected).toHaveBeenCalledWith('fake_line_id_1');
+            expect(serviceLocator.selectedObjectsManager.select).toHaveBeenCalledWith('line', mockLine);
+        });
+    });
+
+    test('onDelete should trigger delete when the line is NOT selected', async () => {
+        
+        // First mocked line (the one being tested for deletion)
+        const mockLine = new Line({ some: "attributes" }, true);
+        jest.spyOn(mockLine, 'hasPaths').mockReturnValue(true);
+        jest.spyOn(mockLine, 'isFrozen').mockReturnValue(false);
+        jest.spyOn(mockLine, 'delete').mockResolvedValue(
+            Status.createOk({ id: 'fake_line_id_1' })
+        );
+        jest.spyOn(mockLine, 'getId').mockReturnValue("fake_line_id_1");
+    
+        // Second mocked line (the currently selected line)
+        const mockLine2 = new Line({ some: "other_attributes" }, true);
+        jest.spyOn(mockLine2, 'getId').mockReturnValue("fake_line_id_2");
+    
+        // Mock serviceLocator
+        serviceLocator.selectedObjectsManager = {
+            deselect: jest.fn(),
+        };
+        serviceLocator.collectionManager = {
+            get: jest.fn().mockImplementation((name) => {
+                if (name === 'paths') {
+                    return {
+                        loadFromServer: jest.fn().mockResolvedValue(undefined),
+                        toGeojson: jest.fn().mockReturnValue({}),
+                    };
+                }
+                return { refresh: jest.fn() };
+            }),
+            refresh: jest.fn(),
+        };
+        serviceLocator.eventManager = {
+            emit: jest.fn(),
+            emitEvent: jest.fn(),
+        };
+        serviceLocator.socketEventManager = {
+            emit: jest.fn(),
+            off: jest.fn(),
+            on: jest.fn(),
+        };
+    
+    
+        const { container, getByText } = render(
+            <TransitLineButton
+                line={mockLine} 
+                selectedLine={mockLine2} 
+                lineIsHidden={false}
+                onObjectSelected={jest.fn()}
+            />
+        );
+    
+        // Verify that the delete button exists
+        const deleteButton = container.querySelector('img[alt="transit:transitLine:Delete"]');
+        expect(deleteButton).not.toBeNull();
+        fireEvent.click(deleteButton as Element);
+    
+        // Confirm delete in the modal
+        const confirmDeleteButton = await waitFor(() =>
+            getByText('transit:transitLine:Delete')
+        );
+        fireEvent.click(confirmDeleteButton);
+    
+        // Ensure delete process executes correctly
+        await waitFor(() => {
+            expect(mockLine.delete).toHaveBeenCalledWith(serviceLocator.socketEventManager);
+            expect(serviceLocator.collectionManager.refresh).toHaveBeenCalledWith('lines');
+        });
+    });
+
+    test('onDuplicate should call duplicateLine and refresh collections', async () => {
+        // Mocking a line
+        const mockLine = new Line({ some: "attributes", longname: "Test Line" }, true);
+        jest.spyOn(mockLine, 'get').mockImplementation((key) => {
+            if (key === 'longname') return 'Test Line';
+            if (key === 'is_frozen') return false; // Mock is_frozen attribute
+            return undefined;
+        });
+    
+        // Mock isFrozen method
+        mockLine.isFrozen = jest.fn().mockReturnValue(false); // Default to not frozen
+    
+        // Mock getAgency method if it exists
+        mockLine.getAgency = jest.fn().mockReturnValue({
+            get: jest.fn().mockImplementation((key) => {
+                if (key === 'is_frozen') return false; // Mock agency is_frozen attribute
+                return undefined;
+            }),
+        });
+    
+        // Mocking duplicateLine to return a new line instance
+        const duplicatedLine = new Line({ some: "newAttributes", longname: "Test Line (Copy)" }, true);
+        (duplicateLine as jest.Mock).mockResolvedValue(duplicatedLine);
+    
+        // Mock ServiceLocator functions
+        serviceLocator.collectionManager = {
+            get: jest.fn((collectionName) => {
+                if (collectionName === 'agencies') {
+                    return {
+                        getById: jest.fn().mockReturnValue({ id: 'fake_agency_id' }), // Mock agency
+                    };
+                }
+                if (collectionName === 'paths') {
+                    return {
+                        toGeojson: jest.fn().mockReturnValue({}),
+                    };
+                }
+                return { refresh: jest.fn() }; // Default return
+            }),
+            refresh: jest.fn(),
+        };
+    
+        serviceLocator.eventManager = {
+            emit: jest.fn(),
+            emitEvent: jest.fn(),
+        };
+        serviceLocator.socketEventManager = {};
+    
+        // Render the component with hideActions set to false so the duplicate button is visible
+        const { container } = render(
+            <TransitLineButton
+                line={mockLine}
+                selectedLine={mockLine} 
+                lineIsHidden={false}
+                onObjectSelected={jest.fn()} 
+            />
+        );
+    
+        // Find the duplicate button using querySelector (Adjust selector as needed)
+        const duplicateButton = container.querySelector('img[alt="transit:transitLine:DuplicateLine"]');
+        expect(duplicateButton).toBeInTheDocument(); // Ensure the button is found
+        if(duplicateButton) {
+            fireEvent.click(duplicateButton); // Click the button
+        }
+        
+    });
+});

--- a/packages/transition-frontend/src/components/forms/line/__tests__/__snapshots__/TransitLineButton.test.tsx.snap
+++ b/packages/transition-frontend/src/components/forms/line/__tests__/__snapshots__/TransitLineButton.test.tsx.snap
@@ -1,0 +1,199 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransitLineButton All props 1`] = `
+<div>
+  <li
+    class="_list _active"
+  >
+    <span
+      class="_list-group _left"
+    >
+      <span
+        class="_list-element"
+      >
+        <span
+          class="_circle-button"
+        />
+        <span
+          class="_list-element"
+          title="main:Hide"
+        >
+          <img
+            alt="main:Hide"
+            class="_list-element _icon-alone"
+            src="/dist/images/icons/interface/visible_white.svg"
+            title="main:Hide"
+          />
+        </span>
+        <img
+          alt="transit:transitLine:modes:null"
+          class="_list-element _icon-alone"
+          src="/dist/images/icons/transit/modes/null_white.svg"
+          title="transit:transitLine:modes:null"
+        />
+      </span>
+    </span>
+    <span
+      class="_list-group _left"
+    >
+      <span
+        class="_list-element"
+      />
+    </span>
+    <span
+      class="_list-group _left"
+    >
+      <span
+        class="_list-element"
+      />
+    </span>
+    <span
+      class="_list-group _flush-right _right"
+    >
+      <span
+        class="_list-element"
+      >
+        transit:transitLine:nPath
+         
+      </span>
+    </span>
+    <span
+      class="_list-group _right"
+      title="main:Edit"
+    >
+      <span
+        class="_list-element"
+      >
+        <img
+          alt="main:Edit"
+          class="_icon-alone"
+          src="/dist/images/icons/interface/edit_white.svg"
+        />
+      </span>
+    </span>
+    <span
+      class="_list-group _right"
+      title="transit:transitLine:DuplicateLine"
+    >
+      <span
+        class="_list-element"
+      >
+        <img
+          alt="transit:transitLine:DuplicateLine"
+          class="_icon"
+          src="/dist/images/icons/interface/copy_white.svg"
+        />
+      </span>
+    </span>
+  </li>
+  <li
+    class="_clear"
+  />
+</div>
+`;
+
+exports[`TransitLineButton Minimal props 1`] = `
+<div>
+  <li
+    class="_list"
+  >
+    <span
+      class="_list-group _left"
+    >
+      <span
+        class="_list-element"
+      >
+        <span
+          class="_circle-button"
+        />
+        <span
+          class="_list-element"
+          title="main:Hide"
+        >
+          <img
+            alt="main:Hide"
+            class="_list-element _icon-alone"
+            src="/dist/images/icons/interface/visible_white.svg"
+            title="main:Hide"
+          />
+        </span>
+        <img
+          alt="transit:transitLine:modes:null"
+          class="_list-element _icon-alone"
+          src="/dist/images/icons/transit/modes/null_white.svg"
+          title="transit:transitLine:modes:null"
+        />
+      </span>
+    </span>
+    <span
+      class="_list-group _left"
+    >
+      <span
+        class="_list-element"
+      />
+    </span>
+    <span
+      class="_list-group _left"
+    >
+      <span
+        class="_list-element"
+      />
+    </span>
+    <span
+      class="_list-group _flush-right _right"
+    >
+      <span
+        class="_list-element"
+      >
+        transit:transitLine:nPath
+         
+      </span>
+    </span>
+    <span
+      class="_list-group _right"
+      title="main:Edit"
+    >
+      <span
+        class="_list-element"
+      >
+        <img
+          alt="main:Edit"
+          class="_icon-alone"
+          src="/dist/images/icons/interface/edit_white.svg"
+        />
+      </span>
+    </span>
+    <span
+      class="_list-group _right"
+      title="transit:transitLine:DuplicateLine"
+    >
+      <span
+        class="_list-element"
+      >
+        <img
+          alt="transit:transitLine:DuplicateLine"
+          class="_icon"
+          src="/dist/images/icons/interface/copy_white.svg"
+        />
+      </span>
+    </span>
+    <span
+      class="_list-group _right"
+      title="transit:transitLine:Delete"
+    >
+      <span
+        class="_list-element"
+      >
+        <img
+          alt="transit:transitLine:Delete"
+          class="_icon-alone"
+          src="/dist/images/icons/interface/delete_white.svg"
+        />
+      </span>
+    </span>
+  </li>
+  <li
+    class="_clear"
+  />
+</div>
+`;

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceButton.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceButton.tsx
@@ -7,11 +7,15 @@
 import React from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
 
+import Collapsible from 'react-collapsible';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Service from 'transition-common/lib/services/service/Service';
 import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
+import DocumentationTooltip from '../../parts/DocumentationTooltip';
+import MathJax from 'react-mathjax';
+import TransitServiceLinesDetail from '../service/TransitServiceLinesDetail';
 
 interface ScheduleButtonProps extends WithTranslation {
     service: Service;
@@ -90,48 +94,62 @@ const TransitServiceButton: React.FunctionComponent<ScheduleButtonProps> = (prop
     }
 
     return (
-        <Button
-            key={serviceId}
-            isSelected={serviceIsSelected}
-            onSelect={{ handler: onSelect }}
-            onDuplicate={{ handler: onDuplicate, altText: props.t('transit:transitService:DuplicateService') }}
-            onDelete={
-                !isFrozen && !serviceIsSelected
-                    ? {
-                        handler: onDelete,
-                        message: hasScheduledLines
-                            ? props.t('transit:transitService:ConfirmDeleteWithSchedule')
-                            : props.t('transit:transitService:ConfirmDelete'),
-                        altText: props.t('transit:transitService:Delete')
-                    }
-                    : undefined
-            }
-            flushActionButtons={scheduledLineCount === 0}
-        >
-            <ButtonCell alignment="left">
-                <span className="_circle-button" style={{ backgroundColor: service.getAttributes().color }}></span>
-            </ButtonCell>
-            {isFrozen && (
+        <React.Fragment>
+            <Button
+                key={serviceId}
+                isSelected={serviceIsSelected}
+                onSelect={{ handler: onSelect }}
+                onDuplicate={{ handler: onDuplicate, altText: props.t('transit:transitService:DuplicateService') }}
+                onDelete={
+                    !isFrozen && !serviceIsSelected
+                        ? {
+                            handler: onDelete,
+                            message: hasScheduledLines
+                                ? props.t('transit:transitService:ConfirmDeleteWithSchedule')
+                                : props.t('transit:transitService:ConfirmDelete'),
+                            altText: props.t('transit:transitService:Delete')
+                        }
+                        : undefined
+                }
+                flushActionButtons={scheduledLineCount === 0}
+            >
                 <ButtonCell alignment="left">
-                    <img
-                        className="_icon-alone"
-                        src={'/dist/images/icons/interface/lock_white.svg'}
-                        alt={props.t('main:Locked')}
-                    />
+                    <span className="_circle-button" style={{ backgroundColor: service.getAttributes().color }}></span>
                 </ButtonCell>
-            )}
-            <ButtonCell alignment="left">
-                {service.get('name') as string}
-                {serviceWeekdaysStr}
-            </ButtonCell>
-            {scheduledLineCount > 0 && (
-                <ButtonCell alignment="flush">
-                    {scheduledLineCount > 1
-                        ? props.t('transit:transitService:nLines', { n: scheduledLineCount })
-                        : props.t('transit:transitService:oneLine')}
+                {isFrozen && (
+                    <ButtonCell alignment="left">
+                        <img
+                            className="_icon-alone"
+                            src={'/dist/images/icons/interface/lock_white.svg'}
+                            alt={props.t('main:Locked')}
+                        />
+                    </ButtonCell>
+                )}
+                <ButtonCell alignment="left">
+                    {service.get('name') as string}
+                    {serviceWeekdaysStr}
                 </ButtonCell>
-            )}
-        </Button>
+            </Button>
+            <div className="tr__form-services-panel-lines-list">
+                <Button key={`lines${props.service.getId()}`} isSelected={serviceIsSelected} flushActionButtons={false}>
+                    <DocumentationTooltip dataTooltipId="line-tooltip" documentationLabel="line" />
+                    <Collapsible
+                        lazyRender={true}
+                        trigger={
+                            <MathJax.Provider>
+                                {props.t('transit:transitLine:List')}&nbsp;
+                                <span>
+                                    <MathJax.Node inline formula={'L'} data-tooltip-id="line-tooltip" />
+                                </span>
+                            </MathJax.Provider>
+                        }
+                        transitionTime={200}
+                    >
+                        <TransitServiceLinesDetail service={props.service} />
+                    </Collapsible>
+                </Button>
+            </div>
+        </React.Fragment>
     );
 };
 

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceEdit.tsx
@@ -23,8 +23,10 @@ import SelectedObjectButtons from 'chaire-lib-frontend/lib/components/pageParts/
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import * as ServiceUtils from '../../../services/transitService/TransitServiceUtils';
 import Service, { serviceDays } from 'transition-common/lib/services/service/Service';
+import MathJax from 'react-mathjax';
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
 import TransitServiceFilterableList from './TransitServiceFilterableList';
+import TransitServiceLinesDetail from '../service/TransitServiceLinesDetail';
 
 interface ServiceFormProps extends WithTranslation {
     service: Service;
@@ -371,6 +373,22 @@ class TransitServiceEdit extends SaveableObjectForm<Service, ServiceFormProps, S
                             closeModal={this.closeBackConfirmModal}
                         />
                     )}
+
+                    <Collapsible
+                        lazyRender={true}
+                        trigger={
+                            <MathJax.Provider>
+                                {this.props.t('transit:transitLine:List')}&nbsp;
+                                <span>
+                                    <MathJax.Node inline formula={'L'} data-tooltip-id="line-tooltip" />
+                                </span>
+                            </MathJax.Provider>
+                        }
+                        open={true}
+                        transitionTime={200}
+                    >
+                        <TransitServiceLinesDetail service={this.props.service} />
+                    </Collapsible>
                 </div>
             </form>
         );

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceLineItem.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceLineItem.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under le MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import Line from 'transition-common/lib/services/line/Line';
+import Agency from 'transition-common/lib/services/agency/Agency';
+import Button from '../../parts/Button';
+import ButtonCell from '../../parts/ButtonCell';
+
+interface TransitServiceLineItemProps {
+    line: Line;
+}
+
+const TransitServiceLineItem: React.FunctionComponent<TransitServiceLineItemProps> = ({ line }) => {
+    const { t } = useTranslation('transit');
+
+    const agencyCollection = serviceLocator.collectionManager.get('agencies');
+    const agency: Agency | undefined = agencyCollection?.getById(line.getAttributes().agency_id);
+
+    return (
+        <Button key={line.getId()} isSelected={false} flushActionButtons={false}>
+            <ButtonCell alignment="left">
+                <img
+                    className="_list-element _icon-alone"
+                    src={`/dist/images/icons/transit/modes/${line.getAttributes().mode}_white.svg`}
+                    alt={t(`transit:transitLine:modes:${line.getAttributes().mode}`)}
+                    title={t(`transit:transitLine:modes:${line.getAttributes().mode}`)}
+                />
+            </ButtonCell>
+            <ButtonCell alignment="left">
+                <span className="_circle-button" style={{ backgroundColor: line.attributes.color }}></span>
+            </ButtonCell>
+            <ButtonCell alignment="left">{line.attributes.shortname}</ButtonCell>
+            <ButtonCell alignment="left">{line.attributes.longname}</ButtonCell>
+            <ButtonCell alignment="left">
+                {agency ? agency.getAttributes().name : t('transit:UnknownAgency')}
+            </ButtonCell>
+        </Button>
+    );
+};
+
+export default TransitServiceLineItem;

--- a/packages/transition-frontend/src/components/forms/service/TransitServiceLinesDetail.tsx
+++ b/packages/transition-frontend/src/components/forms/service/TransitServiceLinesDetail.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import Service from 'transition-common/lib/services/service/Service';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import TransitServiceLineItem from '../service/TransitServiceLineItem';
+import ButtonList from '../../parts/ButtonList';
+
+interface TransitServiceLinesDetailProps {
+    service: Service;
+}
+
+const TransitServiceLinesDetail: React.FunctionComponent<TransitServiceLinesDetailProps> = ({ service }) => {
+    const lines = React.useMemo(() => {
+        const lineCollection = serviceLocator.collectionManager.get('lines');
+        if (!lineCollection) return [];
+
+        return lineCollection
+            .getFeatures()
+            .filter((line) => line.attributes.service_ids?.includes(service.getId()))
+            .sort((lineA, lineB) => lineA.toString().localeCompare(lineB.toString()));
+    }, [service]);
+
+    return (
+        <div className="tr__form-service-lines">
+            <ButtonList key={`button_list_${service.getId()}`}>
+                {lines.map((line) => (
+                    <TransitServiceLineItem key={`line_${line.getId()}`} line={line} />
+                ))}
+            </ButtonList>
+        </div>
+    );
+};
+
+export default TransitServiceLinesDetail;


### PR DESCRIPTION
Enhance Service View with Line Display and Filtering
Part of [#1010](https://github.com/chairemobilite/transition/issues/1010)
	• Added logic to display service lines in both the main Service View and the Edit Panel View
	• Implemented filtering to show only relevant lines based on the selected service
	• Added TransitServiceLinesDetails to manage line filtering per service
	• Updated TransitServiceButton and TransitServiceEdit to integrate the new component
	• Hid unnecessary line information to streamline the UI
	• Renamed elements to align with French naming conventions
Added tests (TransitLineButton.test.ts) to ensure correct behavior after modifying display options