### PR TITLE
Fix lua profile

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/lib/guidance.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/lib/guidance.lua
@@ -85,7 +85,7 @@ function Guidance.set_classification (highway, result, input_way)
       if service_type ~= nil and service_type == 'alley' then
         result.road_classification.road_priority_class = road_priority_class.alley
       else
-        if serice_type == nil then
+        if service_type == nil then
           result.road_classification.road_priority_class = road_priority_class.alley
         else
           result.road_classification.road_priority_class = highway_classes[highway]

--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking.lua
@@ -23,6 +23,7 @@ function setup()
     default_mode            = mode.walking,
     default_speed           = walking_speed,
     oneway_handling         = 'specific',     -- respect 'oneway:foot' but not 'oneway'
+    side_road_multiplier    = 1.0, -- Needs to be defined for way_handlers.penalties
 
     barrier_blacklist = Set {
       'yes',


### PR DESCRIPTION

    OSRM Profile: Define side_road_multiplier for walking.lua
    
    There was one way that define a side_road as "yes" that was processed by the walking
    profile. Since we use the way_handlers:penalties, we need to define the
    value side_road_multiplier, other it will propagate as nil
    
    The offending way was https://www.openstreetmap.org/way/1204310256


Also sync guidance from upstream