### PR TITLE
Fix yarn format command in macos

### DIFF
--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -23,7 +23,7 @@
         "test:sequential": "cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand",
         "test:ui": "echo 'no tests to run for this workspace'",
         "lint": "eslint .",
-        "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+        "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write"
     },
     "dependencies": {
         "@cap.js/server": "^2.0.0",

--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -16,7 +16,7 @@
     "test:sequential": "echo 'no tests to run for this workspace'",
     "test:ui": "echo 'no tests to run for this workspace'",
     "lint": "eslint .",
-    "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write"
   },
   "dependencies": {
     "@casl/ability": "^6.7.3",

--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -17,7 +17,7 @@
     "test:sequential": "echo 'cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand'",
     "test:ui": "echo 'cross-env NODE_ENV=test jest --config=jest.ui.config.js'",
     "lint": "eslint .",
-    "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write"
   },
   "dependencies": {
     "@casl/ability": "^6.7.3",

--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -25,7 +25,7 @@
         "test:sequential": "cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand",
         "test:ui": "echo 'no tests to run for this workspace'",
         "lint": "eslint .",
-        "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+        "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write"
     },
     "dependencies": {
         "@turf/turf": "^7.1.0",

--- a/packages/transition-common/package.json
+++ b/packages/transition-common/package.json
@@ -16,7 +16,7 @@
     "test:sequential": "echo 'no tests to run for this workspace'",
     "test:ui": "echo 'no tests to run for this workspace'",
     "lint": "eslint .",
-    "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write"
   },
   "dependencies": {
     "@turf/turf": "^7.1.0",

--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -20,7 +20,7 @@
     "test:sequential": "echo 'cross-env NODE_ENV=test jest --config=jest.sequential.config.js --runInBand'",
     "test:ui": "LOCALE_DIR=$(pwd)/locales npx playwright test",
     "lint": "eslint .",
-    "format": "prettier-eslint $PWD/'src/**/*.{ts,tsx}' --write"
+    "format": "prettier-eslint \"./src/**/*.{ts,tsx}\" --write"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.1",


### PR DESCRIPTION
In macos, when there is no quotes around the prettier path, it ignores most files and will not fix formatting in several subdirectories. Using quotes seems to fix the issue.

In transition, there was PWD before the path with single quotes. This was removed and replaced with double quotes and should work fine now.