### PR TITLE
Pin version of rust toolchain to use for json2capnp test

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.85.0 # Last working version with latest version of Rouille. Was stable
     - run: cargo build
       working-directory: ./services/json2capnp
     - run: cargo test


### PR DESCRIPTION
The latest version of the toolchain does not work with some of the old dependencies that we have in json2capnp. Until we fix/change json2capnp, let's pin the test to the last working of the rust toolchain