### PR TITLE
Remove the id attribute of userEmailData

### DIFF
--- a/packages/chaire-lib-backend/src/config/auth/__tests__/passwordless.config.test.ts
+++ b/packages/chaire-lib-backend/src/config/auth/__tests__/passwordless.config.test.ts
@@ -8,7 +8,7 @@ import passport from 'passport';
 import { TestUtils } from 'chaire-lib-common/lib/test';
 
 import passwordlessLogin from '../passwordless.config';
-import { sendEmail } from '../../../services/auth/userEmailNotifications';
+import { sendEmail, validateEmailExists } from '../../../services/auth/userEmailNotifications';
 import usersDbQueries from '../../../models/db/users.db.queries';
 import { userAuthModel } from '../../../services/auth/userAuthModel';
 
@@ -34,6 +34,7 @@ jest.mock('../../../models/db/users.db.queries', () => ({
 const mockFind = usersDbQueries.find as jest.MockedFunction<typeof usersDbQueries.find>;
 const mockCreate = usersDbQueries.create as jest.MockedFunction<typeof usersDbQueries.create>;
 const mockSetLastLogin = usersDbQueries.setLastLogin as jest.MockedFunction<typeof usersDbQueries.setLastLogin>;
+const mockValidateEmailExists = validateEmailExists as jest.MockedFunction<typeof validateEmailExists>;
 
 // Initialize various user data
 const newUserEmail = 'newUser@transition.city';
@@ -63,6 +64,7 @@ beforeEach(() => {
             ...attribs
         }
     });
+    mockValidateEmailExists.mockImplementation((email, _errorMessage) => email as string);
     mockSetLastLogin.mockClear();
 });
 
@@ -141,7 +143,7 @@ describe('Complete send/verify flow for existing user', () => {
 
         expect(mockedSendEmail).toHaveBeenCalledTimes(1);
         expect(mockedSendEmail).toHaveBeenLastCalledWith({
-            toUser: { email: existingUserEmail, displayName: '', id: existingUser.id, lang: null },
+            toUser: { email: existingUserEmail, displayName: '', lang: null },
             mailText: ['customServer:magicLinkEmailText', 'server:magicLinkEmailText'],
             mailSubject: ['customServer:magicLinkEmailSubject', 'server:magicLinkEmailSubject']
         }, { magicLinkUrl: { url: expect.stringContaining('/magic/verify') } });

--- a/packages/chaire-lib-backend/src/services/auth/__tests__/userEmailNotifications.test.ts
+++ b/packages/chaire-lib-backend/src/services/auth/__tests__/userEmailNotifications.test.ts
@@ -8,7 +8,7 @@ import { Transporter } from 'nodemailer';
 import nodemailerMock  from 'nodemailer-mock';
 import { v4 as uuidV4 } from 'uuid';
 
-import { sendConfirmationEmail, sendConfirmedByAdminEmail, resetPasswordEmail, sendEmail } from '../userEmailNotifications';
+import { sendConfirmationEmail, sendConfirmedByAdminEmail, resetPasswordEmail, sendEmail, validateEmailExists } from '../userEmailNotifications';
 import UserModel from '../userAuthModel';
 import { registerTranslationDir } from '../../../config/i18next';
 import usersDbQueries from '../../../models/db/users.db.queries';
@@ -173,13 +173,19 @@ test('Confirmed by admin email', async () => {
     expect(sentEmails[0].subject).toContain('compte confirmé');
 });
 
+test('Validate email exists', async () => {
+    expect(() => validateEmailExists(null, 'null email')).toThrow('null email');
+    expect(() => validateEmailExists(undefined, 'undefined email')).toThrow('undefined email');
+    expect(() => validateEmailExists('', 'empty email')).toThrow('empty email');
+    expect(validateEmailExists(fromEmail, '')).toBe(fromEmail);
+});
+
 describe('sendEmail function', () => {
     test('Send email, arbitrary email', async () => {
         await sendEmail({
             mailText: 'Test Text',
             mailSubject: 'Test subject',
             toUser: {
-                id: defaultUserData.id,
                 email: defaultUserData.email,
                 lang: 'en',
                 displayName: defaultUserData.email
@@ -200,7 +206,6 @@ describe('sendEmail function', () => {
             mailText: ['translationNs1:textString', 'translationNs2:textString'],
             mailSubject: ['translationNs1:subjectString', 'translationNs2:subjectString'],
             toUser: {
-                id: defaultUserData.id,
                 email: defaultUserData.email,
                 lang: 'en',
                 displayName: defaultUserData.email


### PR DESCRIPTION
Since this attribute is only used to display an error message that is prone to misinterpretation when the email is null or undefined, we have removed it. The email attribute's type was changed to just be string as a result, and the type verification has been moved to a new function that is called before sendEmail(). Fix: #836