### PR TITLE
Fix double submit when 'Enter' press inside the form.

### DIFF
--- a/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/LoginForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/LoginForm.tsx
@@ -69,20 +69,15 @@ const LoginPage: React.FC<LoginPageProps> = ({ withForgotPassword = false, heade
         );
     };
 
-    const handleKeyPress = (e: React.KeyboardEvent<HTMLFormElement>) => {
-        if (e.key === 'Enter' || e.which === 13) {
+    const handleEnterKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        // Submit form on 'Enter' inside the element
+        if (e.key === 'Enter') {
             submitButtonRef.current?.click();
         }
     };
 
-    const handleKeyUp = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ' || e.which === 13 || e.which === 32) {
-            handleSubmit();
-        }
-    };
-
     return (
-        <form className="apptr__form apptr__form-auth" onKeyUp={handleKeyPress} onSubmit={(e) => e.preventDefault()}>
+        <form className="apptr__form apptr__form-auth" onSubmit={(e) => e.preventDefault()}>
             <div className="apptr__form-label-container center">
                 <div className="apptr__form__label-standalone no-question">
                     <p>{headerText || t('auth:pleaseEnterLoginCredentials')}</p>
@@ -120,6 +115,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ withForgotPassword = false, heade
                         className="apptr__form-input apptr__form-input-string apptr__input apptr__input-string"
                         value={formState.password}
                         onChange={handleInputChange}
+                        onKeyUp={handleEnterKeyPress}
                     />
                     {withForgotPassword && (
                         <div className="right _small">
@@ -132,11 +128,11 @@ const LoginPage: React.FC<LoginPageProps> = ({ withForgotPassword = false, heade
             </div>
 
             <Button
+                type="submit"
                 isVisible={true}
                 onClick={handleSubmit}
                 inputRef={submitButtonRef as React.RefObject<HTMLButtonElement>}
                 label={t('auth:Login')}
-                onKeyUp={handleKeyUp}
             />
         </form>
     );

--- a/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/RegisterForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/RegisterForm.tsx
@@ -109,11 +109,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
         );
     };
 
-    const handleKeyUp = (e: React.KeyboardEvent) => {
-        // submit on Enter or space key
-        // FIXME Remove the deprecated `which` property
-        if (e.key === 'Enter' || e.key === ' ' || e.which === 13 || e.which === 32) {
-            handleSubmit();
+    const handleEnterKeyUp = (e: React.KeyboardEvent) => {
+        // Submit form on 'Enter' inside the element
+        if (e.key === 'Enter') {
+            submitButtonRef.current?.click();
         }
     };
 
@@ -126,7 +125,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
                 {formState.error && <FormErrors errors={[formState.error]} />}
                 {register && !isAuthenticated && <FormErrors errors={['auth:usernameOrEmailAlreadyExists']} />}
             </div>
-
             <div className="apptr__form-container question-empty">
                 <div className="apptr__form-input-container">
                     <label htmlFor="email" className="_flex">
@@ -144,7 +142,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
                     />
                 </div>
             </div>
-
             {!withEmailOnly && (
                 <div className="apptr__form-container question-empty">
                     <div className="apptr__form-input-container">
@@ -162,7 +159,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
                     </div>
                 </div>
             )}
-
             <div className="apptr__form-container question-empty">
                 <div className="apptr__form-input-container">
                     <label htmlFor="password" className="_flex">
@@ -178,7 +174,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
                     />
                 </div>
             </div>
-
             <div className="apptr__form-container question-empty">
                 <div className="apptr__form-input-container">
                     <label htmlFor="passwordConfirmation" className="_flex">
@@ -191,22 +186,25 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
                         className="apptr__form-input apptr__form-input-string apptr__input apptr__input-string _input-password"
                         value={formState.passwordConfirmation}
                         onChange={handleInputChange}
+                        {...(withCaptcha ? {} : { onKeyUp: handleEnterKeyUp })} // Only add onKeyUp if not using captcha
                     />
                 </div>
             </div>
-
             {withCaptcha && (
                 <div className="apptr__form-container question-empty">
-                    <CaptchaComponent value={formState.userCaptcha} onChange={(e) => handleInputChange(e)} />
+                    <CaptchaComponent
+                        value={formState.userCaptcha}
+                        onChange={(e) => handleInputChange(e)}
+                        onKeyUp={handleEnterKeyUp}
+                    />
                 </div>
             )}
-
             <Button
+                type="submit"
                 isVisible={true}
                 onClick={handleSubmit}
                 inputRef={submitButtonRef as React.RefObject<HTMLButtonElement>}
                 label={t(['transition:auth:Register', 'auth:Register'])}
-                onKeyUp={handleKeyUp}
             />
         </form>
     );

--- a/packages/chaire-lib-frontend/src/components/forms/auth/passwordless/PwdLessLoginForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/passwordless/PwdLessLoginForm.tsx
@@ -68,9 +68,9 @@ const LoginPage: React.FC<LoginPageProps> = ({ headerText, buttonText }) => {
     };
 
     const handleKeyUp = (e: React.KeyboardEvent) => {
-        // Submit form on enter or space keys inside the email input
+        // Submit form on 'Enter' or 'space' keys inside the email input
         if (e.key === 'Enter' || e.key === ' ') {
-            handleSubmit();
+            submitButtonRef.current?.click();
         }
     };
 
@@ -111,6 +111,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ headerText, buttonText }) => {
             </div>
 
             <Button
+                type="submit"
                 isVisible={true}
                 onClick={handleSubmit}
                 inputRef={submitButtonRef as React.RefObject<HTMLButtonElement>}

--- a/packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Login page rendering Allow registration, no forgot password page 1`] = 
     >
       <button
         class="button green large"
-        type="button"
+        type="submit"
       >
          
         auth:Login
@@ -160,7 +160,7 @@ exports[`Login page rendering Registration allowed, allow forget password 1`] = 
     >
       <button
         class="button green large"
-        type="button"
+        type="submit"
       >
          
         auth:Login
@@ -246,7 +246,7 @@ exports[`Login page rendering Registration not allowed, no forgot password page 
     >
       <button
         class="button green large"
-        type="button"
+        type="submit"
       >
          
         auth:Login


### PR DESCRIPTION
# Pull request
fix: #1142 

## Description
Fix double submit when 'Enter' press inside the form.
We remove onKeyUp inside a form element because this could send the form twice when clicking 'enter' with the submit button focus. 
We move onKeyUp on the last input of the form so the user can submit the form when pressing 'enter' from there. 
We did this correction for LoginForm, RegisterForm, and PwdLessLoginForm. 
There were the same errors for all of them.
Update the packages/chaire-lib-frontend/src/components/pages/__tests__/__snapshots__/LoginPage.test.tsx.snap snapshot with buttons with type 'submit'