### PR TITLE
ci: add `validationTrajets` branch to docker builds

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: 
       - "main"
       - "deck-gl-poc"
+      - "validationTrajets"
   workflow_dispatch:
   schedule:
     # Do a daily rebuild at 2:00 AM UTC


### PR DESCRIPTION
This branch can be used to test the declared trip validation functionality.