### PR TITLE
Duplicate schedules in the backend

### DIFF
--- a/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
@@ -40,6 +40,10 @@ jest.mock('../../services/transitObjects/transitServices/ServiceDuplicator', () 
     duplicateServices: jest.fn()
 }));
 
+jest.mock('../../services/transitObjects/transitSchedules/ScheduleUtils', () => ({
+    duplicateSchedules: jest.fn()
+}));
+
 import { v4 as uuidV4 } from 'uuid';
 import { EventEmitter } from 'events';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
@@ -47,10 +51,16 @@ import { TransitObjectDataHandler } from '../../services/transitObjects/TransitO
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import transitObjectRoutes from '../transitObjects.socketRoutes';
 import { duplicateServices } from '../../services/transitObjects/transitServices/ServiceDuplicator';
+import { duplicateSchedules } from '../../services/transitObjects/transitSchedules/ScheduleUtils';
 
-const mockedDuplicateAndSave = duplicateServices as jest.MockedFunction<typeof duplicateServices>;
+const mockedDuplicateAndSaveService = duplicateServices as jest.MockedFunction<typeof duplicateServices>;
+const mockedDuplicateSchedules = duplicateSchedules as jest.MockedFunction<typeof duplicateSchedules>;
 const socketStub = new EventEmitter();
 transitObjectRoutes(socketStub);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
 
 describe('Service duplication route', () => {
     test('Duplicate with default options', (done) => {
@@ -59,12 +69,12 @@ describe('Service duplication route', () => {
             [originalServices[0]]: uuidV4(), 
             [originalServices[1]]: uuidV4()
         };
-        mockedDuplicateAndSave.mockResolvedValueOnce(Status.createOk(savedServices));
+        mockedDuplicateAndSaveService.mockResolvedValueOnce(Status.createOk(savedServices));
 
         socketStub.emit('transitServices.duplicate', originalServices, {}, (status) => {
             expect(Status.isStatusOk(status)).toEqual(true);
             expect(Status.unwrap(status)).toEqual(savedServices);
-            expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, {});
+            expect(mockedDuplicateAndSaveService).toHaveBeenLastCalledWith(originalServices, {});
             done();
         });
     });
@@ -76,33 +86,30 @@ describe('Service duplication route', () => {
             [originalServices[1]]: uuidV4()
         };
         const options = { newServiceSuffix: ' copy'}
-        mockedDuplicateAndSave.mockResolvedValueOnce(Status.createOk(savedServices));
+        mockedDuplicateAndSaveService.mockResolvedValueOnce(Status.createOk(savedServices));
 
         socketStub.emit('transitServices.duplicate', originalServices, options, (status) => {
             expect(Status.isStatusOk(status)).toEqual(true);
             expect(Status.unwrap(status)).toEqual(savedServices);
-            expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, options);
+            expect(mockedDuplicateAndSaveService).toHaveBeenLastCalledWith(originalServices, options);
             done();
         });
     });
 
     test('Duplicate where error occurred', (done) => {
         const originalServices = [uuidV4(), uuidV4()];
-        mockedDuplicateAndSave.mockResolvedValueOnce(Status.createError('An error occurred'));
+        mockedDuplicateAndSaveService.mockResolvedValueOnce(Status.createError('An error occurred'));
 
         socketStub.emit('transitServices.duplicate', originalServices, {}, (status) => {
             expect(Status.isStatusOk(status)).toEqual(false);
             expect(Status.isStatusError(status)).toEqual(true);
-            expect(mockedDuplicateAndSave).toHaveBeenLastCalledWith(originalServices, {});
+            expect(mockedDuplicateAndSaveService).toHaveBeenLastCalledWith(originalServices, {});
             done();
         });
     });
 });
 
 describe('Schedules update batch route', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
 
     test('updateSchedulesBatch handler is initialized', () => {
         expect(socketStub.listenerCount('transitSchedules.updateBatch')).toBe(1);
@@ -144,5 +151,54 @@ describe('Schedules update batch route', () => {
             invalidAttributeList
         );
         expect(response).toHaveProperty('error');
+    });
+});
+
+describe('Schedule duplication', () => {
+
+    test('Duplicate with mappings', (done) => {
+        const serviceMapping = {
+            [uuidV4()]: uuidV4(), 
+            [uuidV4()]: uuidV4()
+        };
+        const newScheduleIdMapping = { 1: 2, 3: 4 }; 
+        mockedDuplicateSchedules.mockResolvedValueOnce(Status.createOk(newScheduleIdMapping));
+
+        socketStub.emit('transitSchedules.duplicate', { serviceIdMapping: serviceMapping }, (status) => {
+            try {
+                expect(Status.isStatusOk(status)).toEqual(true);
+                expect(Status.unwrap(status)).toEqual(newScheduleIdMapping);
+                expect(mockedDuplicateSchedules).toHaveBeenCalledWith({ serviceIdMapping: serviceMapping });
+                done();
+            } catch(error) {
+                done(error);
+            }
+        });
+    });
+
+    test('Duplicate where error occurred', (done) => {
+        const serviceMapping = {
+            [uuidV4()]: uuidV4(), 
+            [uuidV4()]: uuidV4()
+        };
+        const lineMapping = {
+            [uuidV4()]: uuidV4(), 
+            [uuidV4()]: uuidV4()
+        };
+        const pathMapping = {
+            [uuidV4()]: uuidV4()
+        }
+        mockedDuplicateSchedules.mockResolvedValueOnce(Status.createError('An error occurred'));
+
+        socketStub.emit('transitSchedules.duplicate', { serviceIdMapping: serviceMapping, lineIdMapping: lineMapping, pathIdMapping: pathMapping }, (status) => {
+            try {
+                expect(Status.isStatusOk(status)).toEqual(false);
+                expect(Status.isStatusError(status)).toEqual(true);
+                expect(mockedDuplicateSchedules).toHaveBeenLastCalledWith({ serviceIdMapping: serviceMapping, lineIdMapping: lineMapping, pathIdMapping: pathMapping });
+                done();
+            } catch(error) {
+                done(error);
+            }
+        });
     });
 });

