### PR TITLE
dep: Update @casl/ability from 5.4.4 to 6.7.3

### DIFF
--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -26,7 +26,7 @@
         "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
     },
     "dependencies": {
-        "@casl/ability": "^5.4.4",
+        "@casl/ability": "^6.7.3",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.29.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.56.0",

--- a/packages/chaire-lib-backend/src/services/auth/userPermissions.ts
+++ b/packages/chaire-lib-backend/src/services/auth/userPermissions.ts
@@ -4,11 +4,11 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { AbilityBuilder, Ability } from '@casl/ability';
+import { AbilityBuilder, MongoAbility, createMongoAbility } from '@casl/ability';
 import { UserAttributes } from '../users/user';
 
-const roleMap: { [key: string]: ((builder: AbilityBuilder<Ability>, user: UserAttributes) => void)[] } = {
-    admin: [({ can }: AbilityBuilder<Ability>) => can('manage', 'all')]
+const roleMap: { [key: string]: ((builder: AbilityBuilder<MongoAbility>, user: UserAttributes) => void)[] } = {
+    admin: [({ can }: AbilityBuilder<MongoAbility>) => can('manage', 'all')]
 };
 
 export const DEFAULT_ROLE_NAME = 'default';
@@ -36,8 +36,6 @@ const ADMIN_ROLE_NAME = 'admin';
  * this role. Abilities can be anything used in the application. Common strings
  * are 'create', 'read', 'update', 'delete'. 'manage' is a wildcard and grants
  * all permissions. Any other permission type can be added.
- * @param {string | undefined} homePage Optional home page to link to by default
- * for this role
  *
  * Example call to this function would be
  * ```
@@ -53,7 +51,7 @@ const ADMIN_ROLE_NAME = 'admin';
  */
 export const addRole = (
     roleName: string,
-    abilitiesFunction: (builder: AbilityBuilder<Ability>, user: UserAttributes) => void
+    abilitiesFunction: (builder: AbilityBuilder<MongoAbility>, user: UserAttributes) => void
 ) => {
     if (roleMap[roleName]) {
         roleMap[roleName].push(abilitiesFunction);
@@ -130,8 +128,8 @@ export const getHomePage = (user: UserAttributes): string | undefined => {
 /**
  * @param user contains details about logged in user: its id, name, email, etc
  */
-export default function defineAbilitiesFor(user: UserAttributes): Ability {
-    const builder: AbilityBuilder<Ability> = new AbilityBuilder(Ability);
+export default function defineAbilitiesFor(user: UserAttributes): MongoAbility {
+    const builder: AbilityBuilder<MongoAbility> = new AbilityBuilder(createMongoAbility);
 
     const userPermissions = user.permissions || {};
     if (user.is_admin) {
@@ -157,5 +155,5 @@ export default function defineAbilitiesFor(user: UserAttributes): Ability {
         }
     }
 
-    return new Ability(builder.rules);
+    return createMongoAbility(builder.rules);
 }

--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -19,7 +19,7 @@
     "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
   },
   "dependencies": {
-    "@casl/ability": "^5.4.4",
+    "@casl/ability": "^6.7.3",
     "@mapbox/polyline": "^1.2.1",
     "@turf/turf": "^7.1.0",
     "JSONStream": "^1.3.5",

--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -20,7 +20,7 @@
     "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
   },
   "dependencies": {
-    "@casl/ability": "^5.4.4",
+    "@casl/ability": "^6.7.3",
     "@fortawesome/fontawesome-svg-core": "^6.7.1",
     "@fortawesome/free-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/packages/chaire-lib-frontend/src/services/auth/authorization.ts
+++ b/packages/chaire-lib-frontend/src/services/auth/authorization.ts
@@ -4,17 +4,16 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { Ability } from '@casl/ability';
+import { createMongoAbility, MongoAbility } from '@casl/ability';
 import { unpackRules } from '@casl/ability/extra';
 import { BaseUser } from 'chaire-lib-common/lib/services/user/userType';
 
 export const deserializeRules = (user: BaseUser) => {
     if (!user.serializedPermissions) {
-        return new Ability();
+        return createMongoAbility();
     }
     const rules = unpackRules(user.serializedPermissions);
-    // TODO: See why the types do not work
-    return new Ability(rules as any);
+    return createMongoAbility(rules);
 };
 
 /**
@@ -26,7 +25,7 @@ export const deserializeRules = (user: BaseUser) => {
  * or 'update' subject of type 'Users', the permissions to send would be {Users:
  * ['read', 'update'] }
  */
-const isAuthorized = (ability: Ability, permissions: { [subject: string]: string | string[] }): boolean => {
+const isAuthorized = (ability: MongoAbility, permissions: { [subject: string]: string | string[] }): boolean => {
     // Check if the user has required permission, admin is a special case [for now]
     const permissionSubjects = Object.keys(permissions);
     for (let i = 0; i < permissionSubjects.length; i++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,10 +273,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@casl/ability@^5.4.4":
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/@casl/ability/-/ability-5.4.4.tgz#fbe54340c156248e73804942eed350903b27b9f3"
-  integrity sha512-7+GOnMUq6q4fqtDDesymBXTS9LSDVezYhFiSJ8Rn3f0aQLeRm7qHn66KWbej4niCOvm0XzNj9jzpkK0yz6hUww==
+"@casl/ability@^6.7.3":
+  version "6.7.3"
+  resolved "https://registry.yarnpkg.com/@casl/ability/-/ability-6.7.3.tgz#3c831c8230ccd32bd8eebc6d10f3d7e28e473958"
+  integrity sha512-A4L28Ko+phJAsTDhRjzCOZWECQWN2jzZnJPnROWWHjJpyMq1h7h9ZqjwS2WbIUa3Z474X1ZPSgW0f1PboZGC0A==
   dependencies:
     "@ucast/mongo2js" "^1.3.0"
 


### PR DESCRIPTION
fixes #1097

The `Ability` type is deprecated and is simply replaced with the `MongoAbility` interface and the `createMongoAbility` factory function instead of a constructor.