### PR TITLE
Pass an ExecutableJob object to batchRouting and batchAccessibility f…

### DIFF
--- a/packages/transition-backend/src/api/__tests__/services.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/services.socketRoutes.test.ts
@@ -239,7 +239,8 @@ describe('trRouting routes', () => {
 
     const transitAttributes = {
         minWaitingTimeSeconds: 180,
-        scenarioId: 'arbitrary'
+        scenarioId: 'arbitrary',
+        routingModes: ['walking']
     };
 
     test('Batch route correctly', (done) => {
@@ -261,6 +262,39 @@ describe('trRouting routes', () => {
             }));
             expect(mockedEnqueue).toHaveBeenCalledTimes(1);
             expect(mockedRefresh).toHaveBeenCalledTimes(1);  
+            done();
+        });
+    });
+
+    test('Batch route auto add walking', (done) => {
+        const transitAttributesOnlyTransit = {
+            minWaitingTimeSeconds: 180,
+            scenarioId: 'arbitrary',
+            routingModes: ['transit']
+        };
+
+        mockedGetDiskUsage.mockReturnValueOnce({ used: 100000, remaining: undefined });
+        mockedEnqueue.mockResolvedValueOnce(true);
+        mockedRefresh.mockResolvedValueOnce(true);
+        socketStub.emit(TrRoutingConstants.BATCH_ROUTE, demandParameters, transitAttributesOnlyTransit, (status) => {
+            expect(Status.isStatusOk(status));
+            expect(mockedJobCreate).toHaveBeenCalledTimes(1);
+            expect(mockedJobCreate).toHaveBeenCalledWith(expect.objectContaining({
+                name: 'batchRoute',
+                user_id: 1,
+                data: {
+                    parameters: {
+                        demandAttributes: demandParameters,
+                        transitRoutingAttributes: {
+                            minWaitingTimeSeconds: 180,
+                            scenarioId: 'arbitrary',
+                            routingModes: ['transit','walking']
+                        },
+                    }
+                }
+            }));
+            expect(mockedEnqueue).toHaveBeenCalledTimes(1);
+            expect(mockedRefresh).toHaveBeenCalledTimes(1);
             done();
         });
     });

--- a/packages/transition-common/src/services/jobs/Job.ts
+++ b/packages/transition-common/src/services/jobs/Job.ts
@@ -88,6 +88,11 @@ export class Job<TData extends JobDataType> {
         return this._attributes.name;
     }
 
+    /** Returns the numeric id */
+    get id(): number {
+        return this._attributes.id;
+    }
+
     /** Get the attributes without the status. To get the status, use the status
      * getter instead */
     get attributes(): Omit<JobAttributes<TData>, 'status'> {


### PR DESCRIPTION
…unction runners

Instead of having several parameters to manage for each functions, we pass a single job object and we fetch the data from there. This will allow us to encapsulate other aspect, like file access.

We change the unit test to load an actual ExecutableJob instead of just mock data via a mock of the db queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Jobs expose a numeric ID and provide helpers to detect/resolve input files; batch operations now accept a job object as the primary entry.
  - Batch routing auto-adds walking when transit is selected.

- **Bug Fixes**
  - Stricter input-file validation with clearer, consistent error reporting when inputs are missing or unavailable.

- **Refactor**
  - IO paths, configuration, progress reporting and checkpointing centralized on the job payload; result processing and worker flows use job-derived context.

- **Tests**
  - Tests migrated to job-driven flows with DB-driven setups, immutability checks, checkpointing and missing-input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->