### PR TITLE
preferences: Make sure `infoPanelPosition` cannot be blank

### DIFF
--- a/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionDashboard.tsx
@@ -50,6 +50,14 @@ interface DashboardProps extends WithTranslation {
 
 interface DashboardState {
     activeSection: string;
+    /**
+     * Position of the info panel. Currently, it is right by default. Only other
+     * supported option for now is 'left'. So we use special cases for 'left'
+     * and put it on the right for any other position.
+     *
+     * FIXME: Use an enum instead of a string and make sure only those values
+     * can be taken.
+     */
     infoPanelPosition: string;
     preferencesLoaded: boolean;
     socketConnected: boolean;
@@ -330,11 +338,11 @@ class Dashboard extends React.Component<DashboardProps, DashboardState> {
                         <LeftMenu activeSection={this.state.activeSection} contributions={this.contributions.menuBar} />
                         <SplitView
                             minLeftWidth={this.state.infoPanelPosition === 'left' ? 500 : 150}
-                            initialLeftWidth={this.state.infoPanelPosition === 'right' ? '65%' : '35%'}
+                            initialLeftWidth={this.state.infoPanelPosition !== 'left' ? '65%' : '35%'}
                             leftViewID={this.state.infoPanelPosition} // Just has to be something that changes when we switch the info panel position from R to L.
                             hideRightViewWhenResizing={this.state.infoPanelPosition === 'left'}
-                            hideLeftViewWhenResizing={this.state.infoPanelPosition === 'right'}
-                            right={this.state.infoPanelPosition === 'right' ? infoPanelComponent : mapComponent}
+                            hideLeftViewWhenResizing={this.state.infoPanelPosition !== 'left'}
+                            right={this.state.infoPanelPosition !== 'left' ? infoPanelComponent : mapComponent}
                             left={this.state.infoPanelPosition === 'left' ? infoPanelComponent : mapComponent}
                         />
                         {this.state.unsavedChangesModalIsOpen && (

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
@@ -58,7 +58,7 @@ const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps
                 <InputWrapper label={props.t('main:preferences:InfoPanelPosition')}>
                     <InputSelect
                         id={'formFieldPreferencesInfoPanelPosition'}
-                        value={prefs.infoPanelPosition}
+                        value={prefs.infoPanelPosition === 'left' ? 'left' : 'right'}
                         choices={[
                             {
                                 label: props.t('main:Left'),
@@ -71,6 +71,7 @@ const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps
                         ]}
                         t={props.t}
                         onValueChange={(e) => props.onValueChange('infoPanelPosition', { value: e.target.value })}
+                        noBlank={true}
                     />
                     <PreferencesResetToDefaultButton
                         resetPrefToDefault={props.resetPrefToDefault}


### PR DESCRIPTION
fixes #1362

Add a `noBlank` prop to the `infoPanelPosition` preferences selection. Also, the value will be shown as left only if the value of the preference is `left`, otherwise, the right will be shown.

In the `TransitionDashboard` component, since we have only 2 possible positions, left or right, we put the panel on the left if and only if the value of the preference is left. Otherwise, we put it on the right. No instead of checking equality with `right`, we check inequality with `left`. That can be revisited when we support more placement options.