### PR TITLE
Do compression on generated zip

### DIFF
--- a/packages/transition-backend/src/services/gtfsExport/GtfsExporter.ts
+++ b/packages/transition-backend/src/services/gtfsExport/GtfsExporter.ts
@@ -52,7 +52,11 @@ const writeZipFile = async (
         zipper
             .generateNodeStream({
                 type: 'nodebuffer',
-                streamFiles: true
+                streamFiles: true,
+                compression: 'DEFLATE',
+                compressionOptions: {
+                    level: 9
+                }
             })
             .pipe(fs.createWriteStream(zipAbsoluteFilePath))
             .on('finish', () => {


### PR DESCRIPTION
The generate zip file for the GTFS export were not compressed. We need to pass explicit compression flags to the JSZip object when generating the file. We set it to max compression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * GTFS export ZIPs now use DEFLATE compression at maximum level, producing significantly smaller downloads and reduced storage usage; export interfaces unchanged (creation may be slightly slower for very large feeds).
* **Tests**
  * Added an integration test to verify export compression effectiveness and confirm expected feed files are included and intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->