### PR TITLE
Display number of selected nodes when editing nodes.

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -54,6 +54,7 @@
         "deleteSelectedNodes": "Delete unused selected nodes",
         "deleteSelectedPolygon": "Cancel selection",
         "editSelectedNodes": "Edit selected nodes",
+        "selectedNodesCount": "Selected editable nodes: {{count}}",
         "editFrozenSelectedNodesWarning": "only unfrozen nodes will be saved",
         "DeleteAllUnusedNodes": "Delete all unused nodes"
     },

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -54,6 +54,7 @@
         "deleteSelectedNodes": "Supprimer les noeuds sélectionnés et inutilisés",
         "deleteSelectedPolygon": "Annuler la sélection",
         "editSelectedNodes": "Modifier les noeuds sélectionnés",
+        "selectedNodesCount": "Noeuds sélectionnés modifiables: {{count}}",
         "editFrozenSelectedNodesWarning": "Seulement les noeuds non verrouillés seront sauvegardés",
         "DeleteAllUnusedNodes": "Supprimer tous les noeuds non utilisés"
     },

--- a/packages/transition-frontend/src/components/forms/node/TransitNodeCollectionEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/node/TransitNodeCollectionEdit.tsx
@@ -210,9 +210,11 @@ class TransitNodeCollectionEdit extends React.Component<
 
         return (
             <form id="tr__form-transit-node-multi" className="tr__form-transit-node-edit apptr__form">
-                <h3>
-                    {this.props.t('transit:transitNode:editSelectedNodes', { count: this.state.editableNodeCount })}
-                </h3>
+                <h3>{this.props.t('transit:transitNode:editSelectedNodes')}</h3>
+                <p>
+                    &nbsp;
+                    {this.props.t('transit:transitNode:selectedNodesCount', { count: this.state.editableNodeCount })}
+                </p>
                 <Collapsible trigger={this.props.t('form:basicFields')} open={true} transitionTime={100}>
                     <div className="tr__form-section">
                         {isFrozen !== true && (


### PR DESCRIPTION
Fix: #1414

<img width="692" height="616" alt="image" src="https://github.com/user-attachments/assets/dd4db406-a786-4865-a77b-984a51ba5c3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - The edit panel now shows the selected editable node count as a separate line beneath the header for clearer readability.
- Refactor
  - Header text no longer embeds the count; the count is displayed in a dedicated paragraph.
- Localization
  - Added English and French translations for the new “Selected editable nodes” text with dynamic count support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->