### PR TITLE
Remove redundant call to prepareSocketRoutes

### DIFF
--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -19,8 +19,6 @@ import { JobDataType } from 'transition-common/lib/services/jobs/Job';
 import Users from 'chaire-lib-backend/lib/services/users/users';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 
-prepareSocketRoutes();
-
 function newProgressEmitter(task: ExecutableJob<JobDataType>) {
     const eventEmitter = new EventEmitter();
     eventEmitter.on('progress', (progressData: { name: string; customText?: string; progress: number }) => {


### PR DESCRIPTION
We had 2 calls to prepareSocketRoutes in TransitionWorkerPool. One in the body of the file and one in the run() function. The first one was not removed when the run() was created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted startup behavior so real-time routes are no longer prepared automatically on load; initialization now occurs only when explicitly triggered. No feature changes.
* **Chores**
  * Streamlined initialization sequence to improve predictability during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->