### PR TITLE
Remove error on starting batch accessibility map

### DIFF
--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -173,8 +173,8 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
             const routingResult: any = await BatchAccessibilityMapCalculator.calculate(this.state.object);
             this.setState({
                 batchRoutingInProgress: false,
-                errors: routingResult.errors,
-                warnings: routingResult.warnings
+                errors: routingResult?.errors ?? [],
+                warnings: routingResult?.warnings ?? []
             });
         } catch (error) {
             this.setState({


### PR DESCRIPTION
We had this error when we started a new batch accessiblity map calculation: TypeError: Cannot read properties of undefined (reading 'errors')

Change is to use optional chaining and provides an empty array as fallback for errors and warnings which might not be yet present in the routingResult when we just create the job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the accessibility map batch form to prevent crashes and ensure warnings/errors are handled safely during batch calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->