### PR TITLE
Revert "Enable use of memcached for trRouting when doing batch calcul…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=json2capnpbuild /app/services/json2capnp/target/debug/json2capnp ser
 
 # Copy in trRouting and osrm binaries
 # For trRouting
-RUN apt-get update && apt-get -y --no-install-recommends install capnproto libboost-regex1.74.0 libboost-filesystem1.74.0 libboost-iostreams1.74.0 libboost-thread1.74.0 libboost-date-time1.74.0 libboost-serialization1.74.0 libboost-program-options1.74.0 libspdlog1.10 libmemcached11 libmemcachedutil2
+RUN apt-get update && apt-get -y --no-install-recommends install capnproto libboost-regex1.74.0 libboost-filesystem1.74.0 libboost-iostreams1.74.0 libboost-thread1.74.0 libboost-date-time1.74.0 libboost-serialization1.74.0 libboost-program-options1.74.0 libspdlog1.10
 
 # For OSRM
 # libtbb12 us only available in bookworm or later copy it from the osrm image
@@ -54,11 +54,6 @@ RUN /usr/local/bin/osrm-extract --help && \
     /usr/local/bin/osrm-contract --help && \
     /usr/local/bin/osrm-partition --help && \
     /usr/local/bin/osrm-customize --help
-
-RUN /usr/local/bin/trRouting --help
-
-# Add memcached
-RUN apt-get install -y memcached
 
 # Copy the necessary files for compilation   
 COPY ./configs /app/configs

