### PR TITLE
workerpool: add functions to cleanup worker pool

### DIFF
--- a/packages/transition-backend/src/server.ts
+++ b/packages/transition-backend/src/server.ts
@@ -15,7 +15,7 @@ import { hideBin } from 'yargs/helpers';
 import express from 'express';
 import { registerTranslationDir, addTranslationNamespace } from 'chaire-lib-backend/lib/config/i18next';
 import config from 'chaire-lib-backend/lib/config/server.config';
-import { startPool } from './tasks/serverWorkerPool';
+import { startPool, terminatePool } from './tasks/serverWorkerPool';
 import OSRMProcessManager from 'chaire-lib-backend/lib/utils/processManagers/OSRMProcessManager';
 import trRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
 import { _booleish } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -134,5 +134,18 @@ const setupAll = async function () {
 
     console.log('Setup done');
 };
+// Register shutdown handlers
+process.on('SIGINT', () => {
+    console.log('Received SIGINT. Performing cleanup...');
+    terminatePool()
+        .catch((error) => console.error('Failed to terminate worker pool', error))
+        .finally(() => process.exit(0));
+});
 
+process.on('SIGTERM', () => {
+    console.log('Received SIGTERM. Performing cleanup...');
+    terminatePool()
+        .catch((error) => console.error('Failed to terminate worker pool', error))
+        .finally(() => process.exit(0));
+});
 setupAll();

--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -169,15 +169,24 @@ export const wrapTaskExecution = async (id: number) => {
     await task.save(taskListener);
 };
 
+// Graceful shutdown handler
+const shutdown = async (code: number | undefined) => {
+    console.log('Worker received a shutdown request with code ', code);
+    // TODO Implement proper shutdown of the tasks, like killing ongoing trRouting processes to avoid defunct (if this callback is called in case of dramatic termination)
+};
+
 const run = async () => {
     // Prepare socket routes to be able to use them
     prepareSocketRoutes();
     await OSRMProcessManager.configureAllOsrmServers(false);
 
     // create a worker and register public functions
-    workerpool.worker({
-        task: wrapTaskExecution
-    });
+    workerpool.worker(
+        {
+            task: wrapTaskExecution
+        },
+        { onTerminate: shutdown }
+    );
 };
 
 run();

--- a/packages/transition-backend/src/tasks/serverWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/serverWorkerPool.ts
@@ -21,3 +21,14 @@ export const execJob = async (...parameters: Parameters<Pool['exec']>): Promise<
     }
     return pool.exec(...parameters);
 };
+
+export const terminatePool = async () => {
+    if (pool !== undefined) {
+        console.log('Terminating worker pool');
+        // Forcing termination to avoid waiting for long running tasks
+        // TODO Implement proper abort mechanism for the tasks, so they can be cleanly stopped
+        await pool.terminate(true);
+        console.log('Terminated worker pool');
+        pool = undefined;
+    }
+};


### PR DESCRIPTION
Make sure to properly shutdown/terminate workerpool when the main process is terminated.

Also add a worker thread's `onTerminate` handler. It does not do anything yet, just a console.log to see when/if this callback is called in case of hard failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved graceful shutdown: process-level termination handlers ensure worker pool and background workers are cleanly stopped on SIGINT/SIGTERM, with errors logged and process exiting after cleanup.
  * Worker runtime now includes an on-terminate cleanup phase so ongoing tasks shut down cleanly without impacting normal startup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->