### PR TITLE
Fix bug with passwordless login form when pressing 'enter' or 'space'.

### DIFF
--- a/packages/chaire-lib-frontend/src/components/forms/auth/passwordless/PwdLessLoginForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/passwordless/PwdLessLoginForm.tsx
@@ -68,9 +68,8 @@ const LoginPage: React.FC<LoginPageProps> = ({ headerText, buttonText }) => {
     };
 
     const handleKeyUp = (e: React.KeyboardEvent) => {
-        // Submit form on enter or space keys
-        // FIXME Remove deprecated `which` property
-        if (e.key === 'Enter' || e.key === ' ' || e.which === 13 || e.which === 32) {
+        // Submit form on enter or space keys inside the email input
+        if (e.key === 'Enter' || e.key === ' ') {
             handleSubmit();
         }
     };
@@ -106,6 +105,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ headerText, buttonText }) => {
                         className="apptr__form-input apptr__form-input-string apptr__input apptr__input-string"
                         value={formState.email}
                         onChange={handleEmailChange}
+                        onKeyUp={handleKeyUp}
                     />
                 </div>
             </div>
@@ -115,7 +115,6 @@ const LoginPage: React.FC<LoginPageProps> = ({ headerText, buttonText }) => {
                 onClick={handleSubmit}
                 inputRef={submitButtonRef as React.RefObject<HTMLButtonElement>}
                 label={!_isBlank(buttonText) ? buttonText : t('auth:Login')}
-                onKeyUp={handleKeyUp}
             />
         </form>
     );


### PR DESCRIPTION
# Pull request
fix: #725 
Close https://github.com/chairemobilite/transition/pull/726 when this is merged. It's a duplicate of an old PR.

## Description
Fix bug with passwordless login form when pressing 'enter' or 'space'.
Remove onKeyUp on the button because the default button already handles that. On the email input, put onKeyUp with handleKeyUp.
So now, the user can press 'enter' or 'space' directly from the email input and go to the survey directly. Remove e.witch that is deprecated. The new method is e.key.