### PR TITLE
Disable useShell for starting trRouting

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
@@ -87,7 +87,7 @@ const startTrRoutingProcess = async (
         command,
         commandArgs,
         waitString,
-        useShell: true, //FIXME: For unknown reason yet, libmemcached pool need trRouting to be run in a shell to work (https://github.com/chairemobilite/transition/issues/1322)
+        useShell: false, //TEMP Revert to no shell //FIXME: For unknown reason yet, libmemcached pool need trRouting to be run in a shell to work (https://github.com/chairemobilite/transition/issues/1322)
         cwd,
         attemptRestart,
         logFiles: {

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -68,7 +68,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -94,7 +94,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -119,7 +119,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -144,7 +144,7 @@ describe('TrRouting Process Manager: start', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: false,
             logFiles: {
@@ -171,7 +171,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -199,7 +199,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -225,7 +225,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -251,7 +251,7 @@ describe('TrRouting Process Manager: start', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -284,7 +284,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -310,7 +310,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -335,7 +335,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=1234', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -360,7 +360,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: './trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=/tmp/cache`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: __dirname,
             attemptRestart: true,
             logFiles: {
@@ -387,7 +387,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -417,7 +417,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -454,7 +454,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -480,7 +480,7 @@ describe('TrRouting Process Manager: restart', () => {
             command: 'trRouting',
             commandArgs: ['--port=4000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: true,
             logFiles: {
@@ -522,7 +522,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -545,7 +545,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -572,7 +572,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -595,7 +595,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -621,7 +621,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -648,7 +648,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {
@@ -673,7 +673,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             command: 'trRouting',
             commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', "--useMemcached=\"localhost:11212\""],
             waitString: 'ready.',
-            useShell: true,
+            useShell: false,
             cwd: undefined,
             attemptRestart: false,
             logFiles: {


### PR DESCRIPTION
The memcached support have changed the start of trRouting to be in a Shell. it could not connect to memcached in a docker container without it. Alas, this make it impossible to kill trRouting to be stop/restart with the current method.

Let's move back to useShell=false. This will have trRouting fail to connect to memcached, but that's ok. It still work, but warn about the failed memcached connection.