### PR TITLE
dep: replace `osmtogeojson` with `osm2geojson-lite`

### DIFF
--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -31,7 +31,7 @@
     "kdbush": "^3.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.7.0",
-    "osmtogeojson": "^3.0.0-beta.5",
+    "osm2geojson-lite": "^1.1.2",
     "papaparse": "^5.5.2",
     "pbf": "^3.3.0",
     "random": "^5.4.0",

--- a/packages/chaire-lib-common/src/utils/osm/OsmOverpassDownloader.ts
+++ b/packages/chaire-lib-common/src/utils/osm/OsmOverpassDownloader.ts
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import fetch from 'node-fetch';
-import osmToGeojson from 'osmtogeojson';
+import osmToGeojson from 'osm2geojson-lite';
 import fs from 'fs';
 import { pipeline } from 'node:stream/promises';
 import JSONStream from 'JSONStream';
@@ -166,12 +166,15 @@ class OsmOverpassDownloaderImpl implements OsmOverpassDownloader {
         return new Promise((resolve, reject) => {
             //If there is an error when reading the json object, reject the promise.
             jsonStream.on('error', (e) => {
-                console.error(e);
+                console.error('error in json stream', e);
                 reject(e);
             });
 
             jsonStream.on('data', (element) => {
-                const geojsonData = osmToGeojson({ elements: [element] });
+                const geojsonData = osmToGeojson(
+                    { elements: [element] },
+                    { completeFeature: true, renderTagged: true, excludeWay: false }
+                );
                 if (geojsonData.features.length > 0) {
                     const featuresString = JSON.stringify(geojsonData.features).slice(1, -1); // Remove the opening and closing brackets
                     const dataOk = writeStream.write((firstIteration ? '' : ',') + featuresString); //Write the comma first (except on the first iteration) so that there will be no trailing comma.

--- a/packages/chaire-lib-common/src/utils/osm/__tests__/OsmOverpassDownloader.test.ts
+++ b/packages/chaire-lib-common/src/utils/osm/__tests__/OsmOverpassDownloader.test.ts
@@ -108,19 +108,19 @@ const geojsonWritten = {
         {
             "type":"Feature",
             "id":"node/123",
-            "properties":{"timestamp":"2020-02-08T17:16:30Z","version":1,"changeset":1,"user":"osmUser","uid":1,"id":"node/123"},
+            "properties":{"id":"node/123","timestamp":"2020-02-08T17:16:30Z","version":1,"user":"osmUser","changeset":1,"uid":1},
             "geometry":{"type":"Point","coordinates":[-73.9678132,45.3941161]}
         },
         {
             "type":"Feature",
             "id":"node/234",
-            "properties":{"timestamp":"2020-02-08T17:16:30Z","version":1,"changeset":1,"user":"osmUser","uid":1,"id":"node/234"},
+            "properties":{"id":"node/234","timestamp":"2020-02-08T17:16:30Z","version":1,"user":"osmUser","changeset":1,"uid":1},
             "geometry":{"type":"Point","coordinates":[-73.9544677,45.3752717]}
         },
         {
             "type":"Feature",
             "id":"node/345",
-            "properties":{"timestamp":"2020-02-08T17:16:30Z","version":1,"changeset":1,"user":"osmUser","uid":1,"id":"node/345"},
+            "properties":{"id":"node/345","timestamp":"2020-02-08T17:16:30Z","version":1,"user":"osmUser","changeset":1,"uid":1},
             "geometry":{"type":"Point","coordinates":[-73.9545144,45.3751139]}
         }
 ]};

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,7 +851,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz#1da1e6b3a7add3ad29909b30f438f60581b7cd80"
   integrity sha1-HaHms6et060pkJsw9Dj2BYG3zYA=
 
-"@mapbox/geojson-rewind@0.5.2", "@mapbox/geojson-rewind@^0.5.0":
+"@mapbox/geojson-rewind@^0.5.0":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
   integrity sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==
@@ -3075,7 +3075,7 @@
     "@types/jsonfile" "*"
     "@types/node" "*"
 
-"@types/geojson@*", "@types/geojson@^7946.0", "@types/geojson@^7946.0.10", "@types/geojson@^7946.0.14", "@types/geojson@^7946.0.16", "@types/geojson@^7946.0.7":
+"@types/geojson@*", "@types/geojson@^7946.0.10", "@types/geojson@^7946.0.14", "@types/geojson@^7946.0.16", "@types/geojson@^7946.0.7":
   version "7946.0.16"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.16.tgz#8ebe53d69efada7044454e3305c19017d97ced2a"
   integrity sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
@@ -4053,11 +4053,6 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
 
-"@xmldom/xmldom@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.3.tgz#beaf980612532aa9a3004aff7e428943aeaa0711"
-  integrity sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4075,14 +4070,6 @@
   dependencies:
     async-retry "^1.3.1"
     debug "^3.1.0"
-
-JSONStream@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.0.tgz#efc462d5a5bc94ec007f4b22571acd7f6f2ae013"
-  integrity sha1-78Ri1aW8lOwAf0siVxrNf28q4BM=
-  dependencies:
-    jsonparse "0.0.5"
-    through "~2.2.7"
 
 JSONStream@^1.3.5:
   version "1.3.5"
@@ -5025,7 +5012,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-concat-stream@2.0.0, concat-stream@^2.0.0:
+concat-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
   integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
@@ -5620,13 +5607,6 @@ domexception@^4.0.0:
   dependencies:
     webidl-conversions "^7.0.0"
 
-domhandler@2.2:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.2.1.tgz#59df9dcd227e808b365ae73e1f6684ac3d946fc2"
-  integrity sha1-Wd+dzSJ+gIs2Wuc+H2aErD2Ub8I=
-  dependencies:
-    domelementtype "1"
-
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
@@ -5640,13 +5620,6 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
-
-domutils@1.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.3.0.tgz#9ad4d59b5af6ca684c62fe6d768ef170e70df192"
-  integrity sha1-mtTVm1r2ymhMYv5tdo7xcOcN8ZI=
-  dependencies:
-    domelementtype "1"
 
 domutils@^1.5.1:
   version "1.7.0"
@@ -6614,14 +6587,6 @@ geojson-flatten@^1.0.4:
     get-stdin "^7.0.0"
     minimist "^1.2.5"
 
-geojson-numeric@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/geojson-numeric/-/geojson-numeric-0.2.1.tgz#2c8c032f792cca0747a6e02ffa86c00ee3d2df6c"
-  integrity sha512-rvItMp3W7pe16o2EQTnRw54v6WHdiE4bYjUsdr3FZskFb6oPC7gjLe4zginP+Wd1B/HLl2acTukfn16Lmwn7lg==
-  dependencies:
-    concat-stream "2.0.0"
-    optimist "~0.3.5"
-
 geojson-polygon-self-intersections@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.1.tgz#7018edabe58e9262f20821a7334953708c78bbb7"
@@ -7031,16 +6996,6 @@ html-webpack-plugin@^5.6.3:
     lodash "^4.17.21"
     pretty-error "^4.0.0"
     tapable "^2.0.0"
-
-htmlparser2@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.5.1.tgz#6f42f7657dd19c13f7d65de9118417394a0be6d0"
-  integrity sha1-b0L3ZX3RnBP31l3pEYQXOUoL5tA=
-  dependencies:
-    domelementtype "1"
-    domhandler "2.2"
-    domutils "1.3"
-    readable-stream "1.1"
 
 htmlparser2@^3.9.0:
   version "3.10.1"
@@ -8191,11 +8146,6 @@ jsonfile@^6.0.1:
     universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonparse@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-0.0.5.tgz#330542ad3f0a654665b778f3eb2d9a9fa507ac64"
-  integrity sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -9537,13 +9487,6 @@ opentelemetry-instrumentation-socket.io@^0.34.0:
     "@opentelemetry/semantic-conventions" "^1.8.0"
     is-promise "^4.0.0"
 
-optimist@~0.3.5:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.7.tgz#c90941ad59e4273328923074d2cf2e7cbc6ec0d9"
-  integrity sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=
-  dependencies:
-    wordwrap "~0.0.2"
-
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -9576,27 +9519,12 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osm-polygon-features@^0.9.1:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/osm-polygon-features/-/osm-polygon-features-0.9.2.tgz#20ae41130c486e49a3b2a3c2b58a1419c4986778"
-  integrity sha1-IK5BEwxIbkmjsqPCtYoUGcSYZ3g=
-
-osmtogeojson@^3.0.0-beta.5:
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/osmtogeojson/-/osmtogeojson-3.0.0-beta.5.tgz#c58ed8e4fb3a82a41cf3f00cbe79991e17e028b6"
-  integrity sha512-izvaUWnunrYvMB4LB0ZN15O1+g90c628yHS4SeSR3daVSBF9vdTHL7iVHfg0wEr1uEYjQ+lMJHCiYFusL5yKVg==
-  dependencies:
-    "@mapbox/geojson-rewind" "0.5.2"
-    "@xmldom/xmldom" "0.8.3"
-    JSONStream "0.8.0"
-    concat-stream "2.0.0"
-    geojson-numeric "0.2.1"
-    htmlparser2 "3.5.1"
-    optimist "~0.3.5"
-    osm-polygon-features "^0.9.1"
-    tiny-osmpbf "^0.1.0"
+osm2geojson-lite@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/osm2geojson-lite/-/osm2geojson-lite-1.1.2.tgz#5c16b98e882b97041d3a5604f06bf5cfb619f286"
+  integrity sha512-6s1uW548fdyLTJ4Cp/hQTKvdgCl/E8nUvBMEzUXnAJPHAFHoIhwMqZ3KGdph2A1g48rsCeA6gVnkPruWGiwupw==
   optionalDependencies:
-    "@types/geojson" "^7946.0"
+    "@types/geojson" "^7946.0.16"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -9901,7 +9829,7 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
 
-pbf@^3.0.4, pbf@^3.0.5, pbf@^3.2.1, pbf@^3.3.0:
+pbf@^3.0.5, pbf@^3.2.1, pbf@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.3.0.tgz#1790f3d99118333cc7f498de816028a346ef367f"
   integrity sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==
@@ -10659,16 +10587,6 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
-
-readable-stream@1.1:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.13.tgz#f6eef764f514c89e2b9e23146a75ba106756d23e"
-  integrity sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.2:
   version "3.6.2"
@@ -11855,11 +11773,6 @@ through@2, through@2.3.x, "through@>=2.2.7 <3", through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-through@~2.2.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
-  integrity sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=
-
 tildify@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
@@ -11869,19 +11782,6 @@ timezone@^1.0.23:
   version "1.0.23"
   resolved "https://registry.yarnpkg.com/timezone/-/timezone-1.0.23.tgz#87865e2c9d6aff6a52a598247e8f5102a92c881b"
   integrity sha512-yhQgk6qmSLB+TF8HGmApZAVI5bfzR1CoKUGr+WMZWmx75ED1uDewAZA8QMGCQ70TEv4GmM8pDB9jrHuxdaQ1PA==
-
-tiny-inflate@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
-  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
-
-tiny-osmpbf@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-osmpbf/-/tiny-osmpbf-0.1.0.tgz#0a895717113ebe6aae363c4be5eefa8ecdafb927"
-  integrity sha1-ColXFxE+vmquNjxL5e76js2vuSc=
-  dependencies:
-    pbf "^3.0.4"
-    tiny-inflate "^1.0.2"
 
 tinycolor2@^1.4.1:
   version "1.4.1"
@@ -12687,11 +12587,6 @@ word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-  integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
 workerpool@^6.5.1:
   version "6.5.1"


### PR DESCRIPTION
fixes #1364

This is a drop-in replacement of the original package, with less dependencies and more supported.

While the geojson generated is a bit different, the differences mostly reside in how it handles relations. `osmtogeojson` would create the features for each feature of the relation, creating duplicates in the content, while `osmtogeojson-lite` will create a node where the relation happens and a single feature for the relation itself.

For our use cases, that difference in geojson output does not pose problems. Our import scripts and usages give the same results as previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved completeness and accuracy when converting OSM data to GeoJSON, reducing missing or incomplete features.
  - Enhanced error logging during data streaming for clearer diagnostics.

- Tests
  - Updated expectations to reflect non-functional JSON property ordering changes.

- Chores
  - Swapped the OSM-to-GeoJSON converter dependency for a lighter, more robust alternative to improve reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->