### PR TITLE
feature batch schedules: enable batch schedule editing for multiple t…

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -164,6 +164,9 @@
     },
     "transitSchedule": {
         "Schedules": "Timetables",
+        "BatchSchedules": "Edit multiple timetables",
+        "ConfirmBatchLineSelection": "Confirm selected lines",
+        "ReturnBatchLineSelection": "Return to line selection",
         "List": "Timetables",
         "Delete": "Delete timetable",
         "ConfirmDelete": "Do you confirm deletion of this timetable?",
@@ -202,7 +205,9 @@
         "nTrip": "{{n}} trip",
         "nTrips": "{{n}} trips",
         "SymmetricSchedule": "Symmetrical schedule",
-        "AsymmetricSchedule": "Asymmetrical schedule"
+        "AsymmetricSchedule": "Asymmetrical schedule",
+        "BatchGenerationSuccess": "{{n}} schedules were successfully generated",
+        "OverwriteScheduleWarningBatch": "Warning: {{n}} line(s) already have a schedule for this service. The existing schedule will be overwritten."
     },
     "transitUnit": {
         "List": "Units",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -164,6 +164,9 @@
     },
     "transitSchedule": {
         "Schedules": "Horaires",
+        "BatchSchedules": "Modifier des horaires en lot",
+        "ConfirmBatchLineSelection": "Confirmer les lignes sélectionnées",
+        "ReturnBatchLineSelection": "Retour à la sélection des lignes",
         "List": "Horaires",
         "Delete": "Supprimer l'horaire",
         "ConfirmDelete": "Confirmez-vous que vous désirez bien supprimer cet horaire?",
@@ -202,7 +205,9 @@
         "nTrip": "{{n}} voyage",
         "nTrips": "{{n}} voyages",
         "SymmetricSchedule": "Horaires symétriques",
-        "AsymmetricSchedule": "Horaires asymétriques"
+        "AsymmetricSchedule": "Horaires asymétriques",
+        "BatchGenerationSuccess": "{{n}} horaires ont été générés avec succès",
+        "OverwriteScheduleWarningBatch": "Attention: {{n}} ligne(s) ont déjà un horaire associé à ce service. L'horaire existant sera écrasé."
     },
     "transitUnit": {
         "List": "Unités",

--- a/packages/chaire-lib-common/src/services/objects/SaveUtils.ts
+++ b/packages/chaire-lib-common/src/services/objects/SaveUtils.ts
@@ -120,5 +120,31 @@ export default {
                 );
             }
         });
+    },
+
+    saveAll: function (
+        objects: GenericObject<any>[],
+        socket: EventEmitter,
+        socketPrefix: string,
+        collection
+    ): Promise<any> {
+        return new Promise((resolve) => {
+            const attributesList = objects.map((obj) => obj.attributes);
+            socket.emit(`${socketPrefix}.updateBatch`, attributesList, (response) => {
+                if (!response.error) {
+                    objects.forEach((object) => {
+                        object._wasFrozen = object.attributes.is_frozen === true;
+                        if (collection) {
+                            if (collection.getIndex(object.attributes.id) >= 0) {
+                                collection.updateById(object.attributes.id, object);
+                            } else {
+                                collection.add(object);
+                            }
+                        }
+                    });
+                }
+                resolve(response);
+            });
+        });
     }
 };

--- a/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
@@ -1,27 +1,56 @@
 /*
- * Copyright 2024, Polytechnique Montreal and contributors
+ * Copyright 2024-2025, Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+
+const mockScheduleDataHandler: TransitObjectDataHandler = {
+    lowerCaseName: 'schedule',
+    className: 'Schedule',
+    classNamePlural: 'Schedules',
+    create: jest.fn().mockResolvedValue({}),
+    read: jest.fn().mockResolvedValue({}),
+    update: jest.fn().mockResolvedValue({}),
+    delete: jest.fn().mockResolvedValue({}),
+    updateBatch: jest.fn().mockImplementation((socket, attributesList) => {
+        try{
+            return Promise.resolve({
+                ids: attributesList.map(item => ({ id: item.id }))
+            });
+        }
+        catch (error) {
+            console.error('Error batch updating schedules: ', error);
+            return TrError.isTrError(error) ? error.export() : { error: 'Error updating batch' };
+        }
+    }),
+};
+jest.mock('../../services/transitObjects/TransitObjectsDataHandler', () => ({
+    __esModule: true,
+    default: {
+        schedules: mockScheduleDataHandler
+    },
+    createDataHandlers: jest.fn(() => ({
+        schedules: mockScheduleDataHandler
+    })),
+    TransitObjectDataHandler: jest.fn()
+}));
+
+jest.mock('../../services/transitObjects/transitServices/ServiceDuplicator', () => ({
+    duplicateServices: jest.fn()
+}));
+
 import { v4 as uuidV4 } from 'uuid';
 import { EventEmitter } from 'events';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { TransitObjectDataHandler } from '../../services/transitObjects/TransitObjectsDataHandler';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
 import transitObjectRoutes from '../transitObjects.socketRoutes';
 import { duplicateServices } from '../../services/transitObjects/transitServices/ServiceDuplicator';
 
+const mockedDuplicateAndSave = duplicateServices as jest.MockedFunction<typeof duplicateServices>;
 const socketStub = new EventEmitter();
 transitObjectRoutes(socketStub);
-jest.mock('../../services/transitObjects/transitServices/ServiceDuplicator', () => {
-    return {
-        duplicateServices: jest.fn(),
-    };
-});
-const mockedDuplicateAndSave = duplicateServices as jest.MockedFunction<typeof duplicateServices>;
-
-beforeEach(() => {
-    jest.clearAllMocks();
-});
 
 describe('Service duplication route', () => {
     test('Duplicate with default options', (done) => {
@@ -67,5 +96,53 @@ describe('Service duplication route', () => {
             expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, {});
             done();
         });
+    });
+});
+
+describe('Schedules update batch route', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('updateSchedulesBatch handler is initialized', () => {
+        expect(socketStub.listenerCount('transitSchedules.updateBatch')).toBe(1);
+    });
+
+    test('updateSchedulesBatch with valid attributes', (done) => {
+        const attributeList = [{id: 'test-id-1'}, {id: 'test-id-2'}];
+        
+        socketStub.emit('transitSchedules.updateBatch', attributeList, (response) => {
+            try {
+                // Verify the mock was called
+                expect(mockScheduleDataHandler.updateBatch).toHaveBeenCalledTimes(1);
+                expect(mockScheduleDataHandler.updateBatch).toHaveBeenCalledWith(
+                    socketStub,
+                    attributeList
+                );
+                
+                // Verify the response
+                expect(response).toEqual({
+                    ids: [
+                        { id: 'test-id-1' },
+                        { id: 'test-id-2' }
+                    ]
+                });
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
+    });
+
+    test('updateSchedulesBatch where error occurred', async () => {
+        const invalidAttributeList = null;
+        const response = await new Promise((resolve) => {
+            socketStub.emit('transitSchedules.updateBatch', invalidAttributeList, resolve);
+        });
+        expect(mockScheduleDataHandler.updateBatch).toHaveBeenCalledWith(
+            socketStub,
+            invalidAttributeList
+        );
+        expect(response).toHaveProperty('error');
     });
 });

--- a/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
+++ b/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, Polytechnique Montreal and contributors
+ * Copyright 2022-2025, Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
@@ -119,6 +119,18 @@ function setupObjectSocketRoutes(socket: EventEmitter) {
                     callback(response);
                 }
             );
+        }
+
+        // Update multiple objects in the database and cache if required
+        if (lowerCasePlural === 'schedules') {
+            socket.on(`transit${dataHandler.classNamePlural}.updateBatch`, async (attributesList, callback) => {
+                try {
+                    const response = await dataHandler.updateBatch!(socket, attributesList);
+                    callback(response);
+                } catch (error) {
+                    console.log('Error in transit${dataHandler.classNamePlural}.updateBatch: ', error);
+                }
+            });
         }
     }
 

--- a/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, Polytechnique Montreal and contributors
+ * Copyright 2022-2025, Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
@@ -404,6 +404,17 @@ const save = async function (scheduleData: ScheduleAttributes, options: { transa
         : await createFromScheduleData(scheduleData, options);
 };
 
+// FIXME Handle a few promises at a time instead of all at once
+const saveAll = async function (schedulesData: ScheduleAttributes[], options: { transaction?: Knex.Transaction } = {}) {
+    const saveAllTransaction = async (trx: Knex.Transaction) => {
+        return await Promise.all(
+            schedulesData.map((scheduleData) => save(scheduleData, { ...options, transaction: trx }))
+        );
+    };
+    return options.transaction
+        ? await saveAllTransaction(options.transaction)
+        : await knex.transaction(saveAllTransaction);
+};
 // Private function to get the period ids for a given schedule, select within
 // the current transaction
 const _getPeriodIdsForSchedule = async function (
@@ -588,6 +599,7 @@ export default {
         { transaction }: { transaction?: Knex.Transaction } = {}
     ) => save({ ...scheduleData, id: scheduleId }, { transaction }),
     save,
+    saveAll,
     delete: deleteScheduleData,
     getScheduleIdsForLine,
     truncateSchedules: truncate.bind(null, knex, scheduleTable),

--- a/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
+++ b/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, Polytechnique Montreal and contributors
+ * Copyright 2024-2025, Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
@@ -35,7 +35,7 @@ import * as Status from 'chaire-lib-common/lib/utils/Status';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { isSocketIo } from '../../api/socketUtils';
 
-interface TransitObjectDataHandler {
+export interface TransitObjectDataHandler {
     lowerCaseName: string;
     className: string;
     classNamePlural: string;
@@ -55,6 +55,7 @@ interface TransitObjectDataHandler {
     loadCache?: (id: string, customCachePath: string | undefined) => Promise<Record<string, any>>;
     saveCollectionCache?: (collection, customCachePath) => Promise<Record<string, any>>;
     loadCollectionCache?: (customCachePath) => Promise<Record<string, any>>;
+    updateBatch?: (socket: EventEmitter, attributes: GenericAttributes[]) => Promise<Record<string, any>>;
 }
 
 const transitClassesConfig = {
@@ -447,6 +448,46 @@ function createDataHandlers(): Record<string, TransitObjectDataHandler> {
                     }
                     console.error(error);
                     return error.export();
+                }
+            };
+        }
+
+        if (lowerCasePlural === 'schedules') {
+            dataHandler.updateBatch = async (
+                socket: EventEmitter,
+                attributeList: GenericAttributes[]
+            ): Promise<Record<string, any>> => {
+                try {
+                    const updatedIds = await transitClassConfig.dbQueries.saveAll(attributeList);
+
+                    if (isSocketIo(socket)) {
+                        socket.broadcast.emit('data.updated');
+                    }
+
+                    if (transitClassConfig.cacheQueries.objectToCache) {
+                        try {
+                            for (const updatedId of updatedIds) {
+                                const updatedObject = await transitClassConfig.dbQueries.read(updatedId);
+                                await transitClassConfig.cacheQueries.objectToCache(
+                                    updatedObject.attributes ? updatedObject.attributes : updatedObject,
+                                    updatedObject.attributes?.data?.customCachePath
+                                );
+                            }
+                        } catch (error) {
+                            throw new TrError(
+                                `cannot update cache files for ${transitClassConfig.classNamePlural} because of an error: ${error}`,
+                                'SKTTRUPB0001',
+                                'CacheCouldNotBeUpdatedBecauseError'
+                            );
+                        }
+                    } else {
+                        socket.emit('cache.dirty');
+                    }
+
+                    return { ids: updatedIds.map((updatedId) => ({ id: updatedId })) };
+                } catch (error) {
+                    console.error('Error batch updating schedules: ', error);
+                    return TrError.isTrError(error) ? error.export() : { error: 'Error updating batch' };
                 }
             };
         }

--- a/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
+++ b/packages/transition-frontend/src/components/dashboard/TransitionFullSizePanel.tsx
@@ -11,6 +11,7 @@ import { LayoutSectionProps } from 'chaire-lib-frontend/lib/services/dashboard/D
 import Line from 'transition-common/lib/services/line/Line';
 import Schedule from 'transition-common/lib/services/schedules/Schedule';
 import TransitSchedulesList from '../forms/schedules/TransitScheduleList';
+import TransitScheduleBatchList from '../forms/schedules/TransitScheduleBatchList';
 
 interface TransitionFSPanelState {
     selectedLine?: Line;
@@ -53,6 +54,7 @@ const FullSizePanel: React.FunctionComponent<LayoutSectionProps> = (_props: Layo
             {state.selectedLine && (
                 <TransitSchedulesList selectedSchedule={state.selectedSchedule} selectedLine={state.selectedLine} />
             )}
+            {!state.selectedLine && <TransitScheduleBatchList />}
         </React.Fragment>
     );
 };

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyList.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, Polytechnique Montreal and contributors
+ * Copyright 2022-2025, Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
@@ -128,6 +128,20 @@ const TransitAgencyList: React.FunctionComponent<AgencyListProps> = (props: Agen
                         iconClass="_icon"
                         label={props.t('transit:transitLine:New')}
                         onClick={newLine}
+                    />
+                </div>
+            )}
+
+            {!objectSelected && props.agencyCollection && (
+                <div className="tr__form-buttons-container">
+                    <Button
+                        color="blue"
+                        iconPath={'/dist/images/icons/transit/schedule_white.svg'}
+                        iconClass="_icon"
+                        label={props.t('transit:transitSchedule:BatchSchedules')}
+                        onClick={function () {
+                            serviceLocator.eventManager.emit('fullSizePanel.show');
+                        }}
                     />
                 </div>
             )}

--- a/packages/transition-frontend/src/components/forms/agency/TransitAgencyPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/agency/TransitAgencyPanel.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, Polytechnique Montreal and contributors
+ * Copyright 2022-2025, Polytechnique Montreal and contributors
  *
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
@@ -105,6 +105,7 @@ const AgencyPanel: React.FunctionComponent<AgencyPanelProps> = (props: AgencyPan
                 ...rest,
                 selectedSchedule: serviceLocator.selectedObjectsManager.getSingleSelection('schedule')
             }));
+
         const onUpdateLayersFilter = () => {
             setRerender(rerender + 1);
         };

--- a/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
@@ -227,7 +227,10 @@ class TransitLineEdit extends SaveableObjectForm<Line, LineFormProps, LineFormSt
                             onDelete={this.onDelete}
                             openDeleteConfirmModal={this.openDeleteConfirmModal}
                             object={line}
-                            backAction={this.onBack}
+                            backAction={(e) => {
+                                this.onBack(e);
+                                serviceLocator.eventManager.emit('fullSizePanel.hide');
+                            }}
                             openBackConfirmModal={this.openBackConfirmModal}
                             saveAction={this.onSave}
                         />

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchButton.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchButton.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import Line from 'transition-common/lib/services/line/Line';
+import Button from '../../parts/Button';
+import ButtonCell from '../../parts/ButtonCell';
+import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
+import LineCollection from 'transition-common/lib/services/line/LineCollection';
+
+interface ScheduleBatchButtonProps {
+    line: Line;
+    selectedLines: LineCollection;
+    lineIsSelected?: boolean;
+    onLineSelectedUpdate: (line: Line, value: boolean) => void;
+}
+
+const TransitScheduleBatchButton: React.FunctionComponent<ScheduleBatchButtonProps & WithTranslation> = (
+    props: ScheduleBatchButtonProps & WithTranslation
+) => {
+    const lineIsSelected =
+        (props.selectedLines && props.selectedLines.getById(props.line.getId()) !== undefined) || false;
+    const lineId = props.line.getId();
+
+    const onClick = () => {
+        if (!isFrozen) {
+            props.onLineSelectedUpdate(props.line, !lineIsSelected);
+        }
+    };
+
+    const onCheckboxChange = (value) => {
+        if (!isFrozen) {
+            props.onLineSelectedUpdate(props.line, value);
+        }
+    };
+
+    const pathsCount = props.line.paths.length;
+    const scheduledServicesCount =
+        props.line.attributes.service_ids !== undefined
+            ? props.line.attributes.service_ids.length
+            : Object.keys(props.line.attributes.scheduleByServiceId).length;
+
+    const isFrozen = props.line.isFrozen();
+
+    return (
+        <Button
+            key={props.line.getId()}
+            isSelected={lineIsSelected}
+            flushActionButtons={false}
+            onSelect={{ handler: onClick }}
+        >
+            <InputCheckboxBoolean
+                disabled={isFrozen}
+                id={`transitBatchLineSelect${lineId}`}
+                label=" "
+                isChecked={lineIsSelected}
+                onValueChange={(e) => onCheckboxChange(e.target.value)}
+            />
+            {isFrozen && (
+                <ButtonCell alignment="left">
+                    <img
+                        className="_icon-alone"
+                        src={'/dist/images/icons/interface/lock_white.svg'}
+                        alt={props.t('main:Locked')}
+                    />
+                </ButtonCell>
+            )}
+
+            <ButtonCell alignment="left">
+                <span className="_circle-button" style={{ backgroundColor: props.line.attributes.color }}></span>
+                <img
+                    className="_list-element _icon-alone"
+                    src={`/dist/images/icons/transit/modes/${props.line.attributes.mode}_white.svg`}
+                    alt={props.t(`transit:transitLine:modes:${props.line.attributes.mode}`)}
+                    title={props.t(`transit:transitLine:modes:${props.line.attributes.mode}`)}
+                />
+            </ButtonCell>
+
+            <ButtonCell alignment="left">{props.line.attributes.shortname}</ButtonCell>
+            <ButtonCell alignment="left">{props.line.attributes.longname}</ButtonCell>
+            <ButtonCell alignment="flush">
+                {pathsCount > 1
+                    ? props.t('transit:transitLine:nPaths', { n: pathsCount })
+                    : props.t('transit:transitLine:nPath', { n: pathsCount })}{' '}
+                {scheduledServicesCount > 0 && (
+                    <span className="_list-element">
+                        {scheduledServicesCount > 1
+                            ? props.t('transit:transitLine:nServices', { n: scheduledServicesCount })
+                            : props.t('transit:transitLine:nService', { n: scheduledServicesCount })}
+                    </span>
+                )}
+            </ButtonCell>
+        </Button>
+    );
+};
+
+export default withTranslation(['transit', 'main', 'notifications'])(TransitScheduleBatchButton);

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchEdit.tsx
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import { faUndoAlt } from '@fortawesome/free-solid-svg-icons/faUndoAlt';
+import { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
+import InputSelect, { choiceType } from 'chaire-lib-frontend/lib/components/input/InputSelect';
+import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import { SaveableObjectForm, SaveableObjectState } from 'chaire-lib-frontend/lib/components/forms/SaveableObjectForm';
+import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
+import Schedule from 'transition-common/lib/services/schedules/Schedule';
+import Line from 'transition-common/lib/services/line/Line';
+import TransitScheduleBatchPeriod from './TransitScheduleBatchPeriod';
+import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
+import { SchedulePeriod } from 'transition-common/lib/services/schedules/Schedule';
+import LineCollection from 'transition-common/lib/services/line/LineCollection';
+
+interface ScheduleBatchFormProps {
+    lines: LineCollection;
+    schedules: Schedule[];
+    availableServices: choiceType[];
+}
+
+interface ScheduleBatchFormState extends SaveableObjectState<Schedule> {
+    scheduleErrors: string[];
+}
+
+// FIXME this component is a variation of TransitScheduleEdit.
+// As such, they should share a common implementation when possible.
+// The props a slightly different. BatchEdit has a schedule[] and LineCollection.
+// The service selection drop down and the logic behind it is different. In batchEdit,
+// All the existing services are displayed, and when the user selects one and saves a schedule,
+// the service is added to all the selected lines.
+// BatchEdit has no delete schedule button.
+// onChangePeriodGroups and OnSave are applied iteratively on all the selectedLines, instead of just one.
+
+// The new shared component could simply always use a LineCollection, and contain a single line when
+// doing single schedule modification.
+class TransitScheduleBatchEdit extends SaveableObjectForm<
+    Schedule,
+    ScheduleBatchFormProps & WithTranslation,
+    ScheduleBatchFormState
+> {
+    private resetChangesCount = 0;
+    private selectedServiceId = '';
+    private selectedPeriodsGroup = '';
+    constructor(props: ScheduleBatchFormProps & WithTranslation) {
+        super(props);
+
+        this.state = {
+            object: props.schedules[0],
+            confirmModalDeleteIsOpen: false,
+            confirmModalBackIsOpen: false,
+            formValues: {},
+            selectedObjectName: 'schedules',
+            scheduleErrors: []
+        };
+    }
+
+    // Helper method to validate multiple schedules
+    private getValidSchedulesWithLines(
+        schedules: Schedule[],
+        lines: LineCollection
+    ): { validSchedules: Schedule[]; scheduleLineMap: Map<Schedule, Line> } {
+        const validSchedules: Schedule[] = [];
+        const scheduleLineMap = new Map();
+
+        schedules.forEach((schedule) => {
+            schedule.validate();
+            const line = lines.getById(schedule.attributes.line_id);
+            if (schedule.isValid) {
+                if (line) {
+                    validSchedules.push(schedule);
+                    scheduleLineMap.set(schedule, line);
+                }
+            } else {
+                console.log(
+                    'The schedule for the line ' +
+                        line?.getDisplayName() +
+                        ' is not valid. \n Schedule object : ' +
+                        schedule
+                );
+            }
+        });
+
+        return { validSchedules, scheduleLineMap };
+    }
+
+    onChangeService(toServiceId: string) {
+        const lines: LineCollection = this.props.lines;
+        const schedules: Schedule[] = this.props.schedules;
+        this.selectedServiceId = toServiceId;
+        let alreadyHasServiceLines = 0;
+        schedules.forEach((schedule, index) => {
+            const line = lines.getById(schedule.attributes.line_id);
+            if (line) {
+                if (line.attributes.service_ids && line.attributes.service_ids.includes(toServiceId)) {
+                    schedule.attributes.integer_id = line.attributes.scheduleByServiceId[toServiceId].integer_id;
+                    schedule.setNew(false);
+                    alreadyHasServiceLines++;
+                } else {
+                    schedule.setNew(true);
+                }
+                schedules[index].set('service_id', toServiceId);
+                if (!schedule.isNew()) {
+                    schedule.validate();
+                }
+                serviceLocator.selectedObjectsManager.setSelection('schedule', schedules);
+            }
+        });
+        schedules[0].errors = [];
+        if (alreadyHasServiceLines > 0) {
+            schedules[0].errors.push(
+                this.props.t('transit:transitSchedule:OverwriteScheduleWarningBatch', { n: alreadyHasServiceLines })
+            );
+        }
+    }
+
+    onChangePeriodsGroup(periodsGroupShortname: string) {
+        const lines: LineCollection = this.props.lines;
+        const schedules: Schedule[] = this.props.schedules;
+        this.selectedPeriodsGroup = periodsGroupShortname;
+        schedules.forEach((schedule) => {
+            const line = lines.getById(schedule.attributes.line_id);
+            if (line) {
+                schedule.set('periods_group_shortname', periodsGroupShortname);
+                if (schedule.isNew()) {
+                    serviceLocator.selectedObjectsManager.setSelection('schedule', [schedule]);
+                } else {
+                    line.updateSchedule(schedule);
+                    schedule.validate();
+                    serviceLocator.selectedObjectsManager.setSelection('schedule', [schedule]);
+                }
+            }
+        });
+    }
+
+    onSave = async () => {
+        const lines: LineCollection = this.props.lines;
+        const schedules: Schedule[] = this.props.schedules;
+        const { validSchedules, scheduleLineMap } = this.getValidSchedulesWithLines(schedules, lines);
+        if (validSchedules.length > 0) {
+            serviceLocator.eventManager.emit('progress', { name: 'SavingSchedule', progress: 0.0 });
+            serviceLocator.selectedObjectsManager.deselect('schedule');
+
+            try {
+                await SaveUtils.saveAll(
+                    validSchedules,
+                    serviceLocator.socketEventManager,
+                    'transitSchedules',
+                    undefined
+                );
+
+                validSchedules.forEach(async (schedule) => {
+                    const line = scheduleLineMap.get(schedule);
+                    if (line) {
+                        line.updateSchedule(schedule);
+                        serviceLocator.collectionManager.refresh('lines');
+                    }
+                });
+                await serviceLocator.collectionManager.get('lines').loadFromServer(serviceLocator.socketEventManager);
+            } finally {
+                serviceLocator.eventManager.emit('progress', { name: 'SavingSchedule', progress: 1.0 });
+            }
+        }
+    };
+
+    render() {
+        const lines = this.props.lines;
+        const schedules = this.props.schedules;
+        const allowSecondsBasedSchedules = schedules[0].attributes.allow_seconds_based_schedules || false;
+        const periodsGroups = Preferences.get('transit.periods');
+        const periodsGroupShortname = schedules[0].attributes.periods_group_shortname || '';
+        const periodsGroup = periodsGroupShortname ? periodsGroups[periodsGroupShortname] : null;
+        const periodsGroupChoices = Object.keys(periodsGroups).map((periodsGroupShortname) => {
+            const periodsGroup = periodsGroups[periodsGroupShortname];
+            return {
+                value: periodsGroupShortname,
+                label: periodsGroup.name[this.props.i18n.language] || periodsGroupShortname
+            };
+        });
+
+        const periodsForms: any[] = [];
+        if (periodsGroupShortname && periodsGroup) {
+            const periods = periodsGroup.periods;
+            schedules.forEach((schedule) => {
+                if (_isBlank(schedule.get('periods'))) {
+                    schedule.attributes.periods = [];
+                }
+            });
+            for (let i = 0, count = periods.length; i < count; i++) {
+                const period = periods[i];
+                const periodShortname = period.shortname;
+                const schedulePeriods: SchedulePeriod[] = [];
+                schedules.forEach((schedule) => {
+                    const existingPeriod = schedule.attributes.periods[i];
+                    const periodData = existingPeriod || {
+                        period_shortname: periodShortname,
+                        start_at_hour: period.startAtHour,
+                        end_at_hour: period.endAtHour
+                    };
+                    // Save the period for this schedule
+                    schedule.attributes.periods[i] = periodData;
+                    // Collect it for the component
+                    schedulePeriods.push(periodData);
+                });
+
+                periodsForms.push(
+                    <TransitScheduleBatchPeriod
+                        key={`period_form_${periodShortname}`}
+                        schedules={schedules}
+                        lines={lines}
+                        periodIndex={i}
+                        period={period}
+                        schedulePeriods={schedulePeriods}
+                        allowSecondsBasedSchedules={allowSecondsBasedSchedules}
+                        resetChangesCount={this.resetChangesCount}
+                        onValueChange={this.onValueChange}
+                    />
+                );
+            }
+        }
+
+        return (
+            <form
+                key={'tr__form-transit-schedule-batch'}
+                id={'tr__form-transit-schedule-batch'}
+                className="tr__form-transit-schedule apptr__form"
+            >
+                <div className="tr__form-section">
+                    <div className="apptr__form-input-container _two-columns">
+                        <label>{this.props.t('transit:transitSchedule:Service')}</label>
+                        <InputSelect
+                            id={'formFieldTransitScheduleBatchService'}
+                            value={schedules[0].attributes.service_id}
+                            choices={this.props.availableServices}
+                            t={this.props.t}
+                            onValueChange={(e) => this.onChangeService(e.target.value)}
+                        />
+                    </div>
+                    <div className="apptr__form-input-container _two-columns">
+                        <label>{this.props.t('transit:transitSchedule:PeriodsGroup')}</label>
+                        <InputSelect
+                            id={'formFieldTransitScheduleBatchPeriodsGroup'}
+                            value={schedules[0].attributes.periods_group_shortname}
+                            choices={periodsGroupChoices}
+                            t={this.props.t}
+                            onValueChange={(e) => this.onChangePeriodsGroup(e.target.value)}
+                        />
+                    </div>
+                    <div className="apptr__form-input-container _two-columns">
+                        <label>{this.props.t('transit:transitSchedule:AllowSecondsBasedSchedules')}</label>
+                        <InputRadio
+                            id={'formFieldTransitSchedulePeriodsGroup'}
+                            value={allowSecondsBasedSchedules}
+                            sameLine={true}
+                            choices={[
+                                {
+                                    value: true
+                                },
+                                {
+                                    value: false
+                                }
+                            ]}
+                            localePrefix="transit:transitSchedule"
+                            t={this.props.t}
+                            isBoolean={true}
+                            onValueChange={(e) =>
+                                this.onValueChange('allow_seconds_based_schedules', { value: e.target.value })
+                            }
+                        />
+                    </div>
+                </div>
+
+                <FormErrors errors={schedules[0].errors} />
+                {this.hasInvalidFields() && <FormErrors errors={['main:errors:InvalidFormFields']} />}
+
+                {this.state.confirmModalDeleteIsOpen && (
+                    <ConfirmModal
+                        isOpen={true}
+                        title={this.props.t('transit:transitSchedule:ConfirmDelete')}
+                        confirmAction={this.onDelete}
+                        confirmButtonColor="red"
+                        confirmButtonLabel={this.props.t('transit:transitSchedule:Delete')}
+                        closeModal={this.closeDeleteConfirmModal}
+                    />
+                )}
+                {this.state.confirmModalBackIsOpen && (
+                    <ConfirmModal
+                        isOpen={true}
+                        title={this.props.t('main:ConfirmBackModal')}
+                        confirmAction={this.onBack}
+                        confirmButtonColor="blue"
+                        confirmButtonLabel={this.props.t('main:DiscardChanges')}
+                        cancelButtonLabel={this.props.t('main:Cancel')}
+                        closeModal={this.closeBackConfirmModal}
+                    />
+                )}
+
+                {
+                    // TODO Use the SelectedObjectButtons instead
+                }
+                <div className="tr__form-buttons-container _left">
+                    <span title={this.props.t('main:Back')}>
+                        <Button
+                            key="back"
+                            color="blue"
+                            icon={faArrowLeft}
+                            iconClass="_icon-alone"
+                            label=""
+                            onClick={schedules[0].hasChanged() ? this.openBackConfirmModal : this.onBack}
+                        />
+                    </span>
+                    {
+                        // TODO Make sure this works if needed
+                        <span title={this.props.t('main:Undo')}>
+                            <Button
+                                color="grey"
+                                icon={faUndoAlt}
+                                iconClass="_icon-alone"
+                                label=""
+                                disabled={!schedules[0].canUndo()}
+                                onClick={() => {
+                                    schedules.forEach((schedule) => {
+                                        schedule.undo();
+                                    });
+                                    this.resetChangesCount++;
+                                }}
+                            />
+                        </span>
+                    }
+                    {
+                        <span title={this.props.t('main:Redo')}>
+                            <Button
+                                color="grey"
+                                icon={faRedoAlt}
+                                iconClass="_icon-alone"
+                                label=""
+                                disabled={!schedules[0].canRedo()}
+                                onClick={() => {
+                                    schedules.forEach((schedule) => {
+                                        schedule.redo();
+                                    });
+                                    this.resetChangesCount++;
+                                }}
+                            />
+                        </span>
+                    }
+                    <span title={this.props.t('main:Save')}>
+                        <Button
+                            icon={faCheckCircle}
+                            iconClass="_icon"
+                            label={this.props.t('transit:transitSchedule:SaveSchedule')}
+                            onClick={this.onSave}
+                        />
+                    </span>
+                </div>
+                <div className="_flex-container-row">{periodsForms}</div>
+            </form>
+        );
+    }
+}
+
+export default withTranslation(['transit', 'main', 'notifications'])(TransitScheduleBatchEdit);

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchList.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchList.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
+import { faWindowClose } from '@fortawesome/free-solid-svg-icons/faWindowClose';
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
+
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import Line from 'transition-common/lib/services/line/Line';
+import TransitScheduleBatchButton from './TransitScheduleBatchButton';
+import ButtonList from '../../parts/ButtonList';
+import TransitScheduleBatchEdit from './TransitScheduleBatchEdit';
+import Schedule from 'transition-common/lib/services/schedules/Schedule';
+import { choiceType } from 'chaire-lib-frontend/lib/components/input/InputSelect';
+import LineCollection from 'transition-common/lib/services/line/LineCollection';
+
+interface BatchListProps {
+    batchSelectedLines: LineCollection;
+    isSelectionConfirmed?: boolean;
+    selectedNewSchedules?: Schedule[];
+}
+
+// The batch schedule modification is only available on the lines that have at least
+// one inbound and one outbound path. See the filteredLinesCollection below
+const TransitScheduleBatchList: React.FunctionComponent<BatchListProps & WithTranslation> = (
+    props: BatchListProps & WithTranslation
+) => {
+    const [state, setState] = React.useState<BatchListProps>({
+        batchSelectedLines: new LineCollection([], undefined),
+        isSelectionConfirmed: false,
+        selectedNewSchedules: []
+    });
+    const agencyCollection = serviceLocator.collectionManager.get('agencies').getFeatures();
+    const linesCollection = serviceLocator.collectionManager.get('lines').getFeatures();
+    // Only the lines with one inbound and one outbound path are displayed
+    const filteredlinesCollection = linesCollection.filter(
+        (line) => line.getOutboundPaths().length > 0 && line.getInboundPaths().length > 0
+    );
+    const transitServices = serviceLocator.collectionManager.get('services');
+    const onLineSelectedUpdate = (selectedLine: Line, isSelected: boolean) => {
+        if (isSelected === true && !state.batchSelectedLines.getById(selectedLine.getId())) {
+            state.batchSelectedLines.add(selectedLine);
+            setState({
+                batchSelectedLines: state.batchSelectedLines,
+                isSelectionConfirmed: false,
+                selectedNewSchedules: []
+            });
+        } else if (isSelected === false) {
+            state.batchSelectedLines.removeById(selectedLine.getId());
+            setState({
+                batchSelectedLines: state.batchSelectedLines,
+                isSelectionConfirmed: false,
+                selectedNewSchedules: []
+            });
+        }
+    };
+
+    const onConfirmation = async () => {
+        const newSchedules = state.batchSelectedLines
+            .getFeatures()
+            .map((line) => new Schedule({ line_id: line.getId() }, true, serviceLocator.collectionManager));
+
+        const refreshPromises = state.batchSelectedLines
+            .getFeatures()
+            .map((line) => line.refreshSchedules(serviceLocator.socketEventManager));
+
+        await Promise.all(refreshPromises);
+
+        setState({
+            isSelectionConfirmed: true,
+            selectedNewSchedules: newSchedules,
+            batchSelectedLines: state.batchSelectedLines
+        });
+    };
+
+    const onUndoConfirmation = () => {
+        setState({
+            isSelectionConfirmed: false,
+            selectedNewSchedules: [],
+            batchSelectedLines: state.batchSelectedLines
+        });
+    };
+
+    const serviceChoices: choiceType[] = [];
+    if (transitServices && transitServices.size() > 0) {
+        const serviceFeatures = transitServices.getFeatures();
+        for (let i = 0, count = transitServices.size(); i < count; i++) {
+            const serviceFeature = serviceFeatures[i];
+            serviceChoices.push({
+                value: serviceFeature.id,
+                label: serviceFeature.toString(false)
+            });
+        }
+    }
+
+    let linesButtons: any[] = [];
+
+    agencyCollection.forEach((agency) => {
+        const agencyLinesButtons: any[] = [];
+        agency.getLines().forEach((line) => {
+            if (filteredlinesCollection.includes(line))
+                agencyLinesButtons.push(
+                    <TransitScheduleBatchButton
+                        disabled={state.isSelectionConfirmed === true}
+                        key={line.getId()}
+                        line={line}
+                        selectedLines={state.batchSelectedLines}
+                        onLineSelectedUpdate={onLineSelectedUpdate}
+                    />
+                );
+        });
+
+        if (agencyLinesButtons.length > 0) linesButtons.push(<h4 key={agency.getId()}>{agency.toString()}</h4>);
+        linesButtons = linesButtons.concat(agencyLinesButtons);
+    });
+
+    return (
+        <div>
+            <h3>
+                <img
+                    src={'/dist/images/icons/transit/schedule_white.svg'}
+                    className="_icon"
+                    alt={props.t('transit:transitSchedule:BatchSchedules')}
+                />{' '}
+                {props.t('transit:transitSchedule:BatchSchedules')}
+            </h3>
+
+            {state.isSelectionConfirmed === false && (
+                <div className="tr__form-buttons-container">
+                    <Button
+                        color="grey"
+                        icon={faWindowClose}
+                        iconClass="_icon"
+                        label={props.t('transit:transitSchedule:CloseSchedulesWindow')}
+                        onClick={function () {
+                            serviceLocator.selectedObjectsManager.deselect('schedule');
+                            serviceLocator.selectedObjectsManager.deselect('line');
+                            serviceLocator.eventManager.emit('fullSizePanel.hide');
+                        }}
+                    />
+                </div>
+            )}
+            {state.isSelectionConfirmed === false && (
+                <div className="tr__form-buttons-container _left">
+                    <Button
+                        disabled={state.batchSelectedLines.length === filteredlinesCollection.length}
+                        color="blue"
+                        label={props.t('main:SelectAll')}
+                        onClick={function () {
+                            state.batchSelectedLines.setFeatures(filteredlinesCollection);
+                            setState({
+                                batchSelectedLines: state.batchSelectedLines,
+                                isSelectionConfirmed: false,
+                                selectedNewSchedules: []
+                            });
+                        }}
+                    />
+
+                    <Button
+                        disabled={state.batchSelectedLines.length === 0}
+                        color="blue"
+                        label={props.t('main:UnselectAll')}
+                        onClick={function () {
+                            state.batchSelectedLines.clear();
+                            setState({
+                                batchSelectedLines: state.batchSelectedLines,
+                                isSelectionConfirmed: false,
+                                selectedNewSchedules: []
+                            });
+                        }}
+                    />
+                </div>
+            )}
+
+            {state.isSelectionConfirmed === false && <ButtonList>{linesButtons}</ButtonList>}
+
+            <div className="tr__form-buttons-container _left">
+                {state.isSelectionConfirmed === true && (
+                    <span>
+                        <Button
+                            color="blue"
+                            icon={faArrowLeft}
+                            iconClass="_icon"
+                            label={props.t('transit:transitSchedule:ReturnBatchLineSelection')}
+                            onClick={onUndoConfirmation}
+                        />
+                    </span>
+                )}
+
+                {state.isSelectionConfirmed === false && (
+                    <span title={props.t('transit:transitSchedule:ConfirmBatchLineSelection')}>
+                        <Button
+                            disabled={state.batchSelectedLines.length < 1 || state.isSelectionConfirmed}
+                            icon={faCheckCircle}
+                            iconClass="_icon"
+                            label={props.t('transit:transitSchedule:ConfirmBatchLineSelection')}
+                            onClick={onConfirmation}
+                        />
+                    </span>
+                )}
+            </div>
+            {!props.batchSelectedLines && (
+                <Button
+                    color="grey"
+                    icon={faWindowClose}
+                    iconClass="_icon"
+                    label={props.t('transit:transitSchedule:CloseSchedulesWindow')}
+                    onClick={function () {
+                        serviceLocator.selectedObjectsManager.deselect('schedule');
+                        serviceLocator.selectedObjectsManager.deselect('line');
+                        serviceLocator.eventManager.emit('fullSizePanel.hide');
+                    }}
+                />
+            )}
+
+            {state.isSelectionConfirmed && (
+                <TransitScheduleBatchEdit
+                    lines={state.batchSelectedLines}
+                    schedules={state.selectedNewSchedules}
+                    availableServices={serviceChoices}
+                />
+            )}
+        </div>
+    );
+};
+
+export default withTranslation('transit')(TransitScheduleBatchList);

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchPeriod.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchPeriod.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import _toString from 'lodash/toString';
+import { useTranslation } from 'react-i18next';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
+import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
+import { faArrowDown } from '@fortawesome/free-solid-svg-icons/faArrowDown';
+
+import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
+import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+import { _isBlank, _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
+import { decimalHourToTimeStr, secondsToMinutes, minutesToSeconds } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import Schedule from 'transition-common/lib/services/schedules/Schedule';
+import LineCollection from 'transition-common/lib/services/line/LineCollection';
+
+interface TransitScheduleBatchPeriodProps {
+    schedules: Schedule[];
+    lines: LineCollection;
+    periodIndex: number;
+    period: any;
+    schedulePeriods: any[];
+    allowSecondsBasedSchedules: boolean;
+    resetChangesCount: number;
+    onValueChange: (path: string, newValue: { value: any }) => void;
+}
+
+// FIXME this component is very similar to TransitSchedulePeriod and the two should be a single component.
+// The main differences between the two are
+// 1. This component takes an array of schedules and a line collection, instead of a single schedule/line.
+// 2. This component has an extra function; chooseLongestPaths, since it would be complicated for the user
+//    to select the paths for all the lines
+// 3. This component doesn't have a remove schedule function
+// 4. When a schedule is generated, this component doesn't display the tripRows, since they're different for each line.
+//    it instead displays how many schedules have been generated
+const TransitScheduleBatchPeriod: React.FC<TransitScheduleBatchPeriodProps> = (props) => {
+    const { t, i18n } = useTranslation();
+
+    const {
+        schedules,
+        lines,
+        period,
+        schedulePeriods,
+        periodIndex,
+        allowSecondsBasedSchedules,
+        resetChangesCount,
+        onValueChange
+    } = props;
+
+    const periodName = period.name[i18n.language];
+    const periodShortname = period.shortname;
+    const periodStartAtTimeStr = decimalHourToTimeStr(period.startAtHour);
+    const periodEndAtTimeStr = decimalHourToTimeStr(period.endAtHour);
+    const [generatedResponses, setGeneratedResponses] = React.useState<any[]>([]);
+
+    // Automatically select the paths with the bigger node count
+    const chooseLongestPaths = () => {
+        lines.getFeatures().forEach((line) => {
+            const paths = line.paths;
+            let chosenOutboundPath;
+            let chosenInboundPath;
+            let chosenInboundPathId = '';
+            let chosenOutboundPathId = '';
+            paths.forEach((path) => {
+                if (['outbound', 'loop', 'other'].includes(path.attributes.direction)) {
+                    chosenOutboundPath = chosenOutboundPath
+                        ? chosenOutboundPath.countNodes() < path.countNodes()
+                            ? path
+                            : chosenOutboundPath
+                        : path;
+                } else if (path.attributes.direction === 'inbound') {
+                    chosenInboundPath = chosenInboundPath
+                        ? chosenInboundPath.countNodes() < path.countNodes()
+                            ? path
+                            : chosenInboundPath
+                        : path;
+                }
+            });
+            chosenOutboundPathId = chosenOutboundPath ? chosenOutboundPath.getId() : '';
+            chosenInboundPathId = chosenInboundPath ? chosenInboundPath.getId() : '';
+            const schedule = schedules.find((schedule) => schedule.attributes.line_id === line.getId());
+            if (schedule && chosenOutboundPath) {
+                const scheduleIdx = schedules.indexOf(schedule);
+                schedules[scheduleIdx].attributes.periods[periodIndex].outbound_path_id = chosenOutboundPathId;
+                schedules[scheduleIdx].attributes.periods[periodIndex].inbound_path_id = chosenInboundPathId;
+            }
+        });
+    };
+
+    const intervalSeconds = schedulePeriods[0].interval_seconds;
+    const calculatedIntervalSeconds = schedulePeriods[0].calculated_interval_seconds;
+    const numberOfUnits = schedulePeriods[0].number_of_units;
+    const calculatedNumberOfUnits = schedulePeriods[0].calculated_number_of_units;
+    const customStartAtStr =
+        schedulePeriods[0].custom_start_at_str || decimalHourToTimeStr(period.startAtHour) || undefined;
+    const customEndAtStr = schedulePeriods[0].custom_end_at_str || undefined;
+    const handleGenerateSchedule = () => {
+        chooseLongestPaths();
+        const generatedResponsesTemp: any[] = [];
+        lines.getFeatures().forEach((line, index) => {
+            const schedule = schedules.find((schedule) => {
+                return schedule.attributes.line_id === line.getId();
+            });
+            if (schedule) {
+                schedulePeriods[index].interval_seconds = intervalSeconds;
+                schedulePeriods[index].calculated_interval_seconds = calculatedIntervalSeconds;
+                schedulePeriods[index].number_of_units = numberOfUnits;
+                schedulePeriods[index].calculated_number_of_units = calculatedNumberOfUnits;
+                schedulePeriods[index].custom_start_at_str = customStartAtStr;
+                schedulePeriods[index].custom_end_at_str = customEndAtStr;
+                const response = schedule.generateForPeriod(periodShortname);
+                if (response.trips) {
+                    schedule.set(`periods[${periodIndex}].trips`, response.trips);
+                    generatedResponsesTemp.push(response);
+                }
+            }
+        });
+        setGeneratedResponses(generatedResponsesTemp);
+    };
+
+    return (
+        <div
+            className="tr__form-section _flex-container-row"
+            key={periodShortname}
+            style={{
+                borderRight: '1px solid rgba(255,255,255,0.2)',
+                alignItems: 'flex-start',
+                minWidth: '20rem'
+            }}
+        >
+            <h4 className="_aside-heading-container" style={{ minHeight: '30rem' }}>
+                <span className="_aside-heading">
+                    <FontAwesomeIcon icon={faClock} className="_icon" />{' '}
+                    <span className="_strong">{periodStartAtTimeStr}</span>{' '}
+                    <FontAwesomeIcon icon={faArrowDown} className="_icon" />{' '}
+                    <span className="_strong">{periodEndAtTimeStr}</span> <span>• {periodName}</span>
+                </span>
+            </h4>
+            <div className="tr__form-section">
+                <div className="tr__form-section">
+                    {allowSecondsBasedSchedules !== true && (
+                        <div className="apptr__form-input-container">
+                            <label>{t('transit:transitSchedule:outboundIntervalMinutes')}</label>
+                            <InputStringFormatted
+                                id={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}`}
+                                value={intervalSeconds}
+                                onValueUpdated={(value) =>
+                                    onValueChange(`periods[${periodIndex}].interval_seconds`, value)
+                                }
+                                key={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${resetChangesCount}`}
+                                stringToValue={minutesToSeconds}
+                                valueToString={(val) => _toString(secondsToMinutes(val))}
+                            />
+                        </div>
+                    )}
+                    {allowSecondsBasedSchedules === true && (
+                        <div className="apptr__form-input-container">
+                            <label>{t('transit:transitSchedule:IntervalSeconds')}</label>
+                            <InputStringFormatted
+                                id={`formFieldTransitScheduleIntervalSecondsPeriod${periodShortname}`}
+                                value={intervalSeconds}
+                                stringToValue={_toInteger}
+                                valueToString={_toString}
+                                key={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${resetChangesCount}`}
+                                onValueUpdated={(value) =>
+                                    onValueChange(`periods[${periodIndex}].interval_seconds`, value)
+                                }
+                            />
+                        </div>
+                    )}
+                    <p className="_small _oblique">
+                        {!intervalSeconds && calculatedIntervalSeconds && numberOfUnits
+                            ? `${t('transit:transitSchedule:CalculatedInterval')}: ${Math.ceil(
+                                calculatedIntervalSeconds / 60
+                            )} ${t('main:minuteAbbr')}`
+                            : ''}
+                    </p>
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:NumberOfUnits')}</label>
+                        <InputStringFormatted
+                            id={`formFieldTransitScheduleNumberOfUnitsPeriod${periodShortname}`}
+                            value={numberOfUnits}
+                            stringToValue={_toInteger}
+                            valueToString={_toString}
+                            key={`formFieldTransitScheduleNumberOfUnitsPeriod${periodShortname}${resetChangesCount}`}
+                            onValueUpdated={(value) => onValueChange(`periods[${periodIndex}].number_of_units`, value)}
+                        />
+                    </div>
+                    <p className="_small _oblique">
+                        {!numberOfUnits && calculatedNumberOfUnits && intervalSeconds
+                            ? `${roundToDecimals(calculatedNumberOfUnits, 1)} ${t(
+                                'transit:transitSchedule:requiredUnits'
+                            )}`
+                            : ''}
+                    </p>
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:CustomStartAt')}</label>
+                        <InputString
+                            id={`formFieldTransitScheduleCustomStartAtPeriod${periodShortname}`}
+                            value={customStartAtStr}
+                            onValueUpdated={(value) =>
+                                onValueChange(`periods[${periodIndex}].custom_start_at_str`, value)
+                            }
+                        />
+                    </div>
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:CustomEndAt')}</label>
+                        <InputString
+                            id={`formFieldTransitScheduleCustomEndAtPeriod${periodShortname}`}
+                            value={customEndAtStr}
+                            onValueUpdated={(value) =>
+                                onValueChange(`periods[${periodIndex}].custom_end_at_str`, value)
+                            }
+                        />
+                    </div>
+                </div>
+                <div className="tr__form-section">
+                    {
+                        <div className="tr__form-buttons-container _left">
+                            {((!_isBlank(intervalSeconds) && _isBlank(numberOfUnits)) ||
+                                (!_isBlank(numberOfUnits) && _isBlank(intervalSeconds))) && (
+                                <Button
+                                    color="blue"
+                                    icon={faSyncAlt}
+                                    iconClass="_icon"
+                                    label={t('transit:transitSchedule:GenerateSchedule')}
+                                    onClick={handleGenerateSchedule}
+                                />
+                            )}
+                        </div>
+                    }
+                </div>
+                {generatedResponses.length > 0 && <span>{generatedResponses.length} horaires générés avec succès</span>}
+            </div>
+        </div>
+    );
+};
+
+export default TransitScheduleBatchPeriod;

--- a/packages/transition-frontend/src/components/forms/schedules/TransitSchedulePeriod.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitSchedulePeriod.tsx
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import _toString from 'lodash/toString';
+import { useTranslation } from 'react-i18next';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
+import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
+import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
+import { faArrowDown } from '@fortawesome/free-solid-svg-icons/faArrowDown';
+
+import InputString from 'chaire-lib-frontend/lib/components/input/InputString';
+import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
+import InputSelect, { choiceType } from 'chaire-lib-frontend/lib/components/input/InputSelect';
+import Button from 'chaire-lib-frontend/lib/components/input/Button';
+import { _isBlank, _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
+import {
+    decimalHourToTimeStr,
+    secondsSinceMidnightToTimeStr,
+    secondsToMinutes,
+    minutesToSeconds
+} from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import Schedule, { ScheduleCalculationMode } from 'transition-common/lib/services/schedules/Schedule';
+import Line from 'transition-common/lib/services/line/Line';
+
+interface TransitSchedulePeriodProps {
+    schedule: Schedule;
+    line: Line;
+    periodIndex: number;
+    period: any;
+    schedulePeriod: any;
+    outboundPathsChoices: choiceType[];
+    inboundPathsChoices: choiceType[];
+    outboundPathIds: string[];
+    inboundPathIds: string[];
+    isFrozen: boolean;
+    scheduleId: string;
+    allowSecondsBasedSchedules: boolean;
+    resetChangesCount: number;
+    calculationMode: ScheduleCalculationMode;
+    onValueChange: (path: string, newValue: { value: any }) => void;
+}
+
+const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
+    const { t, i18n } = useTranslation();
+
+    const {
+        schedule,
+        period,
+        schedulePeriod,
+        periodIndex,
+        outboundPathsChoices,
+        inboundPathsChoices,
+        outboundPathIds,
+        inboundPathIds,
+        isFrozen,
+        scheduleId,
+        allowSecondsBasedSchedules,
+        resetChangesCount,
+        onValueChange,
+        line,
+        calculationMode
+    } = props;
+
+    const periodName = period.name[i18n.language];
+    const periodShortname = period.shortname;
+    const periodStartAtTimeStr = decimalHourToTimeStr(period.startAtHour);
+    const periodEndAtTimeStr = decimalHourToTimeStr(period.endAtHour);
+
+    const trips = schedulePeriod.trips || [];
+    const tripsCount = trips.length;
+
+    const actualOutboundPathId = schedulePeriod.outbound_path_id;
+    const outboundPathId =
+        actualOutboundPathId || (outboundPathsChoices.length === 1 ? outboundPathsChoices[0].value : '');
+
+    const actualInboundPathId = schedulePeriod.inbound_path_id;
+    const inboundPathId =
+        actualInboundPathId || (inboundPathsChoices.length === 1 ? inboundPathsChoices[0].value : undefined);
+
+    const outboundTripsCells: React.ReactNode[] = [];
+    const inboundTripsCells: React.ReactNode[] = [];
+    const tripRows: React.ReactNode[] = [];
+
+    for (let tripI = 0; tripI < tripsCount; tripI++) {
+        const trip = trips[tripI];
+        if (outboundPathIds.includes(trip.path_id)) {
+            // outbound trip
+            outboundTripsCells.push(
+                <td key={`outboundTrip_${tripI}`}>
+                    {secondsSinceMidnightToTimeStr(trip.departure_time_seconds, true, allowSecondsBasedSchedules)}
+                </td>
+            );
+        } else if (inboundPathIds.includes(trip.path_id)) {
+            inboundTripsCells.push(
+                <td key={`inboundTrip_${tripI}`}>
+                    {secondsSinceMidnightToTimeStr(trip.departure_time_seconds, true, allowSecondsBasedSchedules)}
+                </td>
+            );
+        }
+    }
+
+    const totalNumberOfTripRows = Math.max(outboundTripsCells.length, inboundTripsCells.length);
+
+    for (let rowI = 0; rowI < totalNumberOfTripRows; rowI++) {
+        tripRows.push(
+            <tr key={rowI}>
+                {outboundTripsCells[rowI] || <td key={`emptyOutboundTrip_${rowI}`}></td>}
+                {inboundTripsCells[rowI] || <td key={`emptyInboundTrip_${rowI}`}></td>}
+            </tr>
+        );
+    }
+
+    const outboundIntervalSeconds = schedulePeriod.interval_seconds;
+    const inboundIntervalSeconds = schedulePeriod.inbound_interval_seconds;
+    const calculatedIntervalSeconds = schedulePeriod.calculated_interval_seconds;
+    const numberOfUnits = schedulePeriod.number_of_units;
+    const calculatedNumberOfUnits = schedulePeriod.calculated_number_of_units;
+    const customStartAtStr =
+        schedulePeriod.custom_start_at_str || decimalHourToTimeStr(period.startAtHour) || undefined;
+    const customEndAtStr = schedulePeriod.custom_end_at_str || undefined;
+
+    /* temporary for calculations: TODO Do we really need this? */
+    line.attributes.data.tmpIntervalSeconds = outboundIntervalSeconds || calculatedIntervalSeconds;
+    line.attributes.data.tmpNumberOfUnits = numberOfUnits || calculatedNumberOfUnits;
+    /* */
+
+    const handleGenerateSchedule = () => {
+        schedule.set(`periods[${periodIndex}].outbound_path_id`, outboundPathId);
+        schedule.set(`periods[${periodIndex}].inbound_path_id`, inboundPathId);
+
+        const response = schedule.generateForPeriod(periodShortname);
+        if (response.trips) {
+            schedule.set(`periods[${periodIndex}].trips`, response.trips);
+        }
+        serviceLocator.selectedObjectsManager.setSelection('schedule', [schedule]);
+    };
+
+    const handleRemoveSchedule = () => {
+        schedule.set(`periods[${periodIndex}].trips`, []);
+        serviceLocator.selectedObjectsManager.setSelection('schedule', [schedule]);
+    };
+
+    const isReadyForScheduleGeneration = (
+        calculationMode: ScheduleCalculationMode,
+        inboundInterval?: number,
+        outboundInterval?: number,
+        numberOfUnits?: number
+    ) => {
+        return (
+            (calculationMode === ScheduleCalculationMode.BASIC &&
+                !_isBlank(outboundInterval) &&
+                _isBlank(numberOfUnits)) ||
+            (calculationMode === ScheduleCalculationMode.ASYMMETRIC &&
+                !_isBlank(outboundInterval) &&
+                !_isBlank(inboundInterval) &&
+                _isBlank(numberOfUnits)) ||
+            (!_isBlank(numberOfUnits) && _isBlank(outboundInterval) && _isBlank(inboundInterval))
+        );
+    };
+
+    return (
+        <div
+            className="tr__form-section _flex-container-row"
+            key={periodShortname}
+            style={{
+                borderRight: '1px solid rgba(255,255,255,0.2)',
+                alignItems: 'flex-start',
+                minWidth: '20rem'
+            }}
+        >
+            <h4 className="_aside-heading-container" style={{ minHeight: '30rem' }}>
+                <span className="_aside-heading">
+                    <FontAwesomeIcon icon={faClock} className="_icon" />{' '}
+                    <span className="_strong">{periodStartAtTimeStr}</span>{' '}
+                    <FontAwesomeIcon icon={faArrowDown} className="_icon" />{' '}
+                    <span className="_strong">{periodEndAtTimeStr}</span> <span>• {periodName}</span>
+                </span>
+            </h4>
+            <div className="tr__form-section">
+                <div className="tr__form-section">
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:OutboundPath')}</label>
+                        <InputSelect
+                            id={`formFieldTransitScheduleOutboundPathPeriod${periodShortname}${scheduleId}`}
+                            value={outboundPathId}
+                            choices={outboundPathsChoices}
+                            disabled={isFrozen}
+                            t={t}
+                            onValueChange={(e) =>
+                                onValueChange(`periods[${periodIndex}].outbound_path_id`, {
+                                    value: e.target.value
+                                })
+                            }
+                        />
+                    </div>
+                    {allowSecondsBasedSchedules !== true && (
+                        <div className="apptr__form-input-container">
+                            <label>{t('transit:transitSchedule:outboundIntervalMinutes')}</label>
+                            <InputStringFormatted
+                                id={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${scheduleId}`}
+                                disabled={isFrozen}
+                                value={outboundIntervalSeconds}
+                                onValueUpdated={(value) => {
+                                    onValueChange(`periods[${periodIndex}].interval_seconds`, value);
+                                }}
+                                key={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${scheduleId}${resetChangesCount}`}
+                                stringToValue={minutesToSeconds}
+                                valueToString={(val) => _toString(secondsToMinutes(val))}
+                            />
+                        </div>
+                    )}
+                    {allowSecondsBasedSchedules === true && (
+                        <div className="apptr__form-input-container">
+                            <label>{t('transit:transitSchedule:outboundIntervalSeconds')}</label>
+                            <InputStringFormatted
+                                id={`formFieldTransitScheduleIntervalSecondsPeriod${periodShortname}${scheduleId}`}
+                                disabled={isFrozen}
+                                value={outboundIntervalSeconds}
+                                stringToValue={_toInteger}
+                                valueToString={_toString}
+                                key={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${scheduleId}${resetChangesCount}`}
+                                onValueUpdated={(value) => {
+                                    onValueChange(`periods[${periodIndex}].interval_seconds`, value);
+                                }}
+                            />
+                        </div>
+                    )}
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:InboundPath')}</label>
+                        <InputSelect
+                            id={`formFieldTransitScheduleInboundPathPeriod${periodShortname}${scheduleId}`}
+                            value={inboundPathId}
+                            choices={inboundPathsChoices}
+                            disabled={isFrozen}
+                            t={t}
+                            onValueChange={(e) =>
+                                onValueChange(`periods[${periodIndex}].inbound_path_id`, {
+                                    value: e.target.value
+                                })
+                            }
+                        />
+                    </div>
+
+                    {allowSecondsBasedSchedules !== true && calculationMode === ScheduleCalculationMode.ASYMMETRIC && (
+                        <div className="apptr__form-input-container">
+                            <label>{t('transit:transitSchedule:inboundIntervalMinutes')}</label>
+                            <InputStringFormatted
+                                id={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${scheduleId}`}
+                                disabled={isFrozen}
+                                value={inboundIntervalSeconds}
+                                onValueUpdated={(value) =>
+                                    onValueChange(`periods[${periodIndex}].inbound_interval_seconds`, value)
+                                }
+                                key={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${scheduleId}${resetChangesCount}`}
+                                stringToValue={minutesToSeconds}
+                                valueToString={(val) => _toString(secondsToMinutes(val))}
+                            />
+                        </div>
+                    )}
+
+                    {allowSecondsBasedSchedules === true &&
+                        schedule.attributes.calculation_mode === ScheduleCalculationMode.ASYMMETRIC && (
+                        <div className="apptr__form-input-container">
+                            <label>{t('transit:transitSchedule:inboundIntervalSeconds')}</label>
+                            <InputStringFormatted
+                                id={`formFieldTransitScheduleIntervalSecondsPeriod${periodShortname}${scheduleId}`}
+                                disabled={isFrozen}
+                                value={inboundIntervalSeconds}
+                                stringToValue={_toInteger}
+                                valueToString={_toString}
+                                key={`formFieldTransitScheduleIntervalMinutesPeriod${periodShortname}${scheduleId}${resetChangesCount}`}
+                                onValueUpdated={(value) =>
+                                    onValueChange(`periods[${periodIndex}].inbound_interval_seconds`, value)
+                                }
+                            />
+                        </div>
+                    )}
+
+                    <p className="_small _oblique">
+                        {!outboundIntervalSeconds &&
+                        calculatedIntervalSeconds &&
+                        numberOfUnits &&
+                        !inboundIntervalSeconds
+                            ? `${t('transit:transitSchedule:CalculatedInterval')}: ${Math.ceil(
+                                calculatedIntervalSeconds / 60
+                            )} ${t('main:minuteAbbr')}`
+                            : ''}
+                    </p>
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:NumberOfUnits')}</label>
+                        <InputStringFormatted
+                            id={`formFieldTransitScheduleNumberOfUnitsPeriod${periodShortname}${scheduleId}`}
+                            disabled={isFrozen}
+                            value={numberOfUnits}
+                            stringToValue={_toInteger}
+                            valueToString={_toString}
+                            key={`formFieldTransitScheduleNumberOfUnitsPeriod${periodShortname}${scheduleId}${resetChangesCount}`}
+                            onValueUpdated={(value) => onValueChange(`periods[${periodIndex}].number_of_units`, value)}
+                        />
+                    </div>
+                    <p className="_small _oblique">
+                        {!numberOfUnits && calculatedNumberOfUnits && outboundIntervalSeconds
+                            ? `${roundToDecimals(calculatedNumberOfUnits, 1)} ${t(
+                                'transit:transitSchedule:requiredUnits'
+                            )}`
+                            : ''}
+                    </p>
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:CustomStartAt')}</label>
+                        <InputString
+                            id={`formFieldTransitScheduleCustomStartAtPeriod${periodShortname}${scheduleId}`}
+                            disabled={isFrozen}
+                            value={customStartAtStr}
+                            onValueUpdated={(value) =>
+                                onValueChange(`periods[${periodIndex}].custom_start_at_str`, value)
+                            }
+                        />
+                    </div>
+                    <div className="apptr__form-input-container">
+                        <label>{t('transit:transitSchedule:CustomEndAt')}</label>
+                        <InputString
+                            id={`formFieldTransitScheduleCustomEndAtPeriod${periodShortname}${scheduleId}`}
+                            disabled={isFrozen}
+                            value={customEndAtStr}
+                            onValueUpdated={(value) =>
+                                onValueChange(`periods[${periodIndex}].custom_end_at_str`, value)
+                            }
+                        />
+                    </div>
+                </div>
+                <div className="tr__form-section">
+                    {isFrozen !== true && (
+                        <div className="tr__form-buttons-container _left">
+                            {isReadyForScheduleGeneration(
+                                calculationMode,
+                                inboundIntervalSeconds,
+                                outboundIntervalSeconds,
+                                numberOfUnits
+                            ) && (
+                                <Button
+                                    color="blue"
+                                    icon={faSyncAlt}
+                                    iconClass="_icon"
+                                    label={t('transit:transitSchedule:GenerateSchedule')}
+                                    onClick={handleGenerateSchedule}
+                                />
+                            )}
+                        </div>
+                    )}
+                    {isFrozen !== true && tripsCount > 0 && (
+                        <div className="tr__form-buttons-container _left">
+                            <Button
+                                color="red"
+                                icon={faTrash}
+                                iconClass="_icon"
+                                label={t('transit:transitSchedule:RemoveSchedule')}
+                                onClick={handleRemoveSchedule}
+                            />
+                        </div>
+                    )}
+                </div>
+                {tripsCount > 0 && (
+                    <div className="tr__form-section">
+                        <table className="_schedule">
+                            <tbody>
+                                <tr>
+                                    <th>{t('transit:transitPath:directions:outbound')}</th>
+                                    <th>{t('transit:transitPath:directions:inbound')}</th>
+                                </tr>
+                                {tripRows}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default TransitSchedulePeriod;


### PR DESCRIPTION
…ransit lines

Introduce batch modification functionality, allowing users to update schedules across multiple transit lines simultaneously.

Key changes:

* Added `TransitScheduleBatchList` to display all agency lines for selection
* Introduced `TransitScheduleBatchButton` for selecting individual lines
* Updated `TransitionFullSizePanel` to support both 'batch' and 'single' schedule modes
* Added a "Batch Schedule" button to `TransitAgencyList`
* Extracted the schedule period form into a reusable `TransitSchedulePeriod` component
* Implemented backend routes and DB logic for batch schedule updates in `transitObjectsDataHandler`, `transitObjects.socketRoutes`, and `transitSchedules.db.queries`
* Enabled event propagation between batch components for synchronized selection state
* Added "Select all / Deselect all" functionality
* Created new component `TransitScheduleBatchEdit` based on `TransitScheduleEdit` for creating/modifying multiple schedules at once

Note:
 Some redundancy is still present in the code between the frontend for batch schedule modification and single schedule modification. The files in question have a // FIXME section for more information.

Closes #843
---