### PR TITLE
Display an error message at start of test:sequential if json2capnp is…

### DIFF
--- a/packages/transition-backend/jest.sequential.config.js
+++ b/packages/transition-backend/jest.sequential.config.js
@@ -16,5 +16,6 @@ const baseConfig = require('../../tests/jest.config.base');
 // Run the db and integration tests
 module.exports = {
     ...baseConfig,
-    'testRegex': ['(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$','(/__tests__/.*(integration\\.test)\\.(jsx?|tsx?))$']
+    'testRegex': ['(/__tests__/.*(db\\.test)\\.(jsx?|tsx?))$','(/__tests__/.*(integration\\.test)\\.(jsx?|tsx?))$'],
+    globalSetup: '<rootDir>/jest.sequential.setup.js'
 };

--- a/packages/transition-backend/jest.sequential.setup.js
+++ b/packages/transition-backend/jest.sequential.setup.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * Global setup for sequential tests that require the json2capnp service
+ */
+
+function displayJson2CapnpError(host, port, reason = 'not running') {
+    console.error('\n' + '='.repeat(80));
+    console.error(`ERROR: json2capnp service is ${reason}!`);
+    console.error('='.repeat(80));
+    console.error('\nThe sequential tests require the json2capnp rust server to be started.');
+    console.error('\nTo start the service, run the following commands:');
+    console.error('  cd services/json2capnp');
+    console.error('  cargo run 2000 ../../projects/test/test_cache/test');
+    console.error('\nOr in a single command from the project root:');
+    console.error('  (cd services/json2capnp && cargo run 2000 ../../projects/test/test_cache/test)');
+    console.error(`\nExpected service location: ${host}:${port}`);
+    console.error('\n' + '='.repeat(80) + '\n');
+}
+
+module.exports = async () => {
+    const http = require('http');
+    const Preferences = require('chaire-lib-common/lib/config/Preferences').default;
+
+    // Get json2capnp configuration
+    const json2CapnpConfig = Preferences.get('json2Capnp', {
+        host: 'http://localhost',
+        port: 2000
+    });
+
+    const host = json2CapnpConfig.host.replace(/^https?:\/\//, '');
+    const port = json2CapnpConfig.port;
+
+    console.log(`\nChecking if json2capnp service is running at ${host}:${port}...`);
+
+    return new Promise((resolve, reject) => {
+        const request = http.get({
+            hostname: host,
+            port: port,
+            path: '/',
+            timeout: 2000
+        }, (res) => {
+            console.log('✓ json2capnp service is running');
+            resolve();
+        });
+
+        request.on('error', (err) => {
+            displayJson2CapnpError(host, port, 'not running');
+            reject(new Error(`json2capnp service is not available at ${host}:${port}`));
+        });
+
+        request.on('timeout', () => {
+            request.destroy();
+            displayJson2CapnpError(host, port, 'not responding (timeout)');
+            reject(new Error(`json2capnp service connection timeout at ${host}:${port}`));
+        });
+    });
+};


### PR DESCRIPTION
… not running

This will display that error message:

================================================================================ ERROR: json2capnp service is not running!
================================================================================

The sequential tests require the json2capnp rust server to be started.

To start the service, run the following commands:
  cd services/json2capnp
  cargo run 2000 ../../projects/test/test_cache/test

Or in a single command from the project root:
  (cd services/json2capnp && cargo run 2000 ../../projects/test/test_cache/test)

Expected service location: localhost:2000

================================================================================

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Introduced automatic validation of external service connectivity before sequential tests execute, identifying issues at configuration time
- Added comprehensive error messages and actionable troubleshooting guidance including service startup commands and expected host/port information
- Enhanced test configuration with improved timeout handling and automatic defaults to increase reliability during test execution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->