### PR TITLE
Remove error messages when form values are changed.

### DIFF
--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
@@ -287,6 +287,22 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
     }
 
     componentDidMount() {
+        // If a previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
+        // In that case, change it to undefined.
+        const scenarioId1 = this.state.object.attributes.scenarioId;
+        const scenario1 = this.state.scenarioCollection.getById(scenarioId1);
+        if (scenarioId1 !== undefined && scenario1 === undefined) {
+            this.state.object.set('scenarioId', undefined);
+            this.onValueChange('alternateScenario1Id', { value: undefined });
+        }
+
+        const scenarioId2 = this.state.alternateScenarioRouting.attributes.scenarioId;
+        const scenario2 = this.state.scenarioCollection.getById(scenarioId2);
+        if (scenarioId2 !== undefined && scenario2 === undefined) {
+            this.state.alternateScenarioRouting.set('scenarioId', undefined);
+            this.onValueChange('alternateScenario2Id', { value: undefined });
+        }
+
         const contextMenu = document.getElementById('tr__main-map-context-menu');
         this.setState({
             contextMenu,
@@ -333,6 +349,11 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
 
         this.setState({ displayMaxTimeSelect: true });
         this.getDurations();
+    }
+
+    onValueChange(path: string, newValue: { value: any; valid?: boolean } = { value: null, valid: true }) {
+        this.setState({ routingErrors: [] }); //When a value is changed, remove the current routingErrors to stop displaying them.
+        super.onValueChange(path, newValue);
     }
 
     // FIXME: We only want this menu to be available when the comparison mode is locations, so we include it here instead of AccessibilityMapSectionMapEvents.ts.

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -169,11 +169,24 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
     }
 
     componentDidMount() {
+        // If the previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
+        // In that case, change it to undefined.
+        const scenarioId = this.state.object.attributes.scenarioId;
+        const scenario = this.state.scenarioCollection.getById(scenarioId);
+        if (scenarioId !== undefined && scenario === undefined) {
+            this.onValueChange('scenarioId', { value: undefined });
+        }
+
         serviceLocator.eventManager.on('collection.update.scenarios', this.onScenarioCollectionUpdate);
     }
 
     componentWillUnmount() {
         serviceLocator.eventManager.off('collection.update.scenarios', this.onScenarioCollectionUpdate);
+    }
+
+    onValueChange(path: string, newValue: { value: any; valid?: boolean } = { value: null, valid: true }) {
+        this.setState({ routingErrors: [] }); //When a value is changed, remove the current routingErrors to stop displaying them.
+        super.onValueChange(path, newValue);
     }
 
     private onTripTimeChange = (time: { value: any; valid?: boolean }, timeType: 'departure' | 'arrival') => {

--- a/packages/transition-frontend/src/components/forms/comparison/ScenarioComparisonPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/comparison/ScenarioComparisonPanel.tsx
@@ -92,6 +92,7 @@ const ScenarioComparisonPanel: React.FC = () => {
         newValue: { value: any; valid?: boolean } = { value: null, valid: true },
         resetResultsFlag = true
     ) => {
+        setRoutingErrors([]); //When a value is changed, remove the current routingErrors to stop displaying them.
         onFormFieldChange(path, newValue);
         if (
             newValue.valid ||
@@ -314,6 +315,24 @@ const ScenarioComparisonPanel: React.FC = () => {
             serviceLocator.eventManager.off('collection.update.scenarios', onScenarioCollectionUpdate);
         };
     }, []);
+
+    // If a previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
+    // In that case, change it to undefined.
+    useEffect(() => {
+        const scenarioId1 = routingObj.attributes.scenarioId;
+        const scenario1 = scenarioCollection.getById(scenarioId1);
+        if (scenarioId1 !== undefined && scenario1 === undefined) {
+            routingObj.set('scenarioId', undefined);
+            onValueChange('alternateScenario1Id', { value: undefined });
+        }
+
+        const scenarioId2 = alternateRoutingObj.attributes.scenarioId;
+        const scenario2 = scenarioCollection.getById(scenarioId2);
+        if (scenarioId2 !== undefined && scenario2 === undefined) {
+            alternateRoutingObj.set('scenarioId', undefined);
+            onValueChange('alternateScenario2Id', { value: undefined });
+        }
+    }, [scenarioCollection]);
 
     if (!scenarioCollection) {
         return <LoadingPage />;

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -95,6 +95,7 @@ const TransitRoutingForm: React.FC<TransitRoutingFormProps> = (props) => {
         newValue: { value: any; valid?: boolean } = { value: null, valid: true },
         resetResults = true
     ) => {
+        setRoutingErrors([]); //When a value is changed, remove the current routingErrors to stop displaying them.
         onFormFieldChange(path, newValue);
         if (newValue.valid || newValue.valid === undefined) {
             const updatedObject = transitRouting;
@@ -282,6 +283,16 @@ const TransitRoutingForm: React.FC<TransitRoutingFormProps> = (props) => {
             serviceLocator.eventManager.off('collection.update.scenarios', onScenarioCollectionUpdate);
         };
     }, []);
+
+    // If the previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
+    // In that case, change it to undefined.
+    useEffect(() => {
+        const scenarioId = transitRouting.attributes.scenarioId;
+        const scenario = scenarioCollection.getById(scenarioId);
+        if (scenarioId !== undefined && scenario === undefined) {
+            onValueChange('scenarioId', { value: undefined });
+        }
+    }, [scenarioCollection]);
 
     if (!scenarioCollection) {
         return <LoadingPage />;


### PR DESCRIPTION
The accessibility map tab does not remove routing errors, even after switching to new valid values. This commit empties the routing errors when changing a form value so that the error won't be displayed anymore. The fix is also applied to the routing and scenariio comparison tabs.

Fix: #1331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically reset previously selected scenarios when those scenarios are deleted, preventing stale references and related failures across comparison, map, and routing forms.
  * Clear routing error messages whenever form values change so error state is removed promptly after user edits, improving form responsiveness and reducing confusing persistent errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->