### PR TITLE
In the batch routing queue, set concurrency at twice the number of tr…

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -131,7 +131,13 @@ class TrRoutingBatch {
             }
             this.batchRoutingQueryAttributes.routingModes = routingModes;
 
-            const promiseQueue = new pQueue({ concurrency: trRoutingInstancesCount });
+            // TODO: This is a test
+            // When we do not calculate alternatives, we are not saturating all the code that we have available.
+            // Let's test having twice the concurrency in the queue if we do not ask for alternatives
+            const desiredConcurrency = this.batchRoutingQueryAttributes.withAlternatives
+                ? trRoutingInstancesCount
+                : trRoutingInstancesCount * 2;
+            const promiseQueue = new pQueue({ concurrency: desiredConcurrency });
 
             // Log progress at most for each 1% progress
             const logInterval = Math.ceil(odTripsCount / 100);


### PR DESCRIPTION
…Routing threads

When not computing alternative, we seem to be bottlenecked by the Node side of things and not trRouting. So let's test this, only when not asking for alternative