### PR TITLE
dep: Remove dependency to `moment-business-days`

### DIFF
--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -36,7 +36,6 @@
     "lodash": "^4.17.21",
     "mapbox-gl": "chairemobilite/mapbox-gl-js#39bbf9aeb1859424e29cff2584715fddc9d018b9",
     "moment": "^2.30.1",
-    "moment-business-days": "^1.2.0",
     "papaparse": "^5.5.2",
     "react": "^19.0.0",
     "react-collapsible": "^2.10.0",

--- a/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/Header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavLink, useNavigate, NavigateFunction } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import moment from 'moment-business-days';
+import moment from 'moment';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
 

--- a/packages/chaire-lib-frontend/src/config/i18n.config.ts
+++ b/packages/chaire-lib-frontend/src/config/i18n.config.ts
@@ -6,7 +6,7 @@
  */
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import moment from 'moment-business-days';
+import moment from 'moment';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi from 'i18next-http-backend';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9228,11 +9228,6 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==
 
-moment-business-days@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/moment-business-days/-/moment-business-days-1.2.0.tgz#6172f9f38dbf443c2f859baabeabbd2935f63d65"
-  integrity sha512-QJlceLfMSxy/jZSOgJYCKeKw+qGYHj8W0jMa/fYruyoJ85+bJuLRiYv5DIaflyuRipmYRfD4kDlSwVYteLN+Jw==
-
 moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"


### PR DESCRIPTION
fixes #1129

The package is 5 years old and not necessary in Transition