### PR TITLE
batchRoute: handle results through a result visitor

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/BatchRoutingJob.ts
+++ b/packages/transition-backend/src/services/transitRouting/BatchRoutingJob.ts
@@ -7,6 +7,7 @@
 import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import { OdTripRouteResult } from './types';
 
 export type BatchRouteJobType = {
     name: 'batchRoute';
@@ -19,3 +20,9 @@ export type BatchRouteJobType = {
     };
     files: { input: true; csv: true; detailedCsv: true; geojson: true };
 };
+
+export interface BatchRouteResultVisitor<TReturnType> {
+    visitTripResult: (routingResult: OdTripRouteResult) => Promise<void>;
+    end: () => void;
+    getResult: () => TReturnType;
+}

--- a/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/BatchRouteFileResultVisitor.ts
+++ b/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/BatchRouteFileResultVisitor.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { ExecutableJob } from '../../executableJob/ExecutableJob';
+import { BatchRouteJobType, BatchRouteResultVisitor } from '../BatchRoutingJob';
+import { OdTripRouteResult } from '../types';
+import { createRoutingFileResultProcessor, generateFileOutputResults } from './TrRoutingBatchResult';
+import PathCollection from 'transition-common/lib/services/path/PathCollection';
+import pathDbQueries from '../../../models/db/transitPaths.db.queries';
+
+// Example concrete visitor for file generation
+export class BatchRouteFileResultVisitor
+implements
+        BatchRouteResultVisitor<{ files: { input: string; csv?: string; detailedCsv?: string; geojson?: string } }> {
+    private resultHandler = createRoutingFileResultProcessor(this.job);
+    private pathCollection: PathCollection | undefined | false = false;
+
+    constructor(private job: ExecutableJob<BatchRouteJobType>) {
+        // Nothing to do
+    }
+
+    private prepareResultData = async (): Promise<void> => {
+        let pathCollection: PathCollection | undefined = undefined;
+        if (this.job.attributes.data.parameters.transitRoutingAttributes.withGeometries) {
+            pathCollection = new PathCollection([], {});
+            if (this.job.attributes.data.parameters.transitRoutingAttributes.scenarioId) {
+                const pathGeojson = await pathDbQueries.geojsonCollection({
+                    scenarioId: this.job.attributes.data.parameters.transitRoutingAttributes.scenarioId
+                });
+                pathCollection.loadFromCollection(pathGeojson.features);
+            }
+            this.pathCollection = pathCollection;
+        } else {
+            this.pathCollection = false;
+        }
+    };
+
+    visitTripResult = async (routingResult: OdTripRouteResult) => {
+        if (this.pathCollection === false) {
+            await this.prepareResultData();
+        }
+        const processedResults = await generateFileOutputResults(routingResult, {
+            exportCsv: true,
+            exportDetailed: this.job.attributes.data.parameters.transitRoutingAttributes.detailed === true,
+            withGeometries: this.job.attributes.data.parameters.transitRoutingAttributes.withGeometries === true,
+            pathCollection: this.pathCollection as PathCollection | undefined
+        });
+        this.resultHandler.processResult(processedResults);
+    };
+
+    end = () => {
+        this.resultHandler.end();
+    };
+
+    getResult(): { files: { input: string; csv?: string; detailedCsv?: string; geojson?: string } } {
+        return { files: this.resultHandler.getFiles() };
+    }
+}

--- a/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/TrRoutingBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/TrRoutingBatchResult.ts
@@ -11,8 +11,8 @@ import { join } from 'path';
 
 import { TrRoutingV2 } from 'chaire-lib-common/lib/api/TrRouting';
 import { SegmentToGeoJSONFromPaths } from 'transition-common/lib/services/transitRouting/TransitRoutingResult';
-import { getDefaultCsvAttributes, getDefaultStepsAttributes } from './ResultAttributes';
-import { OdTripRouteOutput, OdTripRouteResult } from './types';
+import { getDefaultCsvAttributes, getDefaultStepsAttributes } from '../ResultAttributes';
+import { OdTripRouteOutput, OdTripRouteResult } from '../types';
 import { unparse } from 'papaparse';
 import { ErrorCodes, TrRoutingRoute } from 'chaire-lib-common/lib/services/transitRouting/types';
 import { TransitRoutingResultData } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
