### PR TITLE
tests: destroy connection after db tests

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/__tests__/dataSources.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/dataSources.db.test.ts
@@ -76,7 +76,7 @@ beforeAll(async () => {
 afterAll(async() => {
     await dbQueries.truncate();
     await truncate(knex, 'users');
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/chaire-lib-backend/src/models/db/__tests__/preferences.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/preferences.db.test.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
-import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import knex from '../../../config/shared/db.config';
 
 import dbQueries from '../preferences.db.queries';
 import { truncate } from '../default.db.queries';
@@ -32,6 +32,7 @@ beforeAll(async () => {
 
 afterAll(async() => {
     await truncate(knex, 'users');
+    await knex.destroy();
 });
 
 test('Read initial preferences', async () => {

--- a/packages/chaire-lib-backend/src/models/db/__tests__/tokens.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/tokens.db.test.ts
@@ -106,7 +106,9 @@ const createUser = async (knex: Knex, tableName: string = 'users', user: UserAtt
     }
 }
 
-
+afterAll(async () => {
+    await knex.destroy();
+});
 
 describe(`Tokens Database: Token exists in Tokens table`, () => {
 
@@ -120,7 +122,7 @@ describe(`Tokens Database: Token exists in Tokens table`, () => {
     
     afterAll(async() => {
         await truncate(knex, 'tokens');
-        await truncate(knex, 'users')
+        await truncate(knex, 'users');
     });
 
     test('Should return api token', async () => {

--- a/packages/chaire-lib-backend/src/models/db/__tests__/users.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/users.db.test.ts
@@ -7,7 +7,7 @@
 import { v4 as uuidV4 } from 'uuid';
 import _cloneDeep from 'lodash/cloneDeep';
 import each from 'jest-each';
-import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import knex from '../../../config/shared/db.config';
 
 import dbQueries from '../users.db.queries';
 import { truncate } from '../default.db.queries';
@@ -59,6 +59,7 @@ beforeAll(async () => {
 
 afterAll(async() => {
     await truncate(knex, 'users');
+    await knex.destroy();
 });
 
 each([

--- a/packages/chaire-lib-backend/src/models/db/__tests__/zones.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/zones.db.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import knex from '../../../config/shared/db.config';
 
 import dbQueries from '../zones.db.queries';
 import dataSourceDbQueries from '../dataSources.db.queries';
@@ -62,8 +63,7 @@ beforeAll(async () => {
 afterAll(async() => {
     await dbQueries.truncate();
     await dataSourceDbQueries.truncate();
-    dataSourceDbQueries.destroy();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
@@ -126,13 +126,7 @@ afterAll(async () => {
     await dbQueries.truncate();
     await linesDbQueries.truncate();
     await agencyDbQueries.truncate();
-    schedulesDbQueries.destroy();
-    schedulesDbQueries.destroy();
-    schedulesDbQueries.destroy();
-    servicesDbQueries.destroy();
-    scenariosDbQueries.destroy();
-    dbQueries.destroy();
-    linesDbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, function() {

--- a/packages/transition-backend/src/models/db/__tests__/TransitSchedule.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/TransitSchedule.db.test.ts
@@ -54,11 +54,7 @@ afterAll(async () => {
     await pathsDbQueries.truncate();
     await linesDbQueries.truncate();
     await agenciesDbQueries.truncate();
-    await dbQueries.destroy();
-    await servicesDbQueries.destroy();
-    await pathsDbQueries.destroy();
-    await linesDbQueries.destroy();
-    await agenciesDbQueries.destroy();
+    await knex.destroy();
 });
 
 const pathStub1 = {

--- a/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/batchRouteResults.db.test.ts
@@ -102,7 +102,7 @@ afterAll(async() => {
     await dbQueries.truncate();
     await jobsDbQueries.truncate();
     await knex.raw(`TRUNCATE TABLE users CASCADE`);
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
 afterAll(async() => {
     await dbQueries.truncate();
     await knex.raw(`TRUNCATE TABLE users CASCADE`);
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/odPairs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/odPairs.db.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import dbQueries from '../odPairs.db.queries';
 import dataSourceDbQueries from 'chaire-lib-backend/lib/models/db/dataSources.db.queries';
@@ -55,8 +56,7 @@ beforeAll(async () => {
 afterAll(async() => {
     await dbQueries.truncate();
     await dataSourceDbQueries.truncate();
-    dataSourceDbQueries.destroy();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/places.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/places.db.test.ts
@@ -6,6 +6,7 @@
  */
 import { v4 as uuidV4 } from 'uuid';
 import { point as turfPoint } from '@turf/turf';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import dbQueries from '../places.db.queries';
 import dataSourcesDbQueries from 'chaire-lib-backend/lib/models/db/dataSources.db.queries';
@@ -81,8 +82,7 @@ beforeAll(async () => {
 afterAll(async() => {
     await dbQueries.truncate();
     await dataSourcesDbQueries.truncate();
-    dbQueries.destroy();
-    dataSourcesDbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/simulationRuns.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/simulationRuns.db.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import dbQueries from '../simulationRuns.db.queries';
 import simulationDbQueries from '../simulations.db.queries';
@@ -103,9 +104,7 @@ afterAll(async() => {
     await dbQueries.truncate();
     await simulationDbQueries.truncate();
     await scenariosDbQueries.truncate();
-    scenariosDbQueries.destroy();
-    simulationDbQueries.destroy();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/simulations.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/simulations.db.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import dbQueries from '../simulations.db.queries';
 import Collection from 'transition-common/lib/services/simulation/SimulationCollection';
@@ -51,7 +52,7 @@ beforeAll(async () => {
 
 afterAll(async() => {
     await dbQueries.truncate();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
@@ -67,8 +67,7 @@ beforeAll(async () => {
 afterAll(async() => {
     await dbQueries.truncate();
     await simulationDbQueries.truncate();
-    simulationDbQueries.destroy();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/transitLines.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitLines.db.test.ts
@@ -149,9 +149,7 @@ afterAll(async function() {
     await dbQueries.truncate();
     await agenciesDbQueries.truncate();
     await servicesDbQueries.truncate();
-    await dbQueries.destroy();
-    await servicesDbQueries.destroy();
-    await agenciesDbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/transitNodeTransferable.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodeTransferable.db.test.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { v4 as uuidV4 } from 'uuid';
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 
 import dbQueries from '../transitNodeTransferable.db.queries';
 import nodesDbQueries from '../transitNodes.db.queries';
@@ -42,6 +43,7 @@ beforeAll(async () => {
 afterAll(async () => {
     await dbQueries.truncate();
     await nodesDbQueries.truncate();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitNodes.db.test.ts
@@ -136,7 +136,7 @@ beforeAll(async () => {
 afterAll(async () => {
     await dbQueries.truncate();
     await pathsDbQueries.truncate();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
@@ -110,9 +110,7 @@ afterAll(async() => {
     await dbQueries.truncate();
     await servicesDbQueries.truncate();
     await simulationDbQueries.truncate();
-    simulationDbQueries.destroy();
-    dbQueries.destroy();
-    servicesDbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, () => {

--- a/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
@@ -109,8 +109,7 @@ afterAll(async() => {
     await linesDbQueries.truncate();
     await agenciesDbQueries.truncate();
     await schedulesDbQueries.truncateSchedules();
-    simulationDbQueries.destroy();
-    dbQueries.destroy();
+    await knex.destroy();
 });
 
 describe(`${objectName}`, function() {


### PR DESCRIPTION
By adding `await knex.destroy()` in the `afterAll` block of each database tests, we make sure that the connection is properly destroyed, synchronously, and the tests can exit without open handles.

Some tests already called the `destroy` db query from some tables, but this function was effectively destroying the connection multiple times (as all queries share the same connection) and it was not done synchronously as no callback was passed to the function, so the test was still finishing with open handles.