### PR TITLE
Toggle hide/show buttons of lines with parent agency.

### DIFF
--- a/packages/transition-frontend/src/components/forms/line/TransitLineButton.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineButton.tsx
@@ -26,6 +26,10 @@ const TransitLineButton: React.FunctionComponent<LineButtonProps> = (props: Line
     const [lineIsHidden, setLineIsHidden] = React.useState(props.lineIsHidden);
     const lineIsSelected = (props.selectedLine && props.selectedLine.getId() === props.line.getId()) || false;
 
+    React.useEffect(() => {
+        setLineIsHidden((prevState) => (prevState !== props.lineIsHidden ? props.lineIsHidden : prevState));
+    }, [props.lineIsHidden]);
+
     const onSelect: React.MouseEventHandler = async (e: React.MouseEvent) => {
         if (e) {
             e.stopPropagation();


### PR DESCRIPTION
When toggling the visibility of an agency by clicking the hide/show button, the buttons of the individual lines for that agency will also toggle.

Fix: #1470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Transit line visibility now stays in sync with external updates; show/hide icons on Transit Line buttons correctly reflect changes made elsewhere in the app, preventing stale or incorrect indicators.

- **Chores**
  - No changes to public APIs; internal behavior adjusted to improve UI consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->