@@ -25,8 +25,8 @@ import { BatchCalculationParameters } from 'transition-common/lib/services/batch
 import { pathIsRoute } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { RoutingResultsByMode } from 'chaire-lib-common/lib/services/routing/types';
 import { resultToObject } from 'chaire-lib-common/lib/services/routing/RoutingResultUtils';
-import { ExecutableJob } from '../executableJob/ExecutableJob';
-import { BatchRouteJobType } from './BatchRoutingJob';
+import { ExecutableJob } from '../../executableJob/ExecutableJob';
+import { BatchRouteJobType } from '../BatchRoutingJob';
 
 const CSV_FILE_NAME = 'batchRoutingResults.csv';
 const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';
@@ -58,6 +58,7 @@ class BatchRoutingResultProcessorFile implements BatchRoutingResultProcessor {
     constructor(private job: ExecutableJob<BatchRouteJobType>) {
         this.initResultFiles();
     }
+
     private initResultFiles = () => {
         const csvAttributes = getDefaultCsvAttributes(this.batchParameters.routingModes || []);
 

--- a/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/__tests__/TrRoutingBatchResult.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/__tests__/TrRoutingBatchResult.test.ts
@@ -9,19 +9,19 @@ import { ObjectWritableMock } from 'stream-mock';
 
 
 import { TransitRoutingResult } from 'chaire-lib-common/lib/services/routing/TransitRoutingResult';
-import { simplePathResult, alternativesResult, walkingRouteResult, cyclingRouteResult } from './TrRoutingResultStub';
+import { simplePathResult, alternativesResult, walkingRouteResult, cyclingRouteResult } from '../../__tests__/TrRoutingResultStub';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import { createRoutingFileResultProcessor, generateFileOutputResults } from '../TrRoutingBatchResult';
 import { BaseOdTrip } from 'transition-common/lib/services/odTrip/BaseOdTrip';
-import { getDefaultCsvAttributes, getDefaultStepsAttributes } from '../ResultAttributes';
+import { getDefaultCsvAttributes, getDefaultStepsAttributes } from '../../ResultAttributes';
 import { routeToUserObject, TrRoutingBoardingStep, TrRoutingUnboardingStep, TrRoutingWalkingStep } from 'chaire-lib-common/src/services/transitRouting/TrRoutingResultConversion';
 import Path from 'transition-common/lib/services/path/Path';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { ErrorCodes } from 'chaire-lib-common/lib/services/transitRouting/types';
-import jobsDbQueries from '../../../models/db/jobs.db.queries';
-import { ExecutableJob } from '../../executableJob/ExecutableJob';
-import { BatchRouteJobType } from '../BatchRoutingJob';
+import jobsDbQueries from '../../../../models/db/jobs.db.queries';
+import { ExecutableJob } from '../../../executableJob/ExecutableJob';
+import { BatchRouteJobType } from '../../BatchRoutingJob';
 
 const absoluteDir = `${directoryManager.userDataDirectory}/1/exports`;
 
@@ -49,7 +49,7 @@ const odTrip = new BaseOdTrip({
     timeType: 'departure'
 });
 
-jest.mock('../../../models/db/jobs.db.queries');
+jest.mock('../../../../models/db/jobs.db.queries');
 const mockJobsDbQueries = jobsDbQueries as jest.Mocked<typeof jobsDbQueries>;
 const jobId = 4;
 const inputFileName = 'input.csv';


### PR DESCRIPTION
fixes #1549

Define a `BatchRouteResultVisitor` interface that will visit each result
from the batch calculation and do something about it. The visitor can do
whatever it wants with the result and it does not necessarily involve
generating files.

Move the current result file generation to an implementation of this
visitor: the `BatchRouteFileResultVisitor` class, to generate the
requested files.

The `TrRoutingBatch` class now uses this visitor class to handle results
at the end of the calculation. It does not yet support any other result
handling, but it prepares the way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for batch routing result processing to enhance modularity and maintainability. Result handling is now more flexible, allowing for better extensibility while preserving existing functionality and output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->