### PR TITLE
isBlank: Consider whitespaces as blank

### DIFF
--- a/packages/chaire-lib-common/src/utils/LodashExtensions.ts
+++ b/packages/chaire-lib-common/src/utils/LodashExtensions.ts
@@ -8,12 +8,13 @@ import _isObject from 'lodash/isObject';
 import _isEmpty from 'lodash/isEmpty';
 import _isFinite from 'lodash/isFinite';
 import _isDate from 'lodash/isDate';
+import _isString from 'lodash/isString';
 
 const _isBlank = function (value) {
     return (
         value === undefined ||
         value === null ||
-        value === '' ||
+        (_isString(value) && value.trim() === '') ||
         value.toString().length === 0 ||
         (_isObject(value) && _isEmpty(value) && typeof value !== 'function' && !_isDate(value))
     );

--- a/packages/chaire-lib-common/src/utils/__tests__/LodashExtensions.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/LodashExtensions.test.ts
@@ -9,7 +9,10 @@ import each from 'jest-each';
 
 test('should check if isBlank', function() {
   expect(LE._isBlank(1.3)).toBe(false);
+  expect(LE._isBlank('')).toBe(true);
+  expect(LE._isBlank(' ')).toBe(true);
   expect(LE._isBlank('test')).toBe(false);
+  expect(LE._isBlank('\t')).toBe(true);
   expect(LE._isBlank(['test'])).toBe(false);
   expect(LE._isBlank(Infinity)).toBe(false);
   expect(LE._isBlank(null)).toBe(true);


### PR DESCRIPTION
We trim() string to ensure that whitespaces are considered blank

Added unittest to match those cases

Closes: #1281