### PR TITLE
Refactor accessibility map polygon generation to use postgis functions

### DIFF
--- a/packages/transition-backend/package.json
+++ b/packages/transition-backend/package.json
@@ -58,7 +58,6 @@
         "papaparse": "^5.5.2",
         "passport": "^0.7.0",
         "pbf": "^3.3.0",
-        "polygon-clipping": "^0.15.7",
         "proj4": "^2.15.0",
         "random": "^5.4.0",
         "serve-favicon": "^2.5.0",

--- a/packages/transition-backend/src/models/db/__tests__/geometryUtils.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/geometryUtils.db.test.ts
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import { clipPolygon } from '../geometryUtils.db.queries';
+
+/**
+ * Integration tests for geometry utility functions using live PostgreSQL/PostGIS database
+ */
+
+beforeAll(async () => {
+    jest.setTimeout(30000);
+});
+
+afterAll(async () => {
+    await knex.destroy();
+});
+
+describe('clipPolygon', () => {
+
+    test('should return empty array for empty circles input', async () => {
+        const circles: Array<{ center: [number, number]; radiusKm: number }> = [];
+        const result = await clipPolygon(circles);
+
+        expect(result).toEqual([]);
+    });
+
+    test('should generate valid polygon coordinates for single circle', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Should return MultiPolygon coordinates array
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBe(1); // One polygon in MultiPolygon
+
+        // Check structure: MultiPolygon -> Polygon -> Ring -> Points
+        const polygon = result[0];
+        expect(Array.isArray(polygon)).toBe(true);
+        expect(polygon.length).toBeGreaterThan(0);
+
+        const ring = polygon[0]; // Exterior ring
+        expect(Array.isArray(ring)).toBe(true);
+
+        // With quad_segs=6, should have 25 points (24 segments + 1 closure)
+        expect(ring.length).toBe(25);
+
+        // First and last coordinates should be identical (closed ring)
+        expect(ring[0][0]).toBeCloseTo(ring[ring.length - 1][0], 10);
+        expect(ring[0][1]).toBeCloseTo(ring[ring.length - 1][1], 10);
+
+        // Verify coordinates are numbers in valid range
+        ring.forEach((coord: number[]) => {
+            expect(coord.length).toBe(2);
+            expect(typeof coord[0]).toBe('number'); // longitude
+            expect(typeof coord[1]).toBe('number'); // latitude
+            expect(coord[0]).toBeGreaterThan(-180);
+            expect(coord[0]).toBeLessThan(180);
+            expect(coord[1]).toBeGreaterThan(-90);
+            expect(coord[1]).toBeLessThan(90);
+        });
+
+        // Verify exact values of the coordinates
+        ring.forEach((coord: number[]) => {
+            expect(coord[0]).toBeGreaterThan(-73.5064);
+            expect(coord[0]).toBeLessThan(-73.4936);
+            expect(coord[1]).toBeGreaterThan(45.4955);
+            expect(coord[1]).toBeLessThan(45.5045);
+        });
+    });
+
+    test('should merge overlapping circles into single polygon', async () => {
+        // Two circles with significant overlap
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 },
+            { center: [-73.505, 45.505] as [number, number], radiusKm: 0.5 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Should merge into 1 polygon
+        expect(result.length).toBe(1);
+        expect(Array.isArray(result[0])).toBe(true);
+        expect(result[0].length).toBeGreaterThan(0);
+
+        // Merged polygon should have more points than a simple circle
+        const ring = result[0][0];
+        expect(ring.length).toBeGreaterThan(25); // More than single circle's 25 points
+    });
+
+    test('should keep non-overlapping circles as separate polygons', async () => {
+        // Three circles far apart
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.2 },
+            { center: [-73.6, 45.6] as [number, number], radiusKm: 0.2 },
+            { center: [-73.7, 45.7] as [number, number], radiusKm: 0.2 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Should have 3 separate polygons
+        expect(result.length).toBe(3);
+
+        // Each polygon should be valid
+        result.forEach((polygon: number[][][]) => {
+            expect(Array.isArray(polygon)).toBe(true);
+            expect(polygon.length).toBeGreaterThan(0);
+
+            const ring = polygon[0];
+            expect(ring.length).toBe(25); // Each circle should have 25 points
+        });
+    });
+
+    test('should handle multiple circles with partial overlaps', async () => {
+        // At latitude 45, 1 degree longitude ≈ 78.8 km
+        // So 0.01 degrees ≈ 788m, 0.005 degrees ≈ 394m, 0.003 degrees ≈ 236m
+        // For 300m radius circles to overlap, they need to be < 600m apart
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.3 },
+            { center: [-73.503, 45.5] as [number, number], radiusKm: 0.3 },  // ~236m apart, will overlap
+            { center: [-73.506, 45.5] as [number, number], radiusKm: 0.3 }   // ~236m from second, will overlap
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Three overlapping circles should merge into 1 polygon
+        expect(result.length).toBe(1);
+        expect(Array.isArray(result[0])).toBe(true);
+
+        // Verify the merged polygon is valid
+        const ring = result[0][0];
+        expect(Array.isArray(ring)).toBe(true);
+        expect(ring.length).toBeGreaterThan(0);
+    });
+
+    test('should handle circles with different radii', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 1.0 },
+            { center: [-73.502, 45.501] as [number, number], radiusKm: 0.2 }, // ~220m from center, inside 1km circle
+            { center: [-73.53, 45.53] as [number, number], radiusKm: 0.5 }  // ~3km away, separate
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Small circle inside large merges, medium circle separate = 2 polygons
+        expect(result.length).toBe(2);
+
+        // Verify both polygons are valid
+        result.forEach((polygon: number[][][]) => {
+            expect(Array.isArray(polygon)).toBe(true);
+            expect(polygon.length).toBeGreaterThan(0);
+            expect(polygon[0].length).toBeGreaterThan(0);
+        });
+    });
+
+    test('should handle many circles efficiently', async () => {
+        // Generate 50 circles in a pattern
+        const circles: Array<{ center: [number, number]; radiusKm: number }> = [];
+        for (let i = 0; i < 5; i++) {
+            for (let j = 0; j < 10; j++) {
+                circles.push({
+                    center: [-73.5 + i * 0.01, 45.5 + j * 0.01] as [number, number],
+                    radiusKm: 0.3
+                });
+            }
+        }
+
+        const startTime = Date.now();
+        const result = await clipPolygon(circles);
+        const duration = Date.now() - startTime;
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBeGreaterThan(0);
+
+        console.log(`Processed ${circles.length} circles in ${duration}ms`);
+        console.log(`Result: ${result.length} polygon(s)`);
+    });
+
+    test('should handle circles near coordinate boundaries', async () => {
+        const circles = [
+            { center: [-179.5, 85] as [number, number], radiusKm: 0.5 },  // Near north pole
+            { center: [179.5, -85] as [number, number], radiusKm: 0.5 },  // Near south pole
+            { center: [0, 0] as [number, number], radiusKm: 0.5 }          // Equator/prime meridian
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Should have 3 separate polygons
+        expect(result.length).toBe(3);
+
+        // Verify all are valid
+        result.forEach((polygon: number[][][]) => {
+            expect(Array.isArray(polygon)).toBe(true);
+            const ring = polygon[0];
+            expect(ring.length).toBe(25);
+        });
+    });
+
+    test('should handle very small circles', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.01 } // 10m radius
+        ];
+
+        const result = await clipPolygon(circles);
+
+        expect(result.length).toBe(1);
+        expect(result[0][0].length).toBe(25);
+    });
+
+    test('should handle very large circles', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 10 } // 10km radius
+        ];
+
+        const result = await clipPolygon(circles);
+
+        expect(result.length).toBe(1);
+        expect(result[0][0].length).toBe(25);
+
+        // Verify the circle is actually large
+        const ring = result[0][0];
+        const firstPoint = ring[0];
+
+        // Should be significantly offset from center
+        expect(Math.abs(firstPoint[0] - (-73.5))).toBeGreaterThan(0.05);
+    });
+
+    test('should produce consistent results for same input', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 },
+            { center: [-73.6, 45.6] as [number, number], radiusKm: 0.3 }
+        ];
+
+        const result1 = await clipPolygon(circles);
+        const result2 = await clipPolygon(circles);
+
+        expect(result1.length).toBe(result2.length);
+
+        // Coordinates should be identical (or very close due to floating point)
+        result1.forEach((polygon1: number[][][], idx: number) => {
+            const polygon2 = result2[idx];
+            expect(polygon1.length).toBe(polygon2.length);
+
+            polygon1[0].forEach((coord1: number[], coordIdx: number) => {
+                const coord2 = polygon2[0][coordIdx];
+                expect(coord1[0]).toBeCloseTo(coord2[0], 10);
+                expect(coord1[1]).toBeCloseTo(coord2[1], 10);
+            });
+        });
+    });
+
+    test('should verify geometry can be used in PostGIS queries', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Create a MultiPolygon GeoJSON and verify it's valid in PostGIS
+        const multiPolygon = {
+            type: 'MultiPolygon',
+            coordinates: result
+        };
+
+        const validation = await knex.raw(`
+            SELECT
+                ST_IsValid(ST_GeomFromGeoJSON(?)) as is_valid,
+                ST_GeometryType(ST_GeomFromGeoJSON(?)) as geom_type,
+                ST_Area(ST_GeomFromGeoJSON(?)::geography) as area_sqm
+        `, [JSON.stringify(multiPolygon), JSON.stringify(multiPolygon), JSON.stringify(multiPolygon)]);
+
+        expect(validation.rows[0].is_valid).toBe(true);
+        expect(validation.rows[0].geom_type).toBe('ST_MultiPolygon');
+
+        const areaSqM = parseFloat(validation.rows[0].area_sqm);
+        // Area should be approximately π * 500²
+        const expectedArea = Math.PI * 500 * 500;
+        expect(areaSqM).toBeGreaterThan(expectedArea * 0.95);
+        expect(areaSqM).toBeLessThan(expectedArea * 1.05);
+    });
+
+    test('should handle concurrent calls without conflicts', async () => {
+        const circles1 = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 }
+        ];
+        const circles2 = [
+            { center: [-73.6, 45.6] as [number, number], radiusKm: 0.3 }
+        ];
+        const circles3 = [
+            { center: [-73.7, 45.7] as [number, number], radiusKm: 0.4 }
+        ];
+
+        // Call multiple times in parallel
+        const results = await Promise.all([
+            clipPolygon(circles1),
+            clipPolygon(circles2),
+            clipPolygon(circles3)
+        ]);
+
+        // All should succeed
+        expect(results.length).toBe(3);
+        results.forEach((result) => {
+            expect(Array.isArray(result)).toBe(true);
+            expect(result.length).toBe(1);
+        });
+    });
+
+    test('should handle transaction properly and clean up temp tables', async () => {
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 }
+        ];
+
+        // Execute multiple times
+        await clipPolygon(circles);
+        await clipPolygon(circles);
+        await clipPolygon(circles);
+
+        // Check that no temp tables are left behind
+        // Note: temp tables auto-drop on commit, so there should be none or very few
+        const tempTables = await knex.raw(`
+            SELECT COUNT(*) as count
+            FROM pg_tables
+            WHERE schemaname LIKE 'pg_temp%'
+            AND tablename LIKE 'temp_circles_%'
+        `);
+
+        // Should be 0
+        expect(parseInt(tempTables.rows[0].count)).toBe(0);
+    });
+
+    test.todo('should throw error when db connection fails');
+
+    test('should handle circle at origin coordinates', async () => {
+        const circles = [
+            { center: [0, 0] as [number, number], radiusKm: 0.5 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        expect(result.length).toBe(1);
+        expect(result[0][0].length).toBe(25);
+
+        // Verify center is roughly at origin
+        const ring = result[0][0];
+        const avgLon = ring.reduce((sum: number, coord: number[]) => sum + coord[0], 0) / ring.length;
+        const avgLat = ring.reduce((sum: number, coord: number[]) => sum + coord[1], 0) / ring.length;
+
+        expect(avgLon).toBeCloseTo(0, 2);
+        expect(avgLat).toBeCloseTo(0, 2);
+    });
+
+    test('should throw error for invalid coordinates', async () => {
+        // Test error handling by passing invalid data that would cause DB error
+        // For example, NaN or invalid coordinates
+        const invalidCircles = [
+            { center: [NaN, 45.5] as [number, number], radiusKm: 0.5 }
+        ];
+
+        await expect(clipPolygon(invalidCircles)).rejects.toThrow();
+    });
+
+    test('should handle circles that touch but do not overlap', async () => {
+        // Two circles with 0.5km radius each
+        // At latitude 45.5°, 1 degree longitude ≈ 78.8 km
+        // For circles to touch: distance = 2 * radius = 1.0 km
+        // In degrees: 1.0 / 78.8 ≈ 0.0127 degrees
+        const circles = [
+            { center: [-73.5, 45.5] as [number, number], radiusKm: 0.5 },
+            { center: [-73.5 + 0.0127, 45.5] as [number, number], radiusKm: 0.5 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Touching circles might merge into 1 polygon or stay as 2, depending on precision
+        expect(result.length).toBeGreaterThanOrEqual(1);
+        expect(result.length).toBeLessThanOrEqual(2);
+    });
+
+    test('should maintain precision for coordinates', async () => {
+        const circles = [
+            { center: [-73.123456789, 45.987654321] as [number, number], radiusKm: 0.5 }
+        ];
+
+        const result = await clipPolygon(circles);
+
+        // Check that coordinates have reasonable precision (not excessive decimals)
+        const ring = result[0][0];
+        ring.forEach((coord: number[]) => {
+            // Coordinates should have precision but not be excessive
+            const lonStr = coord[0].toString();
+            const latStr = coord[1].toString();
+
+            // Should have decimal places
+            expect(lonStr).toContain('.');
+            expect(latStr).toContain('.');
+
+            // But not more than ~15 decimal places (reasonable for float64)
+            expect(lonStr.length).toBeLessThan(25);
+            expect(latStr.length).toBeLessThan(25);
+        });
+    });
+});

--- a/packages/transition-backend/src/models/db/geometryUtils.db.queries.ts
+++ b/packages/transition-backend/src/models/db/geometryUtils.db.queries.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/* This file contains geometry operations that uses postgis queries instead
+   of code libraries */
+
+import knex from 'chaire-lib-backend/lib/config/shared/db.config';
+import { randomUUID } from 'crypto';
+
+export async function clipPolygon(circles: Array<{ center: [number, number]; radiusKm: number }>): Promise<any> {
+    if (circles.length === 0) {
+        return [];
+    }
+
+    try {
+        return await knex.transaction(async (trx) => {
+            // Set higher work memory, with the default 4M, the request were swapping
+            // to disk. Given them 5 times that seems to work well and still
+            // safe when doing many requests in parallel.
+            await trx.raw(`
+                   SET LOCAL work_mem = '20MB';
+                   SET LOCAL maintenance_work_mem = '20MB';
+                `);
+
+            // Generate unique table name to prevent conflicts in parallel execution
+            // UUID ensures no name clashes even with same-session parallel calls
+            const uniqueId = randomUUID().replace(/-/g, '_').substring(0, 16);
+            const tableName = `temp_circles_${uniqueId}`;
+            const indexName = `idx_circles_${uniqueId}`;
+
+            // Prepare values for bulk insert
+            const valuePlaceholders: string[] = [];
+            const bindings: number[] = [];
+
+            circles.forEach((circle) => {
+                valuePlaceholders.push('(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)');
+                bindings.push(circle.center[0], circle.center[1], circle.radiusKm * 1000);
+            });
+
+            // Create temp table and generate circles in one go
+            /**
+             * Ajusting the quad_segs will have an impact on speed and precision.
+             * quad_segs is the number of segment to approximate a quarter of a circle.
+             * See https://postgis.net/docs/ST_Buffer.html for more details.
+             *
+             * PostGIS ST_Buffer Precision for 500m Radius Circles (1km diameter)
+             * Formula: max_error = radius × (1 - cos(π/n)) where n = quad_segs × 4
+             *
+             * quad_segs | segments | points | max_error | area_accuracy
+             * ----------|----------|--------|-----------|---------------
+             *     1     |    4     |   5    |  146.4m   |    63.7%
+             *     2     |    8     |   9    |   38.1m   |    90.0%
+             *     3     |   12     |  13    |   17.0m   |    95.5%
+             *     4     |   16     |  17    |    9.6m   |    97.5%
+             *     5     |   20     |  21    |    6.1m   |    98.4%
+             *     6     |   24     |  25    |    4.3m   |    98.9%
+             *     8     |   32     |  33    |    2.4m   |    99.5%
+             *    12     |   48     |  49    |    1.1m   |    99.8%
+             *    16     |   64     |  65    |    0.6m   |    99.9%
+             *    20     |   80     |  81    |    0.4m   |    99.9%
+             *    32     |  128     |  129   |    0.15m  |    99.99%
+             *
+             * Performance: Higher quad_segs = more vertices = slower processing
+             * quad_segs=12 is ~4x slower than quad_segs=3
+             *
+             * For variable radius: error scales proportionally with radius
+             * Example: 1000m radius with quad_segs=12 → 2.2m error (1.1m × 1000/500)
+             *
+             * Formula: error ≈ radius × (1 - cos(π/(quad_segs×4)))
+             */
+            // Based on the table above, we chose a quad_seg of 6, which give a max_error of
+            // about 4 meters
+            await trx.raw(
+                `
+                CREATE TEMPORARY TABLE ?? ON COMMIT DROP AS
+                    SELECT
+                        ROW_NUMBER() OVER () as id,
+                        center_point,
+                        radius_meters,
+                        ST_Buffer(
+                            center_point::geography,
+                            radius_meters::double precision,
+                            'quad_segs=6'
+                        )::geometry as circle_geom
+                    FROM (VALUES ${valuePlaceholders.join(',\n')}) AS t(center_point, radius_meters)
+                `,
+                [tableName, ...bindings]
+            );
+
+            // Create spatial index
+            await trx.raw('CREATE INDEX ?? ON ?? USING GIST (circle_geom)', [indexName, tableName]);
+
+            // Update statistics for optimal query planning
+            await trx.raw('ANALYZE ??', [tableName]);
+
+            const result = await trx.raw(
+                `
+                SELECT ST_AsGeoJSON(
+                    ST_MULTI(
+                        ST_Union(circle_geom ORDER BY id)
+                    )
+                ) AS geometry_json
+                FROM ??
+                `,
+                [tableName]
+            );
+
+            if (result.rows && result.rows.length > 0 && result.rows[0].geometry_json) {
+                const geometry = JSON.parse(result.rows[0].geometry_json);
+
+                if (geometry.type === 'MultiPolygon') {
+                    return geometry.coordinates;
+                }
+
+                console.error('[PostGIS] Unexpected geometry type:', geometry.type);
+                return [];
+            }
+
+            console.error('[PostGIS] No geometry returned');
+            return [];
+        });
+    } catch (error) {
+        console.error('Error in PostGIS polygon generation:', error);
+        throw error;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9968,7 +9968,7 @@ point-in-polygon@^1.1.0:
   resolved "https://registry.yarnpkg.com/point-in-polygon/-/point-in-polygon-1.1.0.tgz#b0af2616c01bdee341cbf2894df643387ca03357"
   integrity sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==
 
-polygon-clipping@^0.15.3, polygon-clipping@^0.15.7:
+polygon-clipping@^0.15.3:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/polygon-clipping/-/polygon-clipping-0.15.7.tgz#3823ca1e372566f350795ce9dd9a7b19e97bdaad"
   integrity sha512-nhfdr83ECBg6xtqOAJab1tbksbBAOMUltN60bU+llHVOL0e5Onm1WpAXXWXVB39L8AJFssoIhEVuy/S90MmotA==


### PR DESCRIPTION
Our accessibility map generate was taking a log of time. They were using turf function in javascript which are not the best performing options.

This change the code to store the result in a temporary postgis table and merge the circle via St_Union.

We also took the opportunity to reduce the circule precision and increase performance by lowering the quad_segs parameter. A full analysis is available in comment in the code.

With these changes, we go from about 18s for a polygon generation to less than 3s. (For a point near Polytechnique Montreal, with an STM GTFS.)

The unit test we redone with Claude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Polygon generation now uses a database-backed path for unioning/clipping circles; progress reporting preserved.
- New Features
  - Added a DB-backed polygon clipping utility that returns MultiPolygon results from circle inputs.
- Bug Fixes
  - Better handling of empty/single-node results, deterministic temp-table behavior, and clearer error handling when polygon generation fails.
- Tests
  - Expanded unit and integration tests covering DB-backed clipping, multi/single-polygon cases, edge conditions, concurrency, and error paths.
- Chores
  - Removed an unused polygon-clipping dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->