### PR TITLE
auth: pass a router to setup auth routes instead of app

### DIFF
--- a/packages/chaire-lib-backend/src/api/__tests__/auth.routes.test.ts
+++ b/packages/chaire-lib-backend/src/api/__tests__/auth.routes.test.ts
@@ -89,7 +89,9 @@ const app = express();
 // FIXME Since upgrading @types/node, the types are wrong and we get compilation error. It is documented for example https://github.com/DefinitelyTyped/DefinitelyTyped/issues/53584 the real fix would require upgrading a few packages and may have side-effects. Simple casting works for now.
 app.use(express.json({ limit: '500mb' }) as RequestHandler);
 app.use(express.urlencoded({extended: true}) as RequestHandler);
-authRoutes(app, userAuthModel, passport);
+const router = express.Router();
+authRoutes(router, userAuthModel, passport);
+app.use(router);
 
 beforeEach(() => {
     authResponse = {


### PR DESCRIPTION
fixes #1392

Setting the routes on a router gives more flexibility to the caller to add middleware and prefix the paths to the auth routes.

The app is a `Router`, but the reverse is not true. So we do not need to change the way those routes are set in the Transition app, as the express application in Transition is quite simple.