### PR TITLE
Fix the duplicate icon getting smaller when a name is too long.

### DIFF
--- a/packages/transition-frontend/src/components/forms/line/__tests__/__snapshots__/TransitLineButton.test.tsx.snap
+++ b/packages/transition-frontend/src/components/forms/line/__tests__/__snapshots__/TransitLineButton.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`TransitLineButton All props 1`] = `
       >
         <img
           alt="transit:transitLine:DuplicateLine"
-          class="_icon"
+          class="_icon-alone"
           src="/dist/images/icons/interface/copy_white.svg"
         />
       </span>
@@ -172,7 +172,7 @@ exports[`TransitLineButton Minimal props 1`] = `
       >
         <img
           alt="transit:transitLine:DuplicateLine"
-          class="_icon"
+          class="_icon-alone"
           src="/dist/images/icons/interface/copy_white.svg"
         />
       </span>

--- a/packages/transition-frontend/src/components/parts/Button.tsx
+++ b/packages/transition-frontend/src/components/parts/Button.tsx
@@ -80,7 +80,7 @@ const Button: React.FunctionComponent<ButtonProps> = (props: ButtonProps) => {
                         title={props.onDuplicate.altText}
                     >
                         <img
-                            className="_icon"
+                            className="_icon-alone"
                             src={'/dist/images/icons/interface/copy_white.svg'}
                             alt={props.onDuplicate.altText}
                         />

--- a/packages/transition-frontend/src/components/parts/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/transition-frontend/src/components/parts/__tests__/__snapshots__/Button.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`All props 1`] = `
       >
         <img
           alt="duplicate"
-          class="_icon"
+          class="_icon-alone"
           src="/dist/images/icons/interface/copy_white.svg"
         />
       </span>
@@ -84,7 +84,7 @@ exports[`Flush action buttons 1`] = `
       >
         <img
           alt="duplicate"
-          class="_icon"
+          class="_icon-alone"
           src="/dist/images/icons/interface/copy_white.svg"
         />
       </span>
@@ -179,7 +179,7 @@ exports[`Not selected, with altText 1`] = `
       >
         <img
           alt="duplicate"
-          class="_icon"
+          class="_icon-alone"
           src="/dist/images/icons/interface/copy_white.svg"
         />
       </span>


### PR DESCRIPTION
The class of the image was _icon instead of _icon-alone like its neighboring images, which caused it to shrink when the name took too much space. Changing the class fixes the problem.
Fix: #1307

![image](https://github.com/user-attachments/assets/d002ec39-9fb3-464f-877b-dabdeda292d3)
