### PR TITLE
captcha: allow to keep a token after validation

### DIFF
--- a/packages/chaire-lib-frontend/src/components/captcha/CapJsCaptcha.tsx
+++ b/packages/chaire-lib-frontend/src/components/captcha/CapJsCaptcha.tsx
@@ -4,8 +4,8 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React from 'react';
-import { CapWidget } from '@pitininja/cap-react-widget';
+import React, { useEffect, useRef } from 'react';
+import { CapWidget, CapWidgetElement } from '@pitininja/cap-react-widget';
 import { useTranslation } from 'react-i18next';
 import { CaptchaProps } from './CaptchaProps';
 
@@ -13,10 +13,18 @@ const ENDPOINT = '/captcha/';
 
 // FIXME The widget loads a file from cdn.jsdelivr.net, which is not ideal for
 // production. We should consider hosting the wasm library ourselves.
-const CapJsCaptcha = ({ onCaptchaValid }: CaptchaProps) => {
+const CapJsCaptcha = ({ onCaptchaValid, reloadKey }: CaptchaProps) => {
     const { t } = useTranslation('auth');
+    const widgetRef = useRef<CapWidgetElement | null>(null);
+
+    useEffect(() => {
+        // Reset the widget if the reloadKey changes
+        widgetRef.current?.dispatchEvent('reset');
+    }, [reloadKey]);
+
     return (
         <CapWidget
+            ref={widgetRef}
             endpoint={ENDPOINT}
             onSolve={(token) => {
                 onCaptchaValid(true, token);


### PR DESCRIPTION
By default, once a cap.js token is validated, it is deleted and cannot be reused by any other query. This is not desirable, for example, in case of login, where legitimate errors can occur and the user may need to re-submit a modified form. He should not have to re-do the captcha every time.

This adds an option to the captcha middleware, a boolean `keepToken` value, which can be set per route, such that a query that should succeed everytime (like help request) can delete the token, while others, like login, can keep the token between queries.

Note that cap.js does a garbage collection of the expired token in any case, this option only applies to the current query.