--- a/packages/chaire-lib-backend/src/utils/processManagers/ProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/ProcessManager.ts
@@ -139,24 +139,9 @@ const startProcess = async function ({
                 };
                 const startedProcess = spawn(command, commandArgs, spawnParams);
 
-                // In case we don't have a waitString (if the started process does not display anything) for example, let's trigger a success on the spawn event.
-                if (waitString === '') {
-                    startedProcess.on('spawn', () => {
-                        const pidFilename = `${PID_DIRECTORY}/${serviceName}.pid`;
-                        console.log(fileManager.writeFile(pidFilename, startedProcess.pid?.toString()));
-                        console.log(`${tagName} server (${serviceName}) started pid:${startedProcess.pid}`);
-                        resolve({
-                            status: 'started',
-                            service: tagName,
-                            action: 'start',
-                            name: serviceName
-                        });
-                    });
-                }
-
                 startedProcess.stdout.on('data', (data) => {
                     // Validate that process is running with a specific output string
-                    if (waitString !== '' && data.includes(waitString)) {
+                    if (data.includes(waitString)) {
                         const pidFilename = `${PID_DIRECTORY}/${serviceName}.pid`;
                         console.log(fileManager.writeFile(pidFilename, startedProcess.pid?.toString()));
                         console.log(`${tagName} server (${serviceName}) started pid:${startedProcess.pid}`);

--- a/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
@@ -33,14 +33,12 @@ const startTrRoutingProcess = async (
         debug = undefined,
         cacheDirectoryPath,
         cacheAllScenarios = false,
-        logFiles,
-        memcachedServer
+        logFiles
     }: {
         debug?: boolean;
         cacheDirectoryPath?: string;
         cacheAllScenarios?: boolean; // Flag to enable the trRouting connection cache for all scenario`
         logFiles: TrRoutingConfig['logs'];
-        memcachedServer?: string; // If defined, enable use of memcached and use the value as the server URL
     }
 ) => {
     const osrmWalkingServerInfo = osrmService.getMode('walking').getHostPort();
@@ -74,11 +72,6 @@ const startTrRoutingProcess = async (
         commandArgs.push('--cacheAllConnectionSets=true');
     }
 
-    // Enable memcached usage in TrRouting
-    if (memcachedServer) {
-        commandArgs.push(`--useMemcached="${memcachedServer}"`);
-    }
-
     const waitString = 'ready.';
 
     const processStatus = await ProcessManager.startProcess({
@@ -87,7 +80,7 @@ const startTrRoutingProcess = async (
         command,
         commandArgs,
         waitString,
-        useShell: true, //FIXME: For unknown reason yet, libmemcached pool need trRouting to be run in a shell to work (https://github.com/chairemobilite/transition/issues/1322)
+        useShell: false,
         cwd,
         attemptRestart,
         logFiles: {
@@ -206,41 +199,11 @@ const startBatch = async function (
     const cacheAllScenarios = batchTrRoutingConfig.cacheAllScenarios;
     const debugFromParamOrConfig = debug !== undefined ? debug : batchTrRoutingConfig.debug;
 
-    // Start Memcached
-    // TODO This is a placeholder variable to be used when we implement config options to control the use of memcached
-    // We could add options to enable/disable and to set a specific host/port
-    const startMemcached = true;
-    let memcachedServer;
-    if (startMemcached) {
-        const memcachedPort = 11212; // 11211 is the default memcached port, we use +1 to not clash
-        const memcachedProcessStatus = await ProcessManager.startProcess({
-            serviceName: 'memcached',
-            tagName: 'memcached',
-            command: 'memcached',
-            commandArgs: [
-                `--port=${memcachedPort}`,
-                '--user=nobody', // Memcached does not want to run as root, let's drop to nobody
-                '-vv'
-            ], // Enable detailled output for logging
-            waitString: '',
-            useShell: false,
-            attemptRestart: false
-        });
-        if (memcachedProcessStatus.status === 'error' && memcachedProcessStatus.error.code === 'ENOENT') {
-            console.error('memcached executable does not exist in path');
-        } else if (memcachedProcessStatus.status === 'started') {
-            memcachedServer = 'localhost:11212';
-        } else {
-            console.error('cannot start memcached:', memcachedProcessStatus);
-        }
-    }
-
     const params = {
         cacheDirectoryPath: cacheDirectoryPath,
         cacheAllScenarios,
         debug: debugFromParamOrConfig,
-        logFiles: batchTrRoutingConfig.logs,
-        memcachedServer: memcachedServer
+        logFiles: batchTrRoutingConfig.logs
     };
 
     await startTrRoutingProcess(port, false, numberOfCpus, params);
@@ -254,10 +217,6 @@ const startBatch = async function (
 
 const stopBatch = async function (port: number = serverConfig.getTrRoutingConfig('batch').port) {
     await stop({ port: port });
-
-    // TODO Consider keeping memcached around, to speed up later calculation that might use
-    // the same data
-    await ProcessManager.stopProcess('memcached', 'memcached');
 
     return {
         status: 'stopped',

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/ProcessManager.test.ts
@@ -110,7 +110,7 @@ describe('Process Manager testing', function() {
         expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
         
     });
-
+    
     test('Simple Start/Restart/Stop', async function() {
         testSpawn.sequence.add(testSpawn.simple(0, 'All Good'));
         testSpawn.sequence.add(testSpawn.simple(0, 'All Good'));
@@ -437,44 +437,6 @@ describe('Process Manager testing', function() {
         const fileTransport = (logger as any).transports[0] as winston.transports.FileTransportInstance;
         expect(fileTransport.maxsize).toEqual(2048 * 1024);
         expect(fileTransport.maxFiles).toEqual(5);
-    });
-
-    test('Start no wait string', async function() {
-        testSpawn.sequence.add(function (this: any, cb) {
-            // Create a mock process object
-            const mockProcess = {
-                stdout: { on: jest.fn() },
-                stderr: { on: jest.fn() },
-                on: jest.fn()
-            };
-
-            // Emit the spawn event immediately
-            this.emit('spawn', mockProcess);
-
-            // Then small delay to leave time for the event emit and then exit
-            setTimeout(function () {
-                return cb(0);
-            }, 100);
-
-            // Return the mock process
-            return mockProcess;
-        });
-
-        expect(fileManager.fileExists("pids/TestService1.pid")).toBe(false);
-
-        // Start service
-        var result = await ProcessManager.startProcess({
-            serviceName: testServiceName,
-            tagName: "TEST",
-            command: "ls",
-            commandArgs: ["-l"],
-            waitString: "",
-            useShell: false
-        });
-        expect(result.status).toBe('started');
-        expect(testSpawn.calls[0].command).toBe('ls');
-        expect(fileManager.fileExists("pids/TestService1.pid")).toBe(true);
-        expect(fileManager.readFile("pids/TestService1.pid")).toBe("12");
     });
 });
 

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -68,7 +68,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -94,7 +94,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -119,7 +119,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -144,7 +144,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -171,7 +171,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -199,7 +199,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -225,7 +225,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -251,7 +251,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -284,7 +284,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -310,7 +310,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -335,7 +335,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -360,7 +360,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -387,7 +387,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -417,7 +417,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -454,7 +454,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -480,7 +480,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -505,24 +505,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenNthCalledWith(1,{
-            serviceName: 'memcached',
-            tagName: 'memcached',
-            command: 'memcached',
-            commandArgs: ['--port=11212', "--user=nobody", "-vv"],
-            waitString: "",
-            useShell: false,
-            cwd: undefined,
-            attemptRestart: false
-        });
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, "--useMemcached=\"localhost:11212\""],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -538,14 +528,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -565,14 +555,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', "--useMemcached=\"localhost:11212\""],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -588,14 +578,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 12345
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
+            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -614,14 +604,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: `trRouting${port}`,
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true', "--useMemcached=\"localhost:11212\""],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -641,14 +631,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 12345
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', "--useMemcached=\"localhost:11212\""],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -666,14 +656,14 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenLastCalledWith({
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {


### PR DESCRIPTION
…ation"

This reverts commit 5060be28eee1c6ed7feb63a92fe187f6a362208a.

Restarting trRouting causes errors since we now use `useShell: true` and that creates a shell process and it's the one being killed when restarting instead of the actual trRouting process.