### PR TITLE
auth: record login in the anonymous strategy

### DIFF
--- a/packages/chaire-lib-backend/src/services/auth/__tests__/anonymousLoginStrategy.test.ts
+++ b/packages/chaire-lib-backend/src/services/auth/__tests__/anonymousLoginStrategy.test.ts
@@ -27,15 +27,15 @@ jest.mock('../../../models/db/users.db.queries', () => ({
             ...attribs
         }
     }),
-    find: jest.fn().mockResolvedValue(undefined)
+    find: jest.fn().mockResolvedValue(undefined),
+    setLastLogin: jest.fn().mockResolvedValue(undefined)
 }));
 const mockCreate = usersDbQueries.create as jest.MockedFunction<typeof usersDbQueries.create>;
 const mockFind = usersDbQueries.find as jest.MockedFunction<typeof usersDbQueries.find>;
+const mockSetLastLogin = usersDbQueries.setLastLogin as jest.MockedFunction<typeof usersDbQueries.setLastLogin>;
 
 beforeEach(() => {
-    logInFct.mockClear();
-    mockCreate.mockClear();
-    mockFind.mockClear();
+    jest.clearAllMocks();
 });
 
 const strategy = new AnonymousLoginStrategy(userAuthModel);
@@ -73,6 +73,7 @@ test('Anonymous strategy success', async () => {
         preferences: null
     });
     expect(logInFct).toHaveBeenCalledWith({ id: newUserId, username: expect.stringContaining('anonym_'), email: undefined, firstName: '', lastName: '', preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());
+    expect(mockSetLastLogin).toHaveBeenCalledWith(newUserId);
 });
 
 test('Anonymous strategy success, but duplicate user name', async () => {
@@ -106,6 +107,7 @@ test('Anonymous strategy success, but duplicate user name', async () => {
         preferences: null
     });
     expect(logInFct).toHaveBeenCalledWith({ id: newUserId, username: expect.stringContaining('anonym_'), email: undefined, firstName: '', lastName: '', preferences: {}, serializedPermissions: []}, expect.anything(), expect.anything());
+    expect(mockSetLastLogin).toHaveBeenCalledWith(newUserId);
 });
 
 test('Anonymous strategy with too many duplicate trials, should fail', async () => {
@@ -129,6 +131,7 @@ test('Anonymous strategy with too many duplicate trials, should fail', async () 
     await authPromise;
     expect(mockCreate).not.toHaveBeenCalled();
     expect(logInFct).not.toHaveBeenCalled();
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
     expect(endFct).toHaveBeenCalledTimes(1);
 });
 
@@ -151,5 +154,6 @@ test('Anonymous strategy failure', async () => {
     await authPromise;
     expect(mockCreate).toHaveBeenCalledTimes(1);
     expect(logInFct).not.toHaveBeenCalled();
+    expect(mockSetLastLogin).not.toHaveBeenCalled();
     expect(endFct).toHaveBeenCalledTimes(1);
 });

--- a/packages/chaire-lib-backend/src/services/auth/anonymousLoginStrategy.ts
+++ b/packages/chaire-lib-backend/src/services/auth/anonymousLoginStrategy.ts
@@ -36,6 +36,8 @@ class AnonymousLoginStrategy<A> {
                 isTest: false
             });
             if (newUser !== undefined) {
+                // Record new user login information
+                newUser.recordLogin();
                 this.success(newUser.sanitize());
             } else {
                 throw 'Cannot save new user';


### PR DESCRIPTION
fixes #1389

When the new user is created with the anonymous login strategy, the `recordLogin` method is called.