### PR TITLE
path: use manual routing for direct path when terminals are manual

### DIFF
--- a/packages/transition-common/src/services/path/PathGeographyUtils.ts
+++ b/packages/transition-common/src/services/path/PathGeographyUtils.ts
@@ -254,10 +254,16 @@ class PathGeographyUtils {
         nodesAndWaypointsGeojsons: FeatureCollection<Point>
     ) {
         try {
-            const directPath = await routingService.mapMatch({
+            const terminals = this.getTerminalGeojson(nodesAndWaypointsGeojsons);
+            const shouldUseManual =
+                terminals.features.find((feature) => feature.properties?.type === 'manual') !== undefined;
+            const directPathRoutingService = shouldUseManual
+                ? routingServiceManager.getRoutingServiceForEngine('manual')
+                : routingService;
+            const directPath = await directPathRoutingService.mapMatch({
                 mode: routingMode,
                 defaultRunningSpeed: defaultRunningSpeedMps,
-                points: this.getTerminalGeojson(nodesAndWaypointsGeojsons)
+                points: terminals
             });
             return directPath;
         } catch (error) {


### PR DESCRIPTION
fixes #1291

If any of the terminal node has a manual type (like with the temporary click on the map), it may be in a zone where there is no network, so we'll use the manual routing service to route this path.