### PR TITLE
batch route: return only known fields and do not save geometries if not requested

### DIFF
--- a/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
@@ -20,7 +20,8 @@ const defaultRoutingRadiusMeters = 20;
 
 const osrmStepToResult = (step: osrm.RouteStep) => {
     return {
-        ...step,
+        distance: step.distance,
+        duration: step.duration,
         geometry: (step.geometry as osrm.LineString).type
             ? (step.geometry as GeoJSON.LineString)
             : polyline.decode(step.geometry as string)
@@ -29,7 +30,8 @@ const osrmStepToResult = (step: osrm.RouteStep) => {
 
 const osrmLegToResult = (leg: osrm.RouteLeg) => {
     return {
-        ...leg,
+        distance: leg.distance,
+        duration: leg.duration,
         steps: leg.steps.map(osrmStepToResult)
     };
 };
@@ -43,7 +45,9 @@ const osrmMatchingToResult = (matching: osrm.MatchRoute) => {
 
 const osrmRouteToResult = (matching: osrm.Route) => {
     return {
-        ...matching,
+        distance: matching.distance,
+        duration: matching.duration,
+        geometry: matching.geometry,
         legs: matching.legs.map(osrmLegToResult)
     };
 };

--- a/packages/chaire-lib-common/src/services/routing/RoutingResultUtils.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingResultUtils.ts
@@ -14,7 +14,7 @@ export type ResultsByMode = {
     transit?: TransitRoutingResult;
 };
 
-const resultIsUnimodal = (
+export const resultIsUnimodal = (
     result: UnimodalRoutingResultData | TransitRoutingResultData
 ): result is UnimodalRoutingResultData => {
     return (result as any).routingMode !== undefined && (result as any).routingMode !== 'transit';

--- a/packages/chaire-lib-common/src/services/routing/RoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingService.ts
@@ -61,11 +61,12 @@ export interface MapLeg {
         distance: number;
         duration?: number;
         geometry: GeoJSON.Geometry;
-        [key: string]: any;
+        // FIXME Type additional properties as requried
     }[];
-    [key: string]: any;
+    // FIXME Type additional properties as requried
 }
 
+// TODO Some routing engine have plenty of additional data for their routes, we should consider optionally adding them, like annotations, OpenStreetMap node ids, speeds and weights per segment, etc.
 export interface Route {
     /**
      * The distance traveled by the route, in float meters

--- a/packages/chaire-lib-common/src/services/routing/__tests__/OSRMRoutingService.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/OSRMRoutingService.test.ts
@@ -72,41 +72,77 @@ const stubPlaces = [{
     }
 }]
 
-
-test('Route', async () => {
-    const point1 = TestUtils.makePoint([-73.1, 45.1]);
-    const point2 =TestUtils.makePoint([-73.1, 44.9]);
-
-    const osrmWaypoint1 = {location: [-73.1, 45.1]}
-    const osrmWaypoint2 = {location: [-73.1, 44.9]}
-
-    // TODO fill the routes fields with something
-    const expectedResponse = {waypoints: [point1.geometry, point2.geometry], routes: []};
-    const osrmResponse = {waypoints: [osrmWaypoint1, osrmWaypoint2], routes: []};
-    const mockRoute = jest.fn().mockImplementation((params, callback) => callback(Status.createOk(osrmResponse)));
-    eventManager.on('service.osrmRouting.route', mockRoute);
+describe('Route', () => {
+    test('Route success', async () => {
+        const point1 = TestUtils.makePoint([-73.1, 45.1]);
+        const point2 =TestUtils.makePoint([-73.1, 44.9]);
     
-    const routeResult = await routingService.route({ mode: 'walking', points: { type: 'FeatureCollection', features: stubPlaces}, withAlternatives: true });
-    expect(mockRoute).toHaveBeenCalledTimes(1);
-    expect(mockRoute).toHaveBeenCalledWith({mode: 'walking', points: stubPlaces, annotations: true, steps: false, continue_straight: undefined, overview: "full", withAlternatives: true }, expect.any(Function))
-    expect(routeResult).toEqual(expectedResponse);
-});
+        const osrmWaypoint1 = {location: [-73.1, 45.1]}
+        const osrmWaypoint2 = {location: [-73.1, 44.9]}
+    
+        const osrmResponse = {waypoints: [osrmWaypoint1, osrmWaypoint2], routes: [{
+           distance: 5000,
+           duration: 3600,
+           geometry: { type: 'LineString', coordinates: [[-73.1, 45.1], [-73.1, 44.9]] },
+           weight: 50,
+           weight_name: 'testWeight',
+           legs: [{
+                distance: 5000,
+                duration: 3600,
+                weight: 50,
+                summary: 'something',
+                steps: [{
+                    distance: 500,
+                    duration: 360,
+                    geometry: { type: 'LineString', coordinates: [[-73.1, 45.1], [-73.1, 44.9]] }
+                }],
+                annotation: {
+                    distance: [100, 500],
+                    duration: [50, 250]
+                }
+           }]
+        }]};
+        const expectedResponse = {waypoints: [point1.geometry, point2.geometry], routes: [{
+            distance: osrmResponse.routes[0].distance,
+            duration: osrmResponse.routes[0].duration,
+            legs: [{
+                distance: osrmResponse.routes[0].legs[0].distance,
+                duration: osrmResponse.routes[0].legs[0].duration,
+                steps: [{
+                    distance: osrmResponse.routes[0].legs[0].steps[0].distance,
+                    duration: osrmResponse.routes[0].legs[0].steps[0].duration,
+                    geometry: osrmResponse.routes[0].legs[0].steps[0].geometry
+                }]
+            }],
+            geometry: osrmResponse.routes[0].geometry
+        }]};
+        const mockRoute = jest.fn().mockImplementation((params, callback) => callback(Status.createOk(osrmResponse)));
+        eventManager.on('service.osrmRouting.route', mockRoute);
+        
+        const routeResult = await routingService.route({ mode: 'walking', points: { type: 'FeatureCollection', features: stubPlaces}, withAlternatives: true });
+        expect(mockRoute).toHaveBeenCalledTimes(1);
+        expect(mockRoute).toHaveBeenCalledWith({mode: 'walking', points: stubPlaces, annotations: true, steps: false, continue_straight: undefined, overview: "full", withAlternatives: true }, expect.any(Function))
+        expect(routeResult).toEqual(expectedResponse);
+    });
+    
+    test('Route fail', async () => {
+    
+        const mockRoute = jest.fn().mockImplementation((params, callback) => callback(Status.createError("BAD RESULTS")));
+        eventManager.on('service.osrmRouting.route', mockRoute);
+    
+        // TODO Could use the Jest expect.toThrow(), but it's a bit complex to implement with async and parameters
+        let routeResult;
+        let haveThrown = false;
+        try {
+            routeResult = await routingService.route({mode: 'walking', points: { type: 'FeatureCollection', features: stubPlaces}});
+        } catch {
+            haveThrown = true;
+        }
+        expect(mockRoute).toHaveBeenCalledTimes(1);
+        expect(mockRoute).toHaveBeenCalledWith({ mode: 'walking', points: stubPlaces, annotations: true, steps: false, continue_straight: undefined, overview: "full", withAlternatives: false }, expect.any(Function))
+        expect(routeResult).toBeUndefined();
+        expect(haveThrown).toBe(true);
+    });
+})
 
-test('Route fail', async () => {
 
-    const mockRoute = jest.fn().mockImplementation((params, callback) => callback(Status.createError("BAD RESULTS")));
-    eventManager.on('service.osrmRouting.route', mockRoute);
-
-    // TODO Could use the Jest expect.toThrow(), but it's a bit complex to implement with async and parameters
-    let routeResult;
-    let haveThrown = false;
-    try {
-        routeResult = await routingService.route({mode: 'walking', points: { type: 'FeatureCollection', features: stubPlaces}});
-    } catch {
-        haveThrown = true;
-    }
-    expect(mockRoute).toHaveBeenCalledTimes(1);
-    expect(mockRoute).toHaveBeenCalledWith({ mode: 'walking', points: stubPlaces, annotations: true, steps: false, continue_straight: undefined, overview: "full", withAlternatives: false }, expect.any(Function))
-    expect(routeResult).toBeUndefined();
-    expect(haveThrown).toBe(true);
-});


### PR DESCRIPTION
fixes #1263 

This greatly reduces the size of the json object response in the batch results:

For example, a result (with error in the transit results) had an original size of 48 241 bytes and finished with 1 111 bytes. With actual transit routing results (~8km walking distance), it's ~7K bytes. Note that this is the size of the json string of the result and does not reflect how it is saved in the database.  These numbers are not directly transferrable to database size of this data, but it gives an idea.