### PR TITLE
config: get the section configuration out of preferences

### DIFF
--- a/examples/config.js
+++ b/examples/config.js
@@ -154,6 +154,16 @@ module.exports = {
         overwriteExistingFile          : true
       }
     },
+
+    // Enable/Disable sections of the application
+    // sections: {
+    //     simulations: {
+    //         enabled: true
+    //    },
+    //    routing: {
+    //        enabled: false
+    //    },
+    //},
   
     defaultPreferences: {
       transit: {

--- a/packages/chaire-lib-backend/src/config/server.config.ts
+++ b/packages/chaire-lib-backend/src/config/server.config.ts
@@ -405,6 +405,22 @@ export const setProjectConfiguration = (newConfig: Partial<ProjectConfiguration<
         }
     }
 
+    // If there are still section configurations in the defaultPreferences section of the project config, set it as section config.
+    // FIXME Remove this if a reasonable time after march 2025, to give time to instances to update their configuration
+    const defaultPreferences = (newConfig as any)?.defaultPreferences;
+    if (defaultPreferences && defaultPreferences.sections) {
+        console.warn(
+            'The `defaultPreferences`\'s `sections` configuration is deprecated and will be removed in the future. Please use `sections.[sectionName]` configuration options instead, with the same format as the defaultPreferences.'
+        );
+        Object.keys(defaultPreferences.sections).forEach((appName) => {
+            Object.keys(defaultPreferences.sections[appName]).forEach((sectionName) => {
+                _merge(newConfig, {
+                    sections: { [sectionName]: defaultPreferences.sections[appName][sectionName] }
+                });
+            });
+        });
+    }
+
     setProjectConfigurationCommon(newConfig);
 };
 

--- a/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
+++ b/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
@@ -8,6 +8,7 @@ import config from './shared/project.config';
 import lineModesDefaultValues from './lineModesDefaultValues';
 import constants from './constants';
 
+// @deprecated This type has moved to chaire-lib's project configuration
 interface SectionDescription {
     localizedTitle: string;
     icon: string;
@@ -19,7 +20,10 @@ export interface PreferencesModel {
     defaultSection: string;
     infoPanelPosition: string;
     dateTimeFormat: string;
-    sections: {
+    // @deprecated This type has moved to chaire-lib's project configuration.
+    // Use the project configuration's `sections` instead, as it is not a
+    // preference, but an instance specific configuration.
+    sections?: {
         [key: string]: {
             [key: string]: SectionDescription;
         };
@@ -36,55 +40,6 @@ const defaultPreferences: PreferencesModel = {
     defaultSection: 'agencies',
     infoPanelPosition: 'right',
     dateTimeFormat: 'YYYY-MM-DD HH:mm',
-    sections: {
-        transition: {
-            agencies: {
-                localizedTitle: 'transit:transitAgency:AgenciesAndLines',
-                icon: '/dist/images/icons/transit/lines_white.svg'
-            },
-            nodes: {
-                localizedTitle: 'transit:transitNode:Nodes',
-                icon: '/dist/images/icons/transit/node_white.svg'
-            },
-            services: {
-                localizedTitle: 'transit:transitService:Services',
-                icon: '/dist/images/icons/transit/service_white.svg'
-            },
-            scenarios: {
-                localizedTitle: 'transit:transitScenario:Scenarios',
-                icon: '/dist/images/icons/transit/scenario_white.svg'
-            },
-            routing: {
-                localizedTitle: 'main:Routing',
-                icon: '/dist/images/icons/interface/routing_white.svg'
-            },
-            accessibilityMap: {
-                localizedTitle: 'main:AccessibilityMap',
-                icon: '/dist/images/icons/interface/accessibility_map_white.svg'
-            },
-            batchCalculation: {
-                localizedTitle: 'main:BatchCalculation',
-                icon: '/dist/images/icons/interface/od_routing_white.svg'
-            },
-            simulations: {
-                localizedTitle: 'transit:simulation:Simulations',
-                icon: '/dist/images/icons/interface/simulation_white.svg',
-                enabled: false
-            },
-            gtfsImport: {
-                localizedTitle: 'transit:gtfs:Import',
-                icon: '/dist/images/icons/interface/import_white.svg'
-            },
-            gtfsExport: {
-                localizedTitle: 'transit:gtfs:Export',
-                icon: '/dist/images/icons/interface/export_white.svg'
-            },
-            preferences: {
-                localizedTitle: 'main:Preferences',
-                icon: '/dist/images/icons/interface/preferences_white.svg'
-            }
-        }
-    },
     map: {
         center: [config.mapDefaultCenter.lon, config.mapDefaultCenter.lat],
         zoom: 10

--- a/packages/chaire-lib-common/src/config/shared/project.config.ts
+++ b/packages/chaire-lib-common/src/config/shared/project.config.ts
@@ -6,6 +6,14 @@
  */
 import _merge from 'lodash/merge';
 
+type SectionType = {
+    localizedTitle: string;
+    icon: string;
+    showMap?: boolean;
+    showFullSizePanel?: boolean;
+    enabled?: boolean;
+};
+
 // TODO Some project config option depend on the application, so should not be
 // typed in chaire-lib. Each app (transition , evolution, etc) should add types
 // to the config and should have a project.config file which imports this one
@@ -98,6 +106,14 @@ export type ProjectConfiguration<AdditionalConfig> = {
      * Absolute directory where project data will be stored (import files, osrm data, user data, caches, etc)
      */
     projectDirectory: string;
+
+    /**
+     * Configuration for the sections in the project. Used for apps that use the
+     * contributions system, with "dashboard" components
+     */
+    sections: {
+        [sectionName: string]: SectionType;
+    };
 } & AdditionalConfig;
 
 // Initialize default configuration
@@ -106,7 +122,8 @@ const projectConfig: ProjectConfiguration<any> = {
     separateAdminLoginPage: false,
     projectShortname: 'default',
     userDiskQuota: '1gb',
-    maxFileUploadMB: 256
+    maxFileUploadMB: 256,
+    sections: {}
 };
 
 /**

--- a/packages/transition-common/src/config/__tests__/project.config.test.ts
+++ b/packages/transition-common/src/config/__tests__/project.config.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { setProjectConfiguration } from 'chaire-lib-common/lib/config/shared/project.config';
+import projectConfig from '../project.config';
+
+describe('Project Configuration', () => {
+    test('should include default sections', () => {
+        const defaultSections = {
+            agencies: {
+                localizedTitle: 'transit:transitAgency:AgenciesAndLines',
+                icon: '/dist/images/icons/transit/lines_white.svg'
+            },
+            nodes: {
+                localizedTitle: 'transit:transitNode:Nodes',
+                icon: '/dist/images/icons/transit/node_white.svg'
+            },
+            services: {
+                localizedTitle: 'transit:transitService:Services',
+                icon: '/dist/images/icons/transit/service_white.svg'
+            },
+            scenarios: {
+                localizedTitle: 'transit:transitScenario:Scenarios',
+                icon: '/dist/images/icons/transit/scenario_white.svg'
+            },
+            routing: {
+                localizedTitle: 'main:Routing',
+                icon: '/dist/images/icons/interface/routing_white.svg'
+            },
+            accessibilityMap: {
+                localizedTitle: 'main:AccessibilityMap',
+                icon: '/dist/images/icons/interface/accessibility_map_white.svg'
+            },
+            batchCalculation: {
+                localizedTitle: 'main:BatchCalculation',
+                icon: '/dist/images/icons/interface/od_routing_white.svg'
+            },
+            simulations: {
+                localizedTitle: 'transit:simulation:Simulations',
+                icon: '/dist/images/icons/interface/simulation_white.svg',
+                enabled: false
+            },
+            gtfsImport: {
+                localizedTitle: 'transit:gtfs:Import',
+                icon: '/dist/images/icons/interface/import_white.svg'
+            },
+            gtfsExport: {
+                localizedTitle: 'transit:gtfs:Export',
+                icon: '/dist/images/icons/interface/export_white.svg'
+            },
+            preferences: {
+                localizedTitle: 'main:Preferences',
+                icon: '/dist/images/icons/interface/preferences_white.svg'
+            }
+        };
+
+        expect(projectConfig.sections).toEqual(expect.objectContaining(defaultSections));
+    });
+
+    test('should retain previous configuration', () => {
+        const previousConfig = {
+            sections: {
+                customSection: {
+                    localizedTitle: 'custom:CustomSection',
+                    icon: '/dist/images/icons/custom/custom_icon.svg'
+                }
+            }
+        };
+
+        setProjectConfiguration(previousConfig);
+
+        const expectedConfig = {
+            ...previousConfig,
+            sections: {
+                ...previousConfig.sections,
+                agencies: {
+                    localizedTitle: 'transit:transitAgency:AgenciesAndLines',
+                    icon: '/dist/images/icons/transit/lines_white.svg'
+                },
+                nodes: {
+                    localizedTitle: 'transit:transitNode:Nodes',
+                    icon: '/dist/images/icons/transit/node_white.svg'
+                },
+                services: {
+                    localizedTitle: 'transit:transitService:Services',
+                    icon: '/dist/images/icons/transit/service_white.svg'
+                },
+                scenarios: {
+                    localizedTitle: 'transit:transitScenario:Scenarios',
+                    icon: '/dist/images/icons/transit/scenario_white.svg'
+                },
+                routing: {
+                    localizedTitle: 'main:Routing',
+                    icon: '/dist/images/icons/interface/routing_white.svg'
+                },
+                accessibilityMap: {
+                    localizedTitle: 'main:AccessibilityMap',
+                    icon: '/dist/images/icons/interface/accessibility_map_white.svg'
+                },
+                batchCalculation: {
+                    localizedTitle: 'main:BatchCalculation',
+                    icon: '/dist/images/icons/interface/od_routing_white.svg'
+                },
+                simulations: {
+                    localizedTitle: 'transit:simulation:Simulations',
+                    icon: '/dist/images/icons/interface/simulation_white.svg',
+                    enabled: false
+                },
+                gtfsImport: {
+                    localizedTitle: 'transit:gtfs:Import',
+                    icon: '/dist/images/icons/interface/import_white.svg'
+                },
+                gtfsExport: {
+                    localizedTitle: 'transit:gtfs:Export',
+                    icon: '/dist/images/icons/interface/export_white.svg'
+                },
+                preferences: {
+                    localizedTitle: 'main:Preferences',
+                    icon: '/dist/images/icons/interface/preferences_white.svg'
+                }
+            }
+        };
+
+        expect(projectConfig.sections).toEqual(expect.objectContaining(expectedConfig.sections));
+    });
+});

--- a/packages/transition-common/src/config/project.config.ts
+++ b/packages/transition-common/src/config/project.config.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import projectConfig, {
+    ProjectConfiguration,
+    setProjectConfiguration
+} from 'chaire-lib-common/lib/config/shared/project.config';
+
+const defaultSectionsConfig = {
+    agencies: {
+        localizedTitle: 'transit:transitAgency:AgenciesAndLines',
+        icon: '/dist/images/icons/transit/lines_white.svg'
+    },
+    nodes: {
+        localizedTitle: 'transit:transitNode:Nodes',
+        icon: '/dist/images/icons/transit/node_white.svg'
+    },
+    services: {
+        localizedTitle: 'transit:transitService:Services',
+        icon: '/dist/images/icons/transit/service_white.svg'
+    },
+    scenarios: {
+        localizedTitle: 'transit:transitScenario:Scenarios',
+        icon: '/dist/images/icons/transit/scenario_white.svg'
+    },
+    routing: {
+        localizedTitle: 'main:Routing',
+        icon: '/dist/images/icons/interface/routing_white.svg'
+    },
+    accessibilityMap: {
+        localizedTitle: 'main:AccessibilityMap',
+        icon: '/dist/images/icons/interface/accessibility_map_white.svg'
+    },
+    batchCalculation: {
+        localizedTitle: 'main:BatchCalculation',
+        icon: '/dist/images/icons/interface/od_routing_white.svg'
+    },
+    simulations: {
+        localizedTitle: 'transit:simulation:Simulations',
+        icon: '/dist/images/icons/interface/simulation_white.svg',
+        enabled: false // Disabled by default as accessing this features requires CLI access
+    },
+    gtfsImport: {
+        localizedTitle: 'transit:gtfs:Import',
+        icon: '/dist/images/icons/interface/import_white.svg'
+    },
+    gtfsExport: {
+        localizedTitle: 'transit:gtfs:Export',
+        icon: '/dist/images/icons/interface/export_white.svg'
+    },
+    preferences: {
+        localizedTitle: 'main:Preferences',
+        icon: '/dist/images/icons/interface/preferences_white.svg'
+    }
+};
+
+// Make sure default values are set
+setProjectConfiguration<ProjectConfiguration<unknown>>({
+    sections: Object.assign({}, defaultSectionsConfig, projectConfig.sections)
+});
+
+export default projectConfig as ProjectConfiguration<unknown>;

--- a/packages/transition-frontend/src/components/dashboard/TransitionMenuBar.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionMenuBar.tsx
@@ -9,7 +9,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/DashboardContribution';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import config from 'chaire-lib-common/lib/config/shared/project.config';
 
 // TODO Menu items should not be provided directly by widgets, it should be
 // built from descriptive elements, or contributions should register their own
@@ -17,7 +17,7 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 const MenuBar: React.FunctionComponent<LayoutSectionProps & WithTranslation> = (
     props: LayoutSectionProps & WithTranslation
 ) => {
-    const sectionsConfig = Preferences.get('sections.transition');
+    const sectionsConfig = config.sections;
 
     const onClickHandler = function (e) {
         e.preventDefault();

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
@@ -6,6 +6,7 @@
  */
 import React from 'react';
 import Collapsible from 'react-collapsible';
+import moment from 'moment';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import _toString from 'lodash/toString';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
@@ -14,25 +15,28 @@ import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
+import config from 'chaire-lib-common/lib/config/shared/project.config';
 import PreferencesSectionProps from '../PreferencesSectionProps';
-import moment from 'moment';
 
 const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
     props: PreferencesSectionProps & WithTranslation
 ) => {
     const prefs = props.preferences.getAttributes();
 
-    const sections = prefs.sections.transition;
-    const sectionsChoices: { value: string; label: string }[] = [];
-    for (const sectionShortname in sections) {
-        const section = sections[sectionShortname];
-        if (section.enabled !== false) {
-            sectionsChoices.push({
-                label: props.t(section.localizedTitle),
-                value: sectionShortname
-            });
+    const sectionsChoices = React.useMemo(() => {
+        const sections = config.sections;
+        const sectionsChoices: { value: string; label: string }[] = [];
+        for (const sectionShortname in sections) {
+            const section = sections[sectionShortname];
+            if (section.enabled !== false) {
+                sectionsChoices.push({
+                    label: props.t(section.localizedTitle),
+                    value: sectionShortname
+                });
+            }
         }
-    }
+        return sectionsChoices;
+    }, []);
 
     return (
         <Collapsible trigger={props.t('main:preferences:General')} open={true} transitionTime={100}>

--- a/packages/transition-frontend/webpack.config.js
+++ b/packages/transition-frontend/webpack.config.js
@@ -18,6 +18,9 @@ if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'development';
 }
 
+// Make sure Transition specific config are loaded
+require('transition-common/lib/config/project.config');
+// Read the configuration file
 const configuration = require('chaire-lib-backend/lib/config/server.config');
 // Extract from the config all options that we should not send to the frontend.
 // The `{ ...config }` will be sent to the frontend


### PR DESCRIPTION
fixes #1286

Add a `sections` configuration option in the config of chaire-lib, to be used by applications like Transition or Octavi that use the dashboard functionality of chaire-lib.

Add a `project.config` file in transition-common with the transition section default configuration.

Update the `webpack.config.js` file to make sure the default section config is imported before reading the config file. That is the only change required to account for the new section config option.

Update usages in the frontend to get the enabled sections from the config instead of preferences.

** Breaking change **

Section configurations on the config file's `defaultPreferences` section is now deprecated. They will still work for a while, but they need to be updated.

Configuration files can overwrite section configuration options, directly, not in the preferences, as follows:

```
module.exports = {
   ...myConfig,
   sections: {
      simulations: {
         enabled: true
      },
      routing: {
         enabled: false
      }
   }
}
```