### PR TITLE
Docker dev environment : 2 small fixes related to the instructions in the documentation

### DIFF
--- a/docker-dev/docker-compose.override.yml
+++ b/docker-dev/docker-compose.override.yml
@@ -6,6 +6,10 @@
 
 services:
   transition-www:
+    # This line is necessary to specify that the build context is at the root of the app,
+    # otherwise the Dockerfile will not be detected. The docker-compose command *must* be
+    # ran from the root folder of the app, as mentioned above
+    build: .
     command:
       - /bin/sh 
       - /app/docker-dev/entrypoint-dev.sh

--- a/docs/devWithDocker.md
+++ b/docs/devWithDocker.md
@@ -49,12 +49,12 @@ Now, with the same terminal you've just opened, run this command to copy your Ge
 > Note: If you're using another GeoJSON file than the one provided as an example (`examples/polygon_rtl_area.geojson`), you need to modify the path specified in the first argument of the command
 
 ```
-docker cp ./examples/polygon_rtl_area.geojson docker-dev-transition-www-1:/app/examples/runtime/imports/polygon.geojson
+docker cp ./examples/polygon_rtl_area.geojson transition-transition-www-1:/app/examples/runtime/imports/polygon.geojson
 ```
 
-Then, in  Docker Desktop, select **Containers** on the left, then click on `docker-dev-transition-www-1` and go to the `Terminal` tab. Run the following commands.
+Then, in  Docker Desktop, select **Containers** on the left, then click on `transition-transition-www-1` and go to the `Terminal` tab. Run the following commands.
 
-> Note: You can also use `docker exec -it docker-dev-transition-www-1` to run these commands without Docker Desktop
+> Note: You can also use `docker exec -it transition-transition-www-1` to run these commands without Docker Desktop
 
 ```
 yarn setup && yarn migrate


### PR DESCRIPTION
1. The documentation mentions `docker-dev-transition-www-1` as the container name, even though when you follow the instructions, the created container is called `transition-transition-www-1`. The name has been corrected accordingly.
2. When trying to setup the dev environment following the documentation, the command  `docker compose ... up --build` would fail because it would try to pull the app's image. Now the docker compose override file changes the build context and uses the root Dockerfile to build the image.