### PR TITLE
schedules: warn for batch edit not displaying one path lines

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -174,6 +174,7 @@
         "NewSchedule": "New timetable",
         "SaveSchedule": "Save timetable",
         "CloseSchedulesWindow": "Close the timetable window",
+        "batchMinTwoPathWarning": "Warning: only lines with at least two paths are displayed in the list. Batch timetable editing does not yet support single paths.",
         "errors": {
             "ServiceIsRequired": "Service is required",
             "PeriodsGroupIsRequired": "Periods group is required",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -174,6 +174,7 @@
         "NewSchedule": "Nouvel horaire",
         "SaveSchedule": "Sauvegarder l'horaire",
         "CloseSchedulesWindow": "Fermer la fenêtre des horaires",
+        "batchMinTwoPathWarning": "Attention: seules les lignes ayant au moins deux parcours sont affichées dans la liste des lignes. La modification d'horaire en lot ne supporte pas encore les parcours uniques.",
         "errors": {
             "ServiceIsRequired": "Le service est requis",
             "PeriodsGroupIsRequired": "Le groupe de périodes est requis",

--- a/packages/chaire-lib-frontend/src/components/pageParts/FormErrors.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/FormErrors.tsx
@@ -5,27 +5,26 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
 
-export type FormErrorsProps = WithTranslation & {
+export type FormErrorsProps = {
     errors: ErrorMessage[];
     errorType?: 'Warning' | 'Error';
 };
 
 const FormErrors: React.FunctionComponent<FormErrorsProps> = (props: FormErrorsProps) => {
+    const { t } = useTranslation();
     if (props.errors && props.errors.length > 0) {
         return (
             <div className="apptr__form-errors-container">
                 {props.errors.map((errorMessage) => {
                     const translatedText =
-                        typeof errorMessage === 'object'
-                            ? props.t(errorMessage.text, errorMessage.params)
-                            : props.t(errorMessage);
+                        typeof errorMessage === 'object' ? t(errorMessage.text, errorMessage.params) : t(errorMessage);
                     return (
                         <p
                             key={translatedText}
@@ -47,4 +46,4 @@ const FormErrors: React.FunctionComponent<FormErrorsProps> = (props: FormErrorsP
     }
 };
 
-export default withTranslation('auth')(FormErrors);
+export default FormErrors;

--- a/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchList.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitScheduleBatchList.tsx
@@ -19,6 +19,7 @@ import TransitScheduleBatchEdit from './TransitScheduleBatchEdit';
 import Schedule from 'transition-common/lib/services/schedules/Schedule';
 import { choiceType } from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
+import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 
 interface BatchListProps {
     batchSelectedLines: LineCollection;
@@ -37,9 +38,9 @@ const TransitScheduleBatchList: React.FunctionComponent<BatchListProps & WithTra
         selectedNewSchedules: []
     });
     const agencyCollection = serviceLocator.collectionManager.get('agencies').getFeatures();
-    const linesCollection = serviceLocator.collectionManager.get('lines').getFeatures();
+    const lines = serviceLocator.collectionManager.get('lines').getFeatures();
     // Only the lines with one inbound and one outbound path are displayed
-    const filteredlinesCollection = linesCollection.filter(
+    const filteredlines = lines.filter(
         (line) => line.getOutboundPaths().length > 0 && line.getInboundPaths().length > 0
     );
     const transitServices = serviceLocator.collectionManager.get('services');
@@ -104,7 +105,7 @@ const TransitScheduleBatchList: React.FunctionComponent<BatchListProps & WithTra
     agencyCollection.forEach((agency) => {
         const agencyLinesButtons: any[] = [];
         agency.getLines().forEach((line) => {
-            if (filteredlinesCollection.includes(line))
+            if (filteredlines.includes(line))
                 agencyLinesButtons.push(
                     <TransitScheduleBatchButton
                         disabled={state.isSelectionConfirmed === true}
@@ -149,11 +150,11 @@ const TransitScheduleBatchList: React.FunctionComponent<BatchListProps & WithTra
             {state.isSelectionConfirmed === false && (
                 <div className="tr__form-buttons-container _left">
                     <Button
-                        disabled={state.batchSelectedLines.length === filteredlinesCollection.length}
+                        disabled={state.batchSelectedLines.length === filteredlines.length}
                         color="blue"
                         label={props.t('main:SelectAll')}
                         onClick={function () {
-                            state.batchSelectedLines.setFeatures(filteredlinesCollection);
+                            state.batchSelectedLines.setFeatures(filteredlines);
                             setState({
                                 batchSelectedLines: state.batchSelectedLines,
                                 isSelectionConfirmed: false,
@@ -178,6 +179,9 @@ const TransitScheduleBatchList: React.FunctionComponent<BatchListProps & WithTra
                 </div>
             )}
 
+            {lines.length > filteredlines.length && (
+                <FormErrors errors={['transit:transitSchedule:batchMinTwoPathWarning']} errorType="Warning" />
+            )}
             {state.isSelectionConfirmed === false && <ButtonList>{linesButtons}</ButtonList>}
 
             <div className="tr__form-buttons-container _left">


### PR DESCRIPTION
fixes #1401

The algorithm for batch edit does not yet support lines with only one
path, so those lines are not displayed in the list. This caused
questioning for the users who were looking for those lines. The warning
explains why some lines may not be there.