--- a/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
+++ b/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
@@ -7,6 +7,10 @@
 import { EventEmitter } from 'events';
 import transitObjectDataHandlers from '../services/transitObjects/TransitObjectsDataHandler';
 import { duplicateServices } from '../services/transitObjects/transitServices/ServiceDuplicator';
+import {
+    DuplicateScheduleMappings,
+    duplicateSchedules
+} from '../services/transitObjects/transitSchedules/ScheduleUtils';
 
 function setupObjectSocketRoutes(socket: EventEmitter) {
     for (const lowerCasePlural in transitObjectDataHandlers) {
@@ -141,6 +145,12 @@ function setupObjectSocketRoutes(socket: EventEmitter) {
     // Duplicate a service
     socket.on('transitServices.duplicate', async (serviceIds: string[], options, callback) => {
         const response = await duplicateServices(serviceIds, options);
+        callback(response);
+    });
+
+    // Duplicate schedules for specific mappings
+    socket.on('transitSchedules.duplicate', async (options: DuplicateScheduleMappings, callback) => {
+        const response = await duplicateSchedules(options);
         callback(response);
     });
 }

--- a/packages/transition-backend/src/services/transitObjects/transitSchedules/ScheduleUtils.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitSchedules/ScheduleUtils.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+// This file contains utility functions for schedules that wrap the database
+// calls for some functionalities.
+
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { WithTransaction } from 'chaire-lib-backend/lib/models/db/types.db';
+import schedulesDbQueries from '../../../models/db/transitSchedules.db.queries';
+
+export type DuplicateScheduleMappings = {
+    /**
+     * The mapping of original line IDs to new line IDs
+     */
+    lineIdMapping?: { [originalLineId: string]: string };
+    /**
+     * The mapping of original service IDs to new service IDs
+     */
+    serviceIdMapping?: { [originalServiceId: string]: string };
+    /**
+     * The mapping of original path IDs to new path IDs
+     */
+    pathIdMapping?: { [originalPathId: string]: string };
+};
+
+/**
+ * Duplicate schedules with the mapping
+ *
+ * @param mappings The mapping of original objects to the new ones. There should
+ * be at least a mapping of lines or services to allow duplication.
+ * @param transaction The database transaction to use
+ * @returns A status object a mapping of the previous service IDs to the new
+ * ones
+ */
+export const duplicateSchedules = async (
+    mappings: DuplicateScheduleMappings,
+    { transaction }: WithTransaction = {}
+): Promise<Status.Status<{ [originalScheduleId: number]: number }>> => {
+    try {
+        const result = await schedulesDbQueries.duplicateSchedule({ ...mappings, transaction });
+        return Status.createOk(result);
+    } catch (error) {
+        console.log('An error occurred while duplicating schedules: ', error);
+        return Status.createError('An error occurred while duplicating schedules');
+    }
+};

--- a/packages/transition-backend/src/services/transitObjects/transitSchedules/__tests__/ScheduleUtils.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitSchedules/__tests__/ScheduleUtils.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import { duplicateSchedules } from '../ScheduleUtils';
+import transitSchedulesDbQueries from '../../../../models/db/transitSchedules.db.queries';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+
+// Mock the knex transaction object.
+const transactionObjectMock = new Object(3) as any;
+
+jest.mock('../../../../models/db/transitSchedules.db.queries', () => ({
+    duplicateSchedule: jest.fn(),
+}));
+const mockDuplicateSchedule = transitSchedulesDbQueries.duplicateSchedule as jest.MockedFunction<typeof transitSchedulesDbQueries.duplicateSchedule>;    
+
+describe('duplicateSchedules', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call the duplicateSchedule db function with mappings and return ok result', async () => {
+        const expectedResult = { 3: 4, 5: 6 };
+        mockDuplicateSchedule.mockResolvedValue(expectedResult);
+        const mappings = {
+            lineIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() }
+        };
+        expect(await duplicateSchedules(mappings)).toEqual(Status.createOk(expectedResult));
+        expect(mockDuplicateSchedule).toHaveBeenCalledWith({
+            ...mappings,
+            transaction: undefined
+        });
+    });
+
+    it('should call the duplicateSchedule db function with mappings and provided transaction and return ok result', async () => {
+        const expectedResult = { 3: 4, 5: 6 };
+        mockDuplicateSchedule.mockResolvedValue(expectedResult);
+        const mappings = {
+            lineIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() },
+            serviceIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() },
+            pathIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() }
+        };
+        expect(await duplicateSchedules(mappings, { transaction: transactionObjectMock })).toEqual(Status.createOk(expectedResult));
+        expect(mockDuplicateSchedule).toHaveBeenCalledWith({
+            ...mappings,
+            transaction: transactionObjectMock
+        });
+    });
+
+    it('should return an error status if db function throw an error', async () => {
+        mockDuplicateSchedule.mockRejectedValue(new Error('error'));
+        const mappings = {
+            lineIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() },
+            serviceIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() },
+            pathIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() }
+        };
+        expect(await duplicateSchedules(mappings)).toEqual(Status.createError('An error occurred while duplicating schedules'));
+        expect(mockDuplicateSchedule).toHaveBeenCalledWith({
+            ...mappings,
+            transaction: undefined
+        });
+    });
+
+});

--- a/packages/transition-common/src/services/schedules/__tests__/ScheduleDuplicator.test.ts
+++ b/packages/transition-common/src/services/schedules/__tests__/ScheduleDuplicator.test.ts
@@ -6,84 +6,43 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import _omit from 'lodash/omit';
+import EventEmitter from 'events';
 import { v4 as uuidV4 } from 'uuid';
 
-import { getScheduleAttributes } from './ScheduleData.test';
-import Schedule from '../Schedule';
-import { duplicateSchedule } from '../ScheduleDuplicator';
+import { duplicateSchedules } from '../ScheduleDuplicator';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
 
-const pathId = uuidV4();
-const scheduleAttributes = getScheduleAttributes({ pathId });
-const schedule = new Schedule(scheduleAttributes, true);
+const socketStub = new EventEmitter();
 
-test('Duplicate schedule, same line path and services', async () => {
-    // Copy the line and make sure the path was correctly copied
-    const newSchedule = await duplicateSchedule(schedule, { });
-    expect(newSchedule.getId()).not.toEqual(schedule.getId());
+let nextResult: Status.Status<{ [oldSchedId: number]: number }> = Status.createOk({ 3: 4, 5: 6 });
+const transitScheduleHandlerMock = jest.fn().mockImplementation(async (mapping, callback) => {
+    callback(nextResult);
+});
+socketStub.on('transitSchedules.duplicate', transitScheduleHandlerMock);
 
-    // Validate the schedule's data
-    const expectedSched = getScheduleAttributes({ pathId, scheduleId: newSchedule.getId() });
-    const actualSched = newSchedule.attributes;
-    const expectedBaseSchedules = _omit(expectedSched, 'periods', 'integer_id');
-    const actualSchedule = _omit(actualSched, 'periods');
-    const expectedPeriods = expectedSched.periods;
-    const actualPeriods = actualSched.periods;
-    expect(actualSchedule).toEqual(expectedBaseSchedules);
+beforeEach(() => {
+    jest.clearAllMocks();
+})
 
-    // Validate the period's data and id propagation
-    for (let i = 0; i < expectedPeriods.length; i++) {
-        const expectedPeriod = _omit(expectedPeriods[i], ['id', 'trips', 'integer_id', 'schedule_id']);
-        const actualPeriod = _omit(actualPeriods[i], ['id', 'trips']);
-        const expectedTrips = expectedPeriods[i].trips;
-        const actualTrips = actualPeriods[i].trips;
-        const periodId = actualPeriods[i].integer_id;
-        expect(actualPeriod).toEqual(expectedPeriod);
-
-        // Validate the trip's data and id propagation
-        for (let j = 0; j < expectedTrips.length; j++) {
-            const expectedTrip = _omit(expectedTrips[j], 'id', 'integer_id', 'schedule_period_id');
-            const actualTrip = _omit(actualTrips[j], 'id');
-            expect(actualTrip).toEqual(expectedTrip);
-        }
-    }
+test('Duplicate schedules with mapping and return ok', async () => {
+    const expectedNextResult = Status.createOk({ 3: 4, 5: 6 });
+    nextResult = _cloneDeep(expectedNextResult);
+    const mappings = {
+        lineIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() },
+        serviceIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() },
+        pathIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() }
+    };
+    const result = await duplicateSchedules(socketStub, mappings);
+    expect(result).toEqual(Status.unwrap(expectedNextResult));
+    expect(transitScheduleHandlerMock).toHaveBeenCalledWith(mappings, expect.any(Function));
 });
 
 test('Duplicate schedule, different line, path and services', async () => {
-    const newServiceId = uuidV4();
-    const newLineId = uuidV4();
-    const newPathId = uuidV4();
-    const pathMapping = {};
-    pathMapping[pathId] = newPathId;
-    
-    // Copy the line and make sure the path was correctly copied
-    const newSchedule = await duplicateSchedule(schedule, { lineId: newLineId, serviceId: newServiceId, pathIdsMapping: pathMapping });
-    expect(newSchedule.getId()).not.toEqual(schedule.getId());
-    expect(newSchedule.attributes.line_id).not.toEqual(schedule.attributes.line_id);
-    expect(newSchedule.attributes.service_id).not.toEqual(schedule.attributes.service_id);
-
-    // Validate the schedule's data
-    const expectedSched = getScheduleAttributes({ pathId: newPathId, lineId: newLineId, serviceId: newServiceId, scheduleId: newSchedule.getId() });
-    const actualSched = newSchedule.attributes;
-    const expectedBaseSchedules = _omit(expectedSched, 'periods', 'integer_id');
-    const actualSchedule = _omit(actualSched, 'periods');
-    const expectedPeriods = expectedSched.periods;
-    const actualPeriods = actualSched.periods;
-    expect(actualSchedule).toEqual(expectedBaseSchedules);
-
-    // Validate the period's data and id propagation
-    for (let i = 0; i < expectedPeriods.length; i++) {
-        const expectedPeriod = _omit(expectedPeriods[i], ['id', 'trips', 'integer_id', 'schedule_id']);
-        const actualPeriod = _omit(actualPeriods[i], ['id', 'trips']);
-        expect(actualPeriod.outbound_path_id).not.toEqual(schedule.attributes.periods[i].outbound_path_id);
-        const expectedTrips = expectedPeriods[i].trips;
-        const actualTrips = actualPeriods[i].trips;
-        expect(actualPeriod).toEqual(expectedPeriod);
-
-        // Validate the trip's data and id propagation
-        for (let j = 0; j < expectedTrips.length; j++) {
-            const expectedTrip = _omit(expectedTrips[j], 'id', 'integer_id', 'schedule_period_id');
-            const actualTrip = _omit(actualTrips[j], 'id');
-            expect(actualTrip).toEqual(expectedTrip);
-        }
-    }
+    const expectedNextResult = Status.createError('socket: Error duplicating schedules');
+    nextResult = _cloneDeep(expectedNextResult);
+    const mappings = {
+        lineIdMapping: { [uuidV4()]: uuidV4(), [uuidV4()]: uuidV4() }
+    };
+    await expect(duplicateSchedules(socketStub, mappings)).rejects.toThrow('Error duplicating schedules');
+    expect(transitScheduleHandlerMock).toHaveBeenCalledWith(mappings, expect.any(Function));
 });


### PR DESCRIPTION
* Add a db query that copies in one query per table all schedules for given line, service, path mappings. This will in time allow to copy all the schedules for an agency in 3 queries
* Add socket routes to duplicate schedules in the backend
* Update the LineDuplicator to use the backend db duplicator
* Unit test everything

fixes #943