### PR TITLE
tests: fix `db.config` mock in `ServiceDuplicator` test

### DIFF
--- a/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceDuplicator.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceDuplicator.test.ts
@@ -14,15 +14,9 @@ import * as Status from 'chaire-lib-common/lib/utils/Status';
 // Mock the knex transaction object.
 const transactionObjectMock = new Object(3);
 
-jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => {
-    const originalModule =
-        jest.requireActual<typeof import('chaire-lib-backend/lib/config/shared/db.config')>('chaire-lib-backend/lib/config/shared/db.config');
-
-    return {
-        ...originalModule,
-        transaction: jest.fn().mockImplementation(async (callback) => await callback(transactionObjectMock))
-    };
-});
+jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => ({
+    transaction: jest.fn().mockImplementation(async (callback) => await callback(transactionObjectMock))
+}));
 
 // Mock the ServiceUtils module
 const defaultSuffix = '-0';

--- a/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceUtils.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/transitServices/__tests__/ServiceUtils.test.ts
@@ -13,15 +13,9 @@ import TrError from 'chaire-lib-common/lib/utils/TrError';
 // Mock the knex transaction object.
 const transactionObjectMock = new Object(3);
 
-jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => {
-    const originalModule =
-        jest.requireActual<typeof import('chaire-lib-backend/lib/config/shared/db.config')>('chaire-lib-backend/lib/config/shared/db.config');
-
-    return {
-        ...originalModule,
-        transaction: jest.fn().mockImplementation(async (callback) => await callback(transactionObjectMock))
-    };
-});
+jest.mock('chaire-lib-backend/lib/config/shared/db.config', () => ({
+    transaction: jest.fn().mockImplementation(async (callback) => await callback(transactionObjectMock))
+}));
 
 jest.mock('../../../../models/db/transitServices.db.queries', () => ({
     getServiceNamesStartingWith: jest.fn(),


### PR DESCRIPTION
The mock required the original module to only mock the `transaction` part, but the db.config is already mocked at the package level so should remained mocked, otherwise, we get a `database is not set` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified database transaction mocks in transit services test suites, replacing partial real-module mocks with minimal, focused mocks.
  * Improves test isolation, stability, and consistency across test runs.
  * No impact on production behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->