### PR TITLE
db: make the readForLines schedule query more efficient

### DIFF
--- a/packages/transition-backend/src/models/db/__tests__/TransitSchedule.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/TransitSchedule.db.test.ts
@@ -378,6 +378,22 @@ describe(`schedules`, function () {
         expect(schedulesForNonexistentLine).toEqual([]);
     });
 
+    test('readForLines', async() => {
+        // Read the schedule for the line ID requested
+        const schedulesForLine = await dbQueries.readForLines([scheduleForServiceId.line_id]);
+        expect(schedulesForLine.length).toEqual(1);
+        expectSchedulesSame(schedulesForLine[0], scheduleForServiceId as any);
+
+        // Read the schedule for multiple lines, only one has schedules
+        const schedulesForMultipleLine = await dbQueries.readForLines([scheduleForServiceId.line_id, lineId2]);
+        expect(schedulesForMultipleLine.length).toEqual(1);
+        expectSchedulesSame(schedulesForMultipleLine[0], scheduleForServiceId as any);
+
+        // Read for a line id without data
+        const schedulesForNonexistentLine = await dbQueries.readForLines([uuidV4()]);
+        expect(schedulesForNonexistentLine).toEqual([]);
+    });
+
     test('test collection', async function() {
         const collection = await dbQueries.collection();
         expect(collection.length).toEqual(1);


### PR DESCRIPTION
fixes #1529

The schedule collection subquery now receives the array of line ids for
which to get the collection so it can add this `where` to the inner
query of the collection. For a large network with many lines, like the
whole Montreal region for many time periods, this can reduce the query
time from 25 seconds to a few milliseconds.

Add sequential tests for the `readForLines` query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for batch retrieval of transit schedules by multiple line IDs, allowing efficient queries across several lines in a single operation.

* **Tests**
  * Expanded test coverage for batch retrieval, including single-line, multi-line (mixed data), and nonexistent-line scenarios to ensure correct responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->