### PR TITLE
Set Node 24 as the minimun version

### DIFF
--- a/.github/workflows/transition.yml
+++ b/.github/workflows/transition.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/examples/config.js
     steps:
@@ -56,7 +56,7 @@ jobs:
     - name: Use latest Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 22.x
+        node-version: 24.x
     - name: Install
       run: yarn install --frozen-lockfile
     - name: Yarn format

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -25,7 +25,7 @@ jobs:
           POSTGRES_DB: testdb
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
     env:
       PROJECT_CONFIG: ${{ github.workspace }}/.github/config-for-github-ui-tests.js
       PG_CONNECTION_STRING_PREFIX: postgres://testuser:testpassword@localhost:5432/

--- a/docs/setupDevEnvironmentUbuntu.md
+++ b/docs/setupDevEnvironmentUbuntu.md
@@ -106,7 +106,7 @@ sudo make install
 
 ## Install and setup node and yarn
 ```
-curl -sL https://deb.nodesource.com/setup_22.x | sudo bash -
+curl -sL https://deb.nodesource.com/setup_24.x | sudo bash -
 sudo apt-get install -y nodejs
 curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/packages/chaire-lib-backend/package.json
+++ b/packages/chaire-lib-backend/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
     },
     "name": "chaire-lib-backend",
     "version": "0.2.2",
@@ -83,7 +83,7 @@
         "@types/geojson": "^7946.0.16",
         "@types/jest": "^29.5.14",
         "@types/lodash": "^4.17.16",
-        "@types/node": "^22.15.3",
+        "@types/node": "^24.0.0",
         "@types/nodemailer": "^6.4.17",
         "@types/passport": "^1.0.17",
         "@types/passport-http-bearer": "^1.0.41",

--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "name": "chaire-lib-common",
   "version": "0.2.2",
@@ -43,7 +43,7 @@
     "@types/jest": "^29.5.14",
     "@types/kdbush": "^3.0.5",
     "@types/lodash": "^4.17.16",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.0",
     "@types/osmtogeojson": "^2.2.34",
     "@types/osrm": "^5.25.5",
     "@typescript-eslint/eslint-plugin": "^8.31.1",

--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "name": "chaire-lib-frontend",
   "version": "0.2.2",
@@ -65,7 +65,7 @@
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.16",
     "@types/mapbox-gl": "^2.3.1",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.0",
     "@types/osrm": "^5.25.5",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.2",

--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -1,6 +1,6 @@
 {
     "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
     },
     "name": "transition-backend",
     "version": "0.2.0-2",
@@ -77,7 +77,7 @@
         "@types/inquirer": "^8.2.1",
         "@types/jest": "^29.5.14",
         "@types/lodash": "^4.17.16",
-        "@types/node": "^22.15.3",
+        "@types/node": "^24.0.0",
         "@types/proj4": "^2.5.5",
         "@types/socketio-wildcard": "^2.0.7",
         "@types/workerpool": "^6.4.7",

--- a/packages/transition-common/package.json
+++ b/packages/transition-common/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "name": "transition-common",
   "version": "0.2.0-2",
@@ -36,7 +36,7 @@
     "@types/geokdbush": "^1.1.5",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.16",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
     "cross-env": "^7.0.3",

--- a/packages/transition-frontend/package.json
+++ b/packages/transition-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "name": "transition-frontend",
   "version": "0.2.0-2",
@@ -68,7 +68,7 @@
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.16",
     "@types/mapbox-gl": "^2.3.1",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.0",
     "@types/react-dom": "^19.0.2",
     "@types/react-mathjax": "^1.0.4",
     "@typescript-eslint/eslint-plugin": "^8.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,17 +3263,24 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.14.1", "@types/node@^22.15.3":
-  version "22.15.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.3.tgz#b7fb9396a8ec5b5dfb1345d8ac2502060e9af68b"
-  integrity sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^24.0.0":
+  version "24.5.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.5.2.tgz#52ceb83f50fe0fcfdfbd2a9fab6db2e9e7ef6446"
+  integrity sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.12.0"
 
 "@types/node@^14.14.20":
   version "14.18.63"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
   integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+
+"@types/node@^22.14.1":
+  version "22.18.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.6.tgz#38172ef0b65e09d1a4fc715eb09a7d5decfdc748"
+  integrity sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/nodemailer@^6.4.17":
   version "6.4.17"
@@ -12201,6 +12208,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~7.12.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.12.0.tgz#15c5c7475c2a3ba30659529f5cdb4674b622fafb"
+  integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
 
 unicorn-magic@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
To allow using the latest features and reduce the maintenance burden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Raised minimum Node.js requirement to 24 across all packages.
  - Updated CI to run exclusively on Node 24, removing Node 22 from all jobs (including UI tests and formatting checks).
- Documentation
  - Updated Ubuntu development setup instructions to install Node.js 24 and fixed end-of-file formatting.

Note: Developers must use Node.js 24+ to install, build, and run the project locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->