### PR TITLE
Allows users to reload the simple captcha

### DIFF
--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -36,6 +36,7 @@
   "forgotPasswordEmailConfirmation": "In the next few minutes, you will receive an email containing a link to reset your password.",
   "forgotPassword": "I forgot my password",
   "EnterCaptchaText": "Enter security code",
+  "ReloadCaptchaText": "Reload CAPTCHA",
   "captchaMismatch": "The CAPTCHA security code answer is wrong (the code is case sensitive).",
   "ConfirmationTokenConfirming": "New account confirmation in progress...",
   "ConfirmationTokenConfirmed": "The new account is now active!",

--- a/locales/fr/auth.json
+++ b/locales/fr/auth.json
@@ -36,6 +36,7 @@
   "forgotPasswordEmailConfirmation": "Dans les prochaines minutes, vous recevrez un courriel comportant un lien qui vous permettra de choisir un nouveau mot de passe.",
   "forgotPassword": "J'ai oublié mon mot de passe",
   "EnterCaptchaText": "Code de sécurité",
+  "ReloadCaptchaText": "Recharger le CAPTCHA",
   "captchaMismatch": "La réponse donnée au code de sécurité CAPTCHA est erronée (le code est sensible à la casse).",
   "ConfirmationTokenConfirming": "Confirmation du nouveau compte usager en cours...",
   "ConfirmationTokenConfirmed": "Le compte usager est maintenant activé!",

--- a/packages/chaire-lib-frontend/src/components/captcha/SimpleCaptcha.tsx
+++ b/packages/chaire-lib-frontend/src/components/captcha/SimpleCaptcha.tsx
@@ -6,8 +6,7 @@
  */
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-// FIXME Using the NoReload captcha (which can pose problems to users) because the "Reload Captcha" text is hardcoded in english. Switch when https://github.com/masroorejaz/react-simple-captcha/pull/2 is accepted
-import { loadCaptchaEnginge, LoadCanvasTemplateNoReload, validateCaptcha } from 'react-simple-captcha';
+import { loadCaptchaEnginge, LoadCanvasTemplate, validateCaptcha } from 'react-simple-captcha';
 import { CaptchaProps } from './CaptchaProps';
 
 export const CaptchaComponent: React.FunctionComponent<CaptchaProps> = (props: CaptchaProps) => {
@@ -35,7 +34,7 @@ export const CaptchaComponent: React.FunctionComponent<CaptchaProps> = (props: C
     return (
         <React.Fragment>
             <div>
-                <LoadCanvasTemplateNoReload />
+                <LoadCanvasTemplate reloadText={t('auth:ReloadCaptchaText')} />
             </div>
             <div className="apptr__form-input-container">
                 <label className="_flex">{t('auth:EnterCaptchaText')}</label>


### PR DESCRIPTION
Now that the simple captcha module allows for custom reload text, we enable the reload on the account creation page with translated text. 
Fix: #1412
<img width="434" height="242" alt="image" src="https://github.com/user-attachments/assets/53db7944-82e9-48f6-a371-e328d2762588" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for the CAPTCHA reload action.
  * Introduced English and French translations for the reload label.

* **Improvements**
  * CAPTCHA component now displays a clear, translated reload option, enhancing usability and accessibility for multilingual users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->