### PR TITLE
Enable use of memcached for trRouting when doing batch calculation

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -75,9 +75,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.85.0 # Last working version with latest version of Rouille. Was stable
+    - name: Install specific Rust version
+      # 1.85 is the last working version with latest version of some of our dependencies (i.e. Rouille).
+      run: |
+        rustup toolchain install 1.85.0
+        rustup default 1.85.0
     - run: cargo build
       working-directory: ./services/json2capnp
     - run: cargo test

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=json2capnpbuild /app/services/json2capnp/target/debug/json2capnp ser
 
 # Copy in trRouting and osrm binaries
 # For trRouting
-RUN apt-get update && apt-get -y --no-install-recommends install capnproto libboost-regex1.74.0 libboost-filesystem1.74.0 libboost-iostreams1.74.0 libboost-thread1.74.0 libboost-date-time1.74.0 libboost-serialization1.74.0 libboost-program-options1.74.0 libspdlog1.10
+RUN apt-get update && apt-get -y --no-install-recommends install capnproto libboost-regex1.74.0 libboost-filesystem1.74.0 libboost-iostreams1.74.0 libboost-thread1.74.0 libboost-date-time1.74.0 libboost-serialization1.74.0 libboost-program-options1.74.0 libspdlog1.10 libmemcached11 libmemcachedutil2
 
 # For OSRM
 # libtbb12 us only available in bookworm or later copy it from the osrm image
@@ -54,6 +54,11 @@ RUN /usr/local/bin/osrm-extract --help && \
     /usr/local/bin/osrm-contract --help && \
     /usr/local/bin/osrm-partition --help && \
     /usr/local/bin/osrm-customize --help
+
+RUN /usr/local/bin/trRouting --help
+
+# Add memcached
+RUN apt-get install -y memcached
 
 # Copy the necessary files for compilation   
 COPY ./configs /app/configs

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
@@ -110,7 +110,7 @@ describe('Process Manager testing', function() {
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
         
     });
-    
+
     test('Simple Start/Restart/Stop', async function() {
         testSpawn.sequence.add(testSpawn.simple(0, 'All Good'));
         testSpawn.sequence.add(testSpawn.simple(0, 'All Good'));
@@ -437,6 +437,44 @@ describe('Process Manager testing', function() {
         const fileTransport = (logger as any).transports[0] as winston.transports.FileTransportInstance;
         expect(fileTransport.maxsize).toEqual(2048 * 1024);
         expect(fileTransport.maxFiles).toEqual(5);
+    });
+
+    test('Start no wait string', async function() {
+        testSpawn.sequence.add(function (this: any, cb) {
+            // Create a mock process object
+            const mockProcess = {
+                stdout: { on: jest.fn() },
+                stderr: { on: jest.fn() },
+                on: jest.fn()
+            };
+
+            // Emit the spawn event immediately
+            this.emit('spawn', mockProcess);
+
+            // Then small delay to leave time for the event emit and then exit
+            setTimeout(function () {
+                return cb(0);
+            }, 100);
+
+            // Return the mock process
+            return mockProcess;
+        });
+
+        expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
+
+        // Start service
+        var result = await ProcessManager.startProcess({
+            serviceName: testServiceName,
+            tagName: "TEST",
+            command: "ls",
+            commandArgs: ["-l"],
+            waitString: "",
+            useShell: false
+        });
+        expect(result.status).toBe('started');
+        expect(testSpawn.calls[0].command).toBe('ls');
+        expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
+        expect(fileManager.readFile("pids/TestService1.pid")).toBe("12");
     });
 });
 

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -68,7 +68,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -94,7 +94,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -119,7 +119,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -144,7 +144,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -171,7 +171,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -199,7 +199,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -225,7 +225,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -251,7 +251,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -284,7 +284,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -310,7 +310,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -335,7 +335,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -360,7 +360,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -387,7 +387,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -417,7 +417,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -454,7 +454,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -480,7 +480,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -505,14 +505,24 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenNthCalledWith(1,{
+            serviceName: 'memcached',
+            tagName: 'memcached',
+            command: 'memcached',
+            commandArgs: ['--port=11212', "--user=nobody", "-vv"],
+            waitString: "",
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false
+        });
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -528,14 +538,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -555,14 +565,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -578,14 +588,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 12345
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -604,14 +614,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: `trRouting${port}`,
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -631,14 +641,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 12345
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -656,14 +666,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(1);
-        expect(startProcessMock).toHaveBeenCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: false,
+            useShell: true,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {


### PR DESCRIPTION
With trRouting now supporting memcached for caching access/egress nodes calculation, we can benefit with some speed up in batch calculation. This is true when a batch calculation have many points that are repeated (either origin or destination). So not every calculation will benefits from this.

This change add the start of a memcached server before starting trRouting for the batch mode. Also add the parameters to the trRouting call to use this memcached.

In this tests with many repeat location, we can see a significant speed improvement: Before:
transition-www-1  | 2025-04-02T14:26:27.409246640Z calc/sec: 3.57 (current: 3.57) transition-www-1  | 2025-04-02T14:26:34.361172558Z calc/sec: 6.24 (current: 16.25) transition-www-1  | 2025-04-02T14:26:42.618879721Z calc/sec: 8.53 (current: 17.67) transition-www-1  | 2025-04-02T14:26:44.886634594Z calc/sec: 9.17 (current: 20.73) transition-www-1  | 2025-04-02T14:26:50.923670639Z calc/sec: 9.99 (current: 15.93) After:
transition-www-1  | 2025-04-02T18:48:30.327998497Z calc/sec: 4.8 (current: 4.8) transition-www-1  | 2025-04-02T18:48:33.450730762Z calc/sec: 8.05 (current: 29.71) transition-www-1  | 2025-04-02T18:48:38.700537032Z calc/sec: 13.52 (current: 38.52) transition-www-1  | 2025-04-02T18:48:38.725429933Z calc/sec: 13.61 (current: 133.01) transition-www-1  | 2025-04-02T18:48:41.304075500Z calc/sec: 15.43 (current: 36.17)