### PR TITLE
feat(weighting): add decay function calculator for gravity-based weighting

### DIFF
--- a/packages/transition-backend/src/services/weighting/DecayFunctionCalculator.ts
+++ b/packages/transition-backend/src/services/weighting/DecayFunctionCalculator.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import {
+    DecayFunctionParameters,
+    PowerDecayParameters,
+    ExponentialDecayParameters,
+    GammaDecayParameters,
+    CombinedDecayParameters,
+    LogisticDecayParameters,
+    DecayInputValueType,
+    DecayInputValue,
+    MIN_DISTANCE_METERS,
+    MIN_TRAVEL_TIME_SECONDS
+} from './types';
+
+/**
+ * Calculator for distance and time decay functions used in gravity-based
+ * accessibility and weighting models.
+ *
+ * Implements the decay functions described in the weighting documentation:
+ * - Power: f(x) = x^(-beta)
+ * - Exponential: f(x) = exp(-beta * x)
+ * - Gamma: f(x) = a * x^(-b) * exp(-c * x) [NCHRP 716 recommended]
+ * - Combined: f(x) = x^(-beta1) * exp(-beta2 * x)
+ * - Logistic: f(x) = 1 / (1 + exp(beta * (x - x0)))
+ *
+ * Where x can be either distance (in meters) or time (in seconds).
+ */
+export class DecayFunctionCalculator {
+    /**
+     * Get the input value (distance or time) from the DecayInputValue object based on inputValueType
+     *
+     * @param inputValue Value object containing both distance and time
+     * @param inputValueType Type of the input value (distance or time)
+     * @returns The distance or time value based on inputValueType
+     */
+    private static getInputValue(inputValue: DecayInputValue, inputValueType: DecayInputValueType): number {
+        if (inputValueType === 'distance') {
+            if (inputValue.distanceMeters === undefined) {
+                throw new TrError('Distance value is required but was undefined', 'WDF001', 'WeightingError');
+            }
+            return inputValue.distanceMeters;
+        } else if (inputValueType === 'time') {
+            if (inputValue.travelTimeSeconds === undefined) {
+                throw new TrError('Time value is required but was undefined', 'WDF002', 'WeightingError');
+            }
+            return inputValue.travelTimeSeconds;
+        } else {
+            throw new TrError(
+                `Unsupported inputValueType '${inputValueType}' in DecayFunctionCalculator.getInputValue. Expected 'distance' or 'time'.`,
+                'WDF003',
+                'WeightingError'
+            );
+        }
+    }
+
+    /**
+     * Get the adjusted input value with thresholds applied
+     * For now, we only apply thresholds to get the minimum value for the input value,
+     * replacing very small and 0 values to a minimum constant to avoid near infinity
+     * values or division by 0 or undefined. In the future, we may want to apply
+     * other thresholds or other functions to handle the input values.
+     *
+     * @param inputValue Value object containing both distance and time
+     * @param inputValueType Type of the input value (distance or time)
+     * @returns The input value adjusted to meet minimum thresholds (MIN_DISTANCE_METERS for distance, MIN_TRAVEL_TIME_SECONDS for time)
+     */
+    private static getAdjustedValue(inputValue: DecayInputValue, inputValueType: DecayInputValueType): number {
+        const adjustedInputValue = this.getInputValue(inputValue, inputValueType);
+        if (adjustedInputValue < MIN_DISTANCE_METERS && inputValueType === 'distance') {
+            return MIN_DISTANCE_METERS;
+        } else if (adjustedInputValue < MIN_TRAVEL_TIME_SECONDS && inputValueType === 'time') {
+            return MIN_TRAVEL_TIME_SECONDS;
+        }
+        return adjustedInputValue;
+    }
+
+    /**
+     * Calculate decay function value (generic, works for both distance and time)
+     *
+     * @param inputValue Value object containing both distance and time
+     * @param inputValueType Type of the input value (distance or time) - determines which value from inputValue is used
+     * @param parameters Decay function parameters
+     * @returns Decay function value (friction factor)
+     * @throws TrError if parameters are invalid
+     */
+    static calculateDecay(
+        inputValue: DecayInputValue,
+        inputValueType: DecayInputValueType,
+        parameters: DecayFunctionParameters
+    ): number {
+        this.validateParameters(inputValue, inputValueType, parameters);
+
+        /**
+         * Handle very small input value for decay functions
+         * Some functions are undefined at zero or would return numbers
+         * near infinity for very small numbers, so we return appropriate limits.
+         * Since most of these formulas were created and tested with zonal data,
+         * distances or travel times of 0 or very small values between two zones
+         * are indeed not possible.
+         * So we need to put a minimum threshold in the input values for some functions
+         * that would be undefined dividing by 0 or return numbers near infinity.
+         * For travel time, we will use a minimum of 60 seconds.
+         * For distance, we will use a minimum of 100 meters.
+         * This is a compromise between the accuracy of the model and the practicality of the data.
+         * However, using the exponential decay function, the result would be close to 1 for very small values,
+         * so this would be the best function to use if very small values are expected.
+         */
+        const adjustedX = this.getAdjustedValue(inputValue, inputValueType);
+
+        switch (parameters.type) {
+        case 'power':
+            return this.calculatePowerDecay(adjustedX, parameters);
+        case 'exponential':
+            return this.calculateExponentialDecay(adjustedX, parameters);
+        case 'gamma':
+            return this.calculateGammaDecay(adjustedX, parameters);
+        case 'combined':
+            return this.calculateCombinedDecay(adjustedX, parameters);
+        case 'logistic':
+            return this.calculateLogisticDecay(adjustedX, parameters);
+        default: {
+            const exhaustiveCheck: never = parameters;
+            throw new TrError(
+                `Unknown decay function type: ${(exhaustiveCheck as DecayFunctionParameters).type}`,
+                'WDF004',
+                'WeightingError'
+            );
+        }
+        }
+    }
+
+    /**
+     * Calculate power decay: f(x) = x^(-beta)
+     */
+    private static calculatePowerDecay(x: number, params: PowerDecayParameters): number {
+        return Math.pow(x, -params.beta);
+    }
+
+    /**
+     * Calculate exponential decay: f(x) = exp(-beta * x)
+     */
+    private static calculateExponentialDecay(x: number, params: ExponentialDecayParameters): number {
+        return Math.exp(-params.beta * x);
+    }
+
+    /**
+     * Calculate gamma decay: f(x) = a * x^(-b) * exp(-c * x)
+     * Recommended standard for four-step models (NCHRP 716)
+     */
+    private static calculateGammaDecay(x: number, params: GammaDecayParameters): number {
+        return params.a * Math.pow(x, -params.b) * Math.exp(-params.c * x);
+    }
+
+    /**
+     * Calculate combined decay: f(x) = x^(-beta1) * exp(-beta2 * x)
+     * Combines power-law and exponential decays
+     */
+    private static calculateCombinedDecay(x: number, params: CombinedDecayParameters): number {
+        return Math.pow(x, -params.beta1) * Math.exp(-params.beta2 * x);
+    }
+
+    /**
+     * Calculate logistic decay: f(x) = 1 / (1 + exp(beta * (x - x0)))
+     * S-shaped decay curve
+     */
+    private static calculateLogisticDecay(x: number, params: LogisticDecayParameters): number {
+        return 1 / (1 + Math.exp(params.beta * (x - params.x0)));
+    }
+
+    /**
+     * Validate decay function parameters and input values
+     *
+     * @param inputValue Value object containing both distance and time
+     * @param inputValueType Type of the input value (distance or time) - determines which value from inputValue is validated
+     * @param parameters Decay function parameters to validate
+     * @returns true if valid, throws TrError if invalid
+     * @throws TrError if parameters or input values are invalid
+     */
+    static validateParameters(
+        inputValue: DecayInputValue,
+        inputValueType: DecayInputValueType,
+        parameters: DecayFunctionParameters
+    ): boolean {
+        if (inputValueType !== 'distance' && inputValueType !== 'time') {
+            throw new TrError('Input value type must be either "distance" or "time"', 'WDF005', 'WeightingError');
+        }
+
+        const x = this.getInputValue(inputValue, inputValueType);
+
+        if (!Number.isFinite(x) || x < 0) {
+            throw new TrError('Input value must be a finite non-negative number', 'WDF006', 'WeightingError');
+        }
+
+        switch (parameters.type) {
+        case 'power':
+            if (!Number.isFinite(parameters.beta) || parameters.beta <= 0) {
+                throw new TrError(
+                    'Power decay parameter beta must be a positive finite number',
+                    'WDF007',
+                    'WeightingError'
+                );
+            }
+            break;
+        case 'exponential':
+            if (!Number.isFinite(parameters.beta) || parameters.beta <= 0) {
+                throw new TrError(
+                    'Exponential decay parameter beta must be a positive finite number',
+                    'WDF008',
+                    'WeightingError'
+                );
+            }
+            break;
+        case 'gamma':
+            if (
+                !Number.isFinite(parameters.a) ||
+                    parameters.a <= 0 ||
+                    !Number.isFinite(parameters.b) ||
+                    parameters.b <= 0 ||
+                    !Number.isFinite(parameters.c) ||
+                    parameters.c <= 0
+            ) {
+                throw new TrError(
+                    'Gamma decay parameters a, b, and c must all be positive finite numbers',
+                    'WDF009',
+                    'WeightingError'
+                );
+            }
+            break;
+        case 'combined':
+            if (
+                !Number.isFinite(parameters.beta1) ||
+                    parameters.beta1 <= 0 ||
+                    !Number.isFinite(parameters.beta2) ||
+                    parameters.beta2 <= 0
+            ) {
+                throw new TrError(
+                    'Combined decay parameters beta1 and beta2 must be positive finite numbers',
+                    'WDF010',
+                    'WeightingError'
+                );
+            }
+            break;
+        case 'logistic':
+            if (!Number.isFinite(parameters.beta) || parameters.beta <= 0 || !Number.isFinite(parameters.x0)) {
+                throw new TrError(
+                    'Logistic decay parameter beta must be positive and x0 must be a finite number',
+                    'WDF011',
+                    'WeightingError'
+                );
+            }
+            break;
+        default: {
+            const exhaustiveCheck: never = parameters;
+            throw new TrError(
+                `Unknown decay function type: ${(exhaustiveCheck as DecayFunctionParameters).type}`,
+                'WDF012',
+                'WeightingError'
+            );
+        }
+        }
+        return true;
+    }
+}

--- a/packages/transition-backend/src/services/weighting/__tests__/DecayFunctionCalculator.test.ts
+++ b/packages/transition-backend/src/services/weighting/__tests__/DecayFunctionCalculator.test.ts
@@ -1,0 +1,609 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { DecayFunctionCalculator } from '../DecayFunctionCalculator';
+import {
+    PowerDecayParameters,
+    ExponentialDecayParameters,
+    GammaDecayParameters,
+    CombinedDecayParameters,
+    LogisticDecayParameters,
+    DecayFunctionParameters,
+    MIN_DISTANCE_METERS,
+    MIN_TRAVEL_TIME_SECONDS,
+    DecayInputValueType,
+    DecayInputValue
+} from '../types';
+
+describe('DecayFunctionCalculator', () => {
+    /**
+     * Helper function to create a DecayInputValue object
+     * Ensures at least one value is defined (enforced by type system)
+     */
+    const createInputValue = (distance: number | undefined, time: number | undefined): DecayInputValue => {
+        if (distance !== undefined) {
+            return { distanceMeters: distance, travelTimeSeconds: time };
+        } else if (time !== undefined) {
+            return { travelTimeSeconds: time, distanceMeters: distance };
+        } else {
+            throw new Error('At least one of distanceMeters or travelTimeSeconds must be defined');
+        }
+    };
+
+    describe('getInputValue (tested indirectly through calculateDecay)', () => {
+        const params: PowerDecayParameters = { type: 'power', beta: 2 };
+
+        it.each([
+            ['distance', 500, 300, Math.pow(500, -2)],
+            ['time', 500, 300, Math.pow(300, -2)],
+            ['distance', 1000, 600, Math.pow(1000, -2)],
+            ['time', 1000, 600, Math.pow(600, -2)]
+        ])('should use correct value when inputValueType is %s for distance=%d, time=%d', (inputValueType, distance, time, expected) => {
+            const inputValue = createInputValue(distance, time);
+            const result = DecayFunctionCalculator.calculateDecay(inputValue, inputValueType as DecayInputValueType, params);
+            expect(result).toBeCloseTo(expected, 5);
+        });
+    });
+
+    describe('getAdjustedValue (tested indirectly through calculateDecay)', () => {
+        const params: PowerDecayParameters = { type: 'power', beta: 2 };
+
+        describe('for distance values', () => {
+            it.each([
+                ['below threshold', 50, MIN_DISTANCE_METERS],
+                ['zero', 0, MIN_DISTANCE_METERS],
+                ['MIN_DISTANCE_METERS - 1', MIN_DISTANCE_METERS - 1, MIN_DISTANCE_METERS],
+                ['MIN_DISTANCE_METERS', MIN_DISTANCE_METERS, MIN_DISTANCE_METERS],
+                ['above MIN_DISTANCE_METERS', 500, 500],
+                ['much larger than MIN_DISTANCE_METERS', 10000, 10000]
+            ])('should return correct adjusted value when distance is %s', (description, distance, expectedAdjusted) => {
+                const inputValue = createInputValue(distance, 300);
+                const result = DecayFunctionCalculator.calculateDecay(inputValue, 'distance', params);
+                const expectedResult = Math.pow(expectedAdjusted, -params.beta);
+                expect(result).toBeCloseTo(expectedResult, 5);
+            });
+        });
+
+        describe('for time values', () => {
+            it.each([
+                ['below threshold', 30, MIN_TRAVEL_TIME_SECONDS],
+                ['zero', 0, MIN_TRAVEL_TIME_SECONDS],
+                ['MIN_TRAVEL_TIME_SECONDS - 1', MIN_TRAVEL_TIME_SECONDS - 1, MIN_TRAVEL_TIME_SECONDS],
+                ['MIN_TRAVEL_TIME_SECONDS', MIN_TRAVEL_TIME_SECONDS, MIN_TRAVEL_TIME_SECONDS],
+                ['above MIN_TRAVEL_TIME_SECONDS', 300, 300],
+                ['much larger than MIN_TRAVEL_TIME_SECONDS', 6000, 6000]
+            ])('should return correct adjusted value when time is %s', (description, time, expectedAdjusted) => {
+                const inputValue = createInputValue(500, time);
+                const result = DecayFunctionCalculator.calculateDecay(inputValue, 'time', params);
+                const expectedResult = Math.pow(expectedAdjusted, -params.beta);
+                expect(result).toBeCloseTo(expectedResult, 5);
+            });
+        });
+
+        describe('edge cases', () => {
+            it.each([
+                ['distance', 50, 300, MIN_DISTANCE_METERS, 300],
+                ['time', 500, 30, MIN_TRAVEL_TIME_SECONDS, 500]
+            ])('should not affect the other value when adjusting %s', (inputValueType, distance, time, expectedAdjusted, expectedOther) => {
+                const inputValue = createInputValue(distance, time);
+                const result = DecayFunctionCalculator.calculateDecay(inputValue, inputValueType as DecayInputValueType, params);
+                const expectedResult = Math.pow(expectedAdjusted, -params.beta);
+                expect(result).toBeCloseTo(expectedResult, 5);
+                const otherResult = DecayFunctionCalculator.calculateDecay(inputValue, inputValueType === 'distance' ? 'time' : 'distance', params);
+                const expectedOtherResult = Math.pow(expectedOther, -params.beta);
+                expect(otherResult).toBeCloseTo(expectedOtherResult, 5);
+            });
+
+            it.each([
+                ['both below threshold', 50, 30, MIN_DISTANCE_METERS, MIN_TRAVEL_TIME_SECONDS],
+                ['very small fractional values', 0.001, 0.001, MIN_DISTANCE_METERS, MIN_TRAVEL_TIME_SECONDS]
+            ])('should handle %s independently', (description, distance, time, expectedDistance, expectedTime) => {
+                const inputValue = createInputValue(distance, time);
+                const distanceResult = DecayFunctionCalculator.calculateDecay(inputValue, 'distance', params);
+                const expectedDistanceResult = Math.pow(expectedDistance, -params.beta);
+                expect(distanceResult).toBeCloseTo(expectedDistanceResult, 5);
+                const timeResult = DecayFunctionCalculator.calculateDecay(inputValue, 'time', params);
+                const expectedTimeResult = Math.pow(expectedTime, -params.beta);
+                expect(timeResult).toBeCloseTo(expectedTimeResult, 5);
+            });
+        });
+    });
+
+    describe('Power decay', () => {
+        const params: PowerDecayParameters = { type: 'power', beta: 2 };
+
+        it.each([
+            [300, Math.pow(300, -2)],
+            [600, Math.pow(600, -2)],
+            [120, Math.pow(120, -2)]
+        ])('should calculate power decay correctly for input %d', (input, expected) => {
+            expect(DecayFunctionCalculator.calculateDecay(createInputValue(0, input), 'time', params)).toBeCloseTo(expected, 5);
+        });
+
+        it.each([
+            [500, 0.000004],
+            [100, 0.0001],
+            [2000, 0.00000025]
+        ])('should calculate power decay correctly for input %d', (input, expected) => {
+            expect(DecayFunctionCalculator.calculateDecay(createInputValue(input, 0), 'distance', params)).toBeCloseTo(expected, 5);
+        });
+
+        it('should throw error for negative input', () => {
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, -1), 'time', params)).toThrow(TrError);
+        });
+
+        it('should throw error for invalid beta parameter', () => {
+            const invalidParams: PowerDecayParameters = { type: 'power', beta: -1 };
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 300), 'time', invalidParams)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 300), 'time', invalidParams)).toThrow(TrError);
+        });
+
+        describe.each([
+            ['distance', 'distance' as DecayInputValueType],
+            ['time', 'time' as DecayInputValueType]
+        ])('should throw error for %s input type', (description, inputType) => {
+            it.each([
+                ['NaN', NaN],
+                ['Infinity', Infinity],
+                ['negative value', -1],
+                ['negative infinity', -Infinity]
+            ])('should throw error for %s', (valueDescription, value) => {
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, inputType, params)).toThrow(TrError);
+            });
+        });
+
+        it.each([
+            ['zero', 'distance', 0],
+            ['zero', 'time', 0],
+            ['very small value below MIN_DISTANCE_METERS','distance', MIN_DISTANCE_METERS * 0.5],
+            ['very small value below MIN_TRAVEL_TIME_SECONDS', 'time', MIN_TRAVEL_TIME_SECONDS * 0.5],
+            ['small fraction', 'distance', 0.001],
+            ['small fraction', 'time', 0.001]
+        ])('should apply minimum threshold for %s', (description, inputType, value) => {
+            const expected = inputType === 'distance' ? Math.pow(MIN_DISTANCE_METERS, -params.beta) : Math.pow(MIN_TRAVEL_TIME_SECONDS, -params.beta);
+            const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+            const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+            expect(result).toBeCloseTo(expected, 5);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+    });
+
+    describe('Exponential decay', () => {
+        const params: ExponentialDecayParameters = { type: 'exponential', beta: 0.1 };
+
+        it.each([
+            [300, Math.exp(-0.1 * 300)],
+            [600, Math.exp(-0.1 * 600)],
+            [0, Math.exp(-0.1 * MIN_TRAVEL_TIME_SECONDS)]
+        ])('should calculate exponential decay correctly for input %d', (input, expected) => {
+            expect(DecayFunctionCalculator.calculateDecay(createInputValue(0, input), 'time', params)).toBeCloseTo(expected, 5);
+        });
+
+        it('should throw error for zero beta (constant value of 1)', () => {
+            const zeroBetaParams: ExponentialDecayParameters = { type: 'exponential', beta: 0 };
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', zeroBetaParams)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', zeroBetaParams)).toThrow(TrError);
+        });
+
+        it('should throw error for negative beta in validation', () => {
+            const invalidParams: ExponentialDecayParameters = { type: 'exponential', beta: -0.1 };
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+        });
+
+        describe.each([
+            ['distance', 'distance' as DecayInputValueType],
+            ['time', 'time' as DecayInputValueType]
+        ])('should throw error for %s input type', (description, inputType) => {
+            it.each([
+                ['NaN', NaN],
+                ['Infinity', Infinity],
+                ['negative value', -1],
+                ['negative infinity', -Infinity]
+            ])('should throw error for %s', (valueDescription, value) => {
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, inputType, params)).toThrow(TrError);
+            });
+        });
+
+        it.each([
+            ['zero', 'distance', 0],
+            ['zero', 'time', 0],
+            ['very small value below MIN_DISTANCE_METERS', 'distance', MIN_DISTANCE_METERS * 0.5],
+            ['very small value below MIN_TRAVEL_TIME_SECONDS', 'time', MIN_TRAVEL_TIME_SECONDS * 0.5],
+            ['small fraction', 'distance', 0.001],
+            ['small fraction', 'time', 0.001]
+        ])('should apply minimum threshold for %s', (description, inputType, value) => {
+            const expected = inputType === 'distance' ? Math.exp(-params.beta * MIN_DISTANCE_METERS) : Math.exp(-params.beta * MIN_TRAVEL_TIME_SECONDS);
+            const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+            const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+            expect(result).toBeCloseTo(expected, 5);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+    });
+
+    describe('Gamma decay', () => {
+        const params: GammaDecayParameters = { type: 'gamma', a: 5280, b: 0.926, c: 0.087 };
+
+        it('should calculate gamma decay correctly (NCHRP 716 example)', () => {
+            const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 900), 'time', params);
+            expect(result).toBeGreaterThan(0);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+
+        it('should calculate gamma decay for other values', () => {
+            const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', params);
+            expect(result).toBeGreaterThan(0);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+
+        it('should throw error for invalid parameters', () => {
+            const invalidParams: GammaDecayParameters = { type: 'gamma', a: -1, b: 0.926, c: 0.087 };
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+        });
+
+        describe.each([
+            ['distance', 'distance' as DecayInputValueType],
+            ['time', 'time' as DecayInputValueType]
+        ])('should throw error for %s input type', (description, inputType) => {
+            it.each([
+                ['NaN', NaN],
+                ['Infinity', Infinity],
+                ['negative value', -1],
+                ['negative infinity', -Infinity]
+            ])('should throw error for %s', (valueDescription, value) => {
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, inputType, params)).toThrow(TrError);
+            });
+        });
+
+        it.each([
+            ['zero', 'distance', 0],
+            ['zero', 'time', 0],
+            ['very small value below MIN_DISTANCE_METERS', 'distance', MIN_DISTANCE_METERS * 0.5],
+            ['very small value below MIN_TRAVEL_TIME_SECONDS', 'time', MIN_TRAVEL_TIME_SECONDS * 0.5],
+            ['small fraction', 'distance', 0.001],
+            ['small fraction', 'time', 0.001]
+        ])('should apply minimum threshold for %s', (description, inputType, value) => {
+            const expected = inputType === 'distance'
+                ? params.a * Math.pow(MIN_DISTANCE_METERS, -params.b) * Math.exp(-params.c * MIN_DISTANCE_METERS)
+                : params.a * Math.pow(MIN_TRAVEL_TIME_SECONDS, -params.b) * Math.exp(-params.c * MIN_TRAVEL_TIME_SECONDS);
+            const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+            const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+            expect(result).toBeCloseTo(expected, 5);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+    });
+
+    describe('Combined decay', () => {
+        const params: CombinedDecayParameters = { type: 'combined', beta1: 1.0, beta2: 0.1 };
+
+        it('should calculate combined decay correctly', () => {
+            const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 300), 'time', params);
+            const expected = Math.pow(300, -1.0) * Math.exp(-0.1 * 300);
+            expect(result).toBeCloseTo(expected, 5);
+        });
+
+        it.each([
+            ['negative beta1', { type: 'combined' as const, beta1: -1, beta2: 0.1 }],
+            ['zero beta1', { type: 'combined' as const, beta1: 0, beta2: 0.1 }],
+            ['negative beta2', { type: 'combined' as const, beta1: 1.0, beta2: -0.1 }],
+            ['zero beta2', { type: 'combined' as const, beta1: 1.0, beta2: 0 }]
+        ])('should throw error for %s in validation', (description, invalidParams) => {
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', invalidParams as DecayFunctionParameters)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', invalidParams as DecayFunctionParameters)).toThrow(TrError);
+        });
+
+        describe.each([
+            ['distance', 'distance' as DecayInputValueType],
+            ['time', 'time' as DecayInputValueType]
+        ])('should throw error for %s input type', (description, inputType) => {
+            it.each([
+                ['NaN', NaN],
+                ['Infinity', Infinity],
+                ['negative value', -1],
+                ['negative infinity', -Infinity]
+            ])('should throw error for %s', (valueDescription, value) => {
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, inputType, params)).toThrow(TrError);
+            });
+        });
+
+        it.each([
+            ['zero', 'distance', 0],
+            ['zero', 'time', 0],
+            ['very small value below MIN_DISTANCE_METERS', 'distance', MIN_DISTANCE_METERS * 0.5],
+            ['very small value below MIN_TRAVEL_TIME_SECONDS', 'time', MIN_TRAVEL_TIME_SECONDS * 0.5],
+            ['small fraction', 'distance', 0.001],
+            ['small fraction', 'time', 0.001]
+        ])('should apply minimum threshold for %s', (description, inputType, value) => {
+            const expected = inputType === 'distance'
+                ? Math.pow(MIN_DISTANCE_METERS, -params.beta1) * Math.exp(-params.beta2 * MIN_DISTANCE_METERS)
+                : Math.pow(MIN_TRAVEL_TIME_SECONDS, -params.beta1) * Math.exp(-params.beta2 * MIN_TRAVEL_TIME_SECONDS);
+            const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+            const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+            expect(result).toBeCloseTo(expected, 5);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+    });
+
+    describe('Logistic decay', () => {
+        const params: LogisticDecayParameters = { type: 'logistic', beta: 0.5, x0: 600 };
+
+        it('should calculate logistic decay correctly', () => {
+            const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', params);
+            expect(result).toBeCloseTo(0.5, 5); // At x0, should be 0.5
+        });
+
+        it('should approach 1 for values much less than x0', () => {
+            const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 0), 'time', params);
+            // With MIN_TRAVEL_TIME_SECONDS = 60, result should be calculated with x = 60
+            const expected = 1 / (1 + Math.exp(params.beta * (MIN_TRAVEL_TIME_SECONDS - params.x0)));
+            expect(result).toBeCloseTo(expected, 5);
+        });
+
+        it('should approach 0 for values much greater than x0', () => {
+            const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 3000), 'time', params);
+            expect(result).toBeLessThan(0.1);
+        });
+
+        it.each([
+            ['non-finite beta', { type: 'logistic' as const, beta: Infinity, x0: 600 }],
+            ['non-finite x0', { type: 'logistic' as const, beta: 0.5, x0: Infinity }],
+            ['NaN beta', { type: 'logistic' as const, beta: NaN, x0: 600 }],
+            ['NaN x0', { type: 'logistic' as const, beta: 0.5, x0: NaN }],
+            ['zero beta', { type: 'logistic' as const, beta: 0, x0: 600 }],
+            ['negative beta', { type: 'logistic' as const, beta: -0.5, x0: 600 }]
+        ])('should throw error for %s in validation', (description, invalidParams) => {
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', invalidParams as DecayFunctionParameters)).toThrow(TrError);
+        });
+
+        describe.each([
+            ['distance', 'distance' as DecayInputValueType],
+            ['time', 'time' as DecayInputValueType]
+        ])('should throw error for %s input type', (description, inputType) => {
+            it.each([
+                ['NaN', NaN],
+                ['Infinity', Infinity],
+                ['negative value', -1],
+                ['negative infinity', -Infinity]
+            ])('should throw error for %s', (valueDescription, value) => {
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, inputType, params)).toThrow(TrError);
+            });
+        });
+
+        it.each([
+            ['zero', 'distance', 0],
+            ['zero', 'time', 0],
+            ['very small value below MIN_DISTANCE_METERS', 'distance', MIN_DISTANCE_METERS * 0.5],
+            ['very small value below MIN_TRAVEL_TIME_SECONDS', 'time', MIN_TRAVEL_TIME_SECONDS * 0.5],
+            ['small fraction', 'distance', 0.001],
+            ['small fraction', 'time', 0.001]
+        ])('should apply minimum threshold for %s', (description, inputType, value) => {
+            const expected = inputType === 'distance'
+                ? 1 / (1 + Math.exp(params.beta * (MIN_DISTANCE_METERS - params.x0)))
+                : 1 / (1 + Math.exp(params.beta * (MIN_TRAVEL_TIME_SECONDS - params.x0)));
+            const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+            const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+            expect(result).toBeCloseTo(expected, 5);
+            expect(Number.isFinite(result)).toBe(true);
+        });
+    });
+
+    describe('Parameter validation', () => {
+        it.each([
+            ['power', { type: 'power' as const, beta: 2 }],
+            ['exponential', { type: 'exponential' as const, beta: 0.1 }],
+            ['gamma', { type: 'gamma' as const, a: 5280, b: 0.926, c: 0.087 }],
+            ['combined', { type: 'combined' as const, beta1: 1.0, beta2: 0.1 }],
+            ['logistic', { type: 'logistic' as const, beta: 0.5, x0: 600 }]
+        ])('should validate valid %s parameters', (decayType, params) => {
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', params)).not.toThrow();
+        });
+
+        it('should throw error for unknown decay function type in validateParameters', () => {
+            // Use type assertion to create an invalid decay function type
+            const invalidParams = { type: 'unknown' as never, beta: 2 } as DecayFunctionParameters;
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+        });
+    });
+
+    describe('Edge cases', () => {
+        describe.each([
+            ['Power', { type: 'power' as const, beta: 2 }],
+            ['Exponential', { type: 'exponential' as const, beta: 0.1 }],
+            ['Gamma', { type: 'gamma' as const, a: 5280, b: 0.926, c: 0.087 }],
+            ['Combined', { type: 'combined' as const, beta1: 1.0, beta2: 0.1 }],
+            ['Logistic', { type: 'logistic' as const, beta: 0.5, x0: 10 }]
+        ])('Invalid inputs for %s decay', (decayType, params) => {
+            describe.each([
+                ['distance', 'distance' as DecayInputValueType],
+                ['time', 'time' as DecayInputValueType]
+            ])('should throw error for %s input type', (description, inputType) => {
+                it.each([
+                    ['NaN', NaN],
+                    ['Infinity', Infinity],
+                    ['negative value', -1],
+                    ['negative infinity', -Infinity]
+                ])('should throw error for %s', (valueDescription, value) => {
+                    const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                    expect(() => DecayFunctionCalculator.calculateDecay(inputValue, inputType, params)).toThrow(TrError);
+                });
+            });
+        });
+
+        describe.each([
+            ['Power', { type: 'power' as const, beta: 2 }, (x: number) => Math.pow(x, -2)],
+            ['Exponential', { type: 'exponential' as const, beta: 0.1 }, (x: number) => Math.exp(-0.1 * x)],
+            ['Gamma', { type: 'gamma' as const, a: 5280, b: 0.926, c: 0.087 }, (x: number) => 5280 * Math.pow(x, -0.926) * Math.exp(-0.087 * x)],
+            ['Combined', { type: 'combined' as const, beta1: 1.0, beta2: 0.1 }, (x: number) => Math.pow(x, -1.0) * Math.exp(-0.1 * x)],
+            ['Logistic', { type: 'logistic' as const, beta: 0.5, x0: 10 }, (x: number) => 1 / (1 + Math.exp(0.5 * (x - 10)))]
+        ])('Very small values for %s decay', (decayType, params, expectedFn) => {
+            it.each([
+                ['zero', 'distance', 0],
+                ['zero', 'time', 0],
+                ['very small value below MIN_DISTANCE_METERS', 'distance', MIN_DISTANCE_METERS * 0.5],
+                ['very small value below MIN_TRAVEL_TIME_SECONDS', 'time', MIN_TRAVEL_TIME_SECONDS * 0.5],
+                ['small fraction', 'distance', 0.001],
+                ['small fraction', 'time', 0.001]
+            ])('should apply minimum threshold for %s', (description, inputType, value) => {
+                const expected = inputType === 'distance' ? expectedFn(MIN_DISTANCE_METERS) : expectedFn(MIN_TRAVEL_TIME_SECONDS);
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+                expect(result).toBeCloseTo(expected, 5);
+                expect(Number.isFinite(result)).toBe(true);
+                expect(result).toBeGreaterThan(0);
+            });
+        });
+
+        describe.each([
+            ['Power', { type: 'power' as const, beta: 2 }],
+            ['Exponential', { type: 'exponential' as const, beta: 0.1 }],
+            ['Gamma', { type: 'gamma' as const, a: 5280, b: 0.926, c: 0.087 }],
+            ['Combined', { type: 'combined' as const, beta1: 1.0, beta2: 0.1 }],
+            ['Logistic', { type: 'logistic' as const, beta: 0.5, x0: 10 }]
+        ])('Very large values for %s decay', (decayType, params) => {
+            it.each([
+                ['very large distance', 10000, 'distance'],
+                ['very large time', 60000, 'time'],
+                ['extremely large distance', 100000, 'distance'],
+                ['extremely large time', 600000, 'time']
+            ])('should handle %s', (valueDescription, value, inputType) => {
+                const inputValue = inputType === 'distance' ? createInputValue(value, 0) : createInputValue(0, value);
+                const result = DecayFunctionCalculator.calculateDecay(inputValue, inputType as DecayInputValueType, params);
+                expect(Number.isFinite(result)).toBe(true);
+                expect(result).toBeGreaterThanOrEqual(0);
+            });
+        });
+    });
+
+    describe('Error handling for invalid types', () => {
+        it('should throw error for unknown decay function type in calculateDecay', () => {
+            // Use type assertion to create an invalid decay function type
+            const invalidParams = { type: 'unknown' as never, beta: 2 } as DecayFunctionParameters;
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+        });
+
+        it('should throw error for unknown decay function type in calculateDecay default case', () => {
+            // Mock validateParameters to bypass validation and test the default case in calculateDecay
+            const validateSpy = jest.spyOn(DecayFunctionCalculator, 'validateParameters').mockReturnValue(true);
+            // Use type assertion to create an invalid decay function type
+            const invalidParams = { type: 'unknown' as never, beta: 2 } as DecayFunctionParameters;
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', invalidParams)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', invalidParams)).toThrow('Unknown decay function type');
+            validateSpy.mockRestore();
+        });
+
+        it('should throw error when inputValueType is neither distance nor time', () => {
+            // Mock validateParameters to bypass validation, but getInputValue will still throw
+            const validateSpy = jest.spyOn(DecayFunctionCalculator, 'validateParameters').mockReturnValue(true);
+            const validParams: PowerDecayParameters = { type: 'power', beta: 2 };
+            // Use type assertion to bypass TypeScript checking and test invalid inputValueType
+            const invalidInputValueType = 'other' as DecayInputValueType;
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 300), invalidInputValueType, validParams)).toThrow(TrError);
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 300), invalidInputValueType, validParams)).toThrow('Unsupported inputValueType');
+            validateSpy.mockRestore();
+        });
+
+        it('should throw error for invalid inputValueType in validateParameters', () => {
+            const validParams: PowerDecayParameters = { type: 'power', beta: 2 };
+            // Use type assertion to bypass TypeScript checking and test invalid inputValueType
+            const invalidInputValueType = 'invalid' as DecayInputValueType;
+            expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), invalidInputValueType, validParams)).toThrow('Input value type must be either "distance" or "time"');
+            expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), invalidInputValueType, validParams)).toThrow('Input value type must be either "distance" or "time"');
+        });
+
+
+        describe('should only validate the requested inputValueType value in DecayInputValue', () => {
+            const validParams: PowerDecayParameters = { type: 'power', beta: 2 };
+
+            describe('when inputValueType is distance', () => {
+                it.each([
+                    ['NaN time', NaN],
+                    ['Infinity time', Infinity],
+                    ['negative time', -1],
+                    ['negative infinity time', -Infinity]
+                ])('should not throw error for invalid time value (%s) when distance is valid', (description, invalidTime) => {
+                    expect(() => DecayFunctionCalculator.validateParameters(createInputValue(100, invalidTime), 'distance', validParams)).not.toThrow();
+                    expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(100, invalidTime), 'distance', validParams)).not.toThrow();
+                });
+            });
+
+            describe('when inputValueType is time', () => {
+                it.each([
+                    ['NaN distance', NaN],
+                    ['Infinity distance', Infinity],
+                    ['negative distance', -1],
+                    ['negative infinity distance', -Infinity]
+                ])('should not throw error for invalid distance value (%s) when time is valid', (description, invalidDistance) => {
+                    expect(() => DecayFunctionCalculator.validateParameters(createInputValue(invalidDistance, 600), 'time', validParams)).not.toThrow();
+                    expect(() => DecayFunctionCalculator.calculateDecay(createInputValue(invalidDistance, 600), 'time', validParams)).not.toThrow();
+                });
+            });
+        });
+
+        describe('should accept input value when non-selected type is 0 or undefined', () => {
+            const validParams: PowerDecayParameters = { type: 'power', beta: 2 };
+
+            describe('when inputValueType is distance', () => {
+                it('should accept input when travelTimeSeconds is 0', () => {
+                    expect(() => DecayFunctionCalculator.validateParameters(createInputValue(100, 0), 'distance', validParams)).not.toThrow();
+                    const result = DecayFunctionCalculator.calculateDecay(createInputValue(100, 0), 'distance', validParams);
+                    expect(Number.isFinite(result)).toBe(true);
+                    expect(result).toBeGreaterThanOrEqual(0);
+                });
+
+                it('should accept input when travelTimeSeconds is undefined', () => {
+                    const inputValue = createInputValue(100, undefined);
+                    expect(() => DecayFunctionCalculator.validateParameters(inputValue, 'distance', validParams)).not.toThrow();
+                    const result = DecayFunctionCalculator.calculateDecay(inputValue, 'distance', validParams);
+                    expect(Number.isFinite(result)).toBe(true);
+                    expect(result).toBeGreaterThanOrEqual(0);
+                });
+            });
+
+            describe('when inputValueType is time', () => {
+                it('should accept input when distanceMeters is 0', () => {
+                    expect(() => DecayFunctionCalculator.validateParameters(createInputValue(0, 600), 'time', validParams)).not.toThrow();
+                    const result = DecayFunctionCalculator.calculateDecay(createInputValue(0, 600), 'time', validParams);
+                    expect(Number.isFinite(result)).toBe(true);
+                    expect(result).toBeGreaterThanOrEqual(0);
+                });
+
+                it('should accept input when distanceMeters is undefined', () => {
+                    const inputValue = createInputValue(undefined, 600);
+                    expect(() => DecayFunctionCalculator.validateParameters(inputValue, 'time', validParams)).not.toThrow();
+                    const result = DecayFunctionCalculator.calculateDecay(inputValue, 'time', validParams);
+                    expect(Number.isFinite(result)).toBe(true);
+                    expect(result).toBeGreaterThanOrEqual(0);
+                });
+            });
+        });
+
+        describe('should throw error when selected type is undefined', () => {
+            const validParams: PowerDecayParameters = { type: 'power', beta: 2 };
+
+            it('should throw error when distanceMeters is undefined and inputValueType is distance', () => {
+                const inputValue = createInputValue(undefined, 600);
+                expect(() => DecayFunctionCalculator.validateParameters(inputValue, 'distance', validParams)).toThrow(TrError);
+                expect(() => DecayFunctionCalculator.validateParameters(inputValue, 'distance', validParams)).toThrow('Distance value is required but was undefined');
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, 'distance', validParams)).toThrow(TrError);
+            });
+
+            it('should throw error when travelTimeSeconds is undefined and inputValueType is time', () => {
+                const inputValue = createInputValue(100, undefined);
+                expect(() => DecayFunctionCalculator.validateParameters(inputValue, 'time', validParams)).toThrow(TrError);
+                expect(() => DecayFunctionCalculator.validateParameters(inputValue, 'time', validParams)).toThrow('Time value is required but was undefined');
+                expect(() => DecayFunctionCalculator.calculateDecay(inputValue, 'time', validParams)).toThrow(TrError);
+            });
+        });
+    });
+});

--- a/packages/transition-backend/src/services/weighting/types.ts
+++ b/packages/transition-backend/src/services/weighting/types.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/** Full documentation on the weighting methodology is available in the docs/weighting directory. */
+
+/**
+ * Type of decay function to use
+ */
+export type DecayFunctionType = 'power' | 'exponential' | 'gamma' | 'combined' | 'logistic';
+
+/**
+ * Type of input value (distance or time)
+ */
+export type DecayInputValueType = 'distance' | 'time';
+
+/**
+ * Value object containing both distance and time values for decay function calculations.
+ * The inputValueType parameter determines which value is used in the calculation.
+ * One of the values can be undefined, but not both, and the value used in the calculation must be defined
+ */
+export type DecayInputValue =
+    | { distanceMeters: number; travelTimeSeconds?: number }
+    | { travelTimeSeconds: number; distanceMeters?: number };
+
+/**
+ * Minimum value for distance and time to prevent numerical instability in power-law decay functions.
+ * Power functions like x^(-beta) approach infinity as x approaches zero.
+ */
+export const MIN_DISTANCE_METERS = 100; // 100 meters
+export const MIN_TRAVEL_TIME_SECONDS = 60; // 60 seconds
+
+/**
+ * Parameters for power decay function: f(x) = x^(-beta)
+ *
+ * Constraints:
+ * - beta must be > 0 for decay behavior (typical range: 0.5 to 3.0)
+ * - Larger beta values produce steeper decay curves
+ * - Input x can be distance (meters) or time (seconds)
+ */
+export interface PowerDecayParameters {
+    type: 'power';
+    beta: number;
+}
+
+/**
+ * Parameters for exponential decay function: f(x) = exp(-beta * x)
+ *
+ * Constraints:
+ * - beta must be > 0 (beta = 0 would result in no decay, constant value of 1)
+ * - Typical values range from 0.01 to 0.5 for moderate decay
+ * - Larger beta values produce steeper exponential decay curves
+ * - Input x can be distance (meters) or time (seconds)
+ */
+export interface ExponentialDecayParameters {
+    type: 'exponential';
+    beta: number;
+}
+
+/**
+ * Parameters for gamma decay function: f(x) = a * x^(-b) * exp(-c * x)
+ *
+ * Constraints:
+ * - a, b, and c must all be > 0 (all parameters must be positive)
+ * - Recommended standard for four-step models (NCHRP 716)
+ * - proposed values in NCHRP 716: a ≈ 5280, b ≈ 0.926, c ≈ 0.087 (careful, these were used with different units and will change the decay function curve if used with seconds and/or meters)
+ * - Combines power-law and exponential decay behaviors
+ * - Input x can be distance (meters) or time (seconds)
+ */
+export interface GammaDecayParameters {
+    type: 'gamma';
+    a: number;
+    b: number;
+    c: number;
+}
+
+/**
+ * Parameters for combined decay function: f(x) = x^(-beta1) * exp(-beta2 * x)
+ *
+ * Constraints:
+ * - beta1 must be > 0 for power-law component (typical range: 0.5 to 2.0)
+ * - beta2 must be > 0 for exponential component (beta2 = 0 would result in pure power decay, which is not combined)
+ * - Typical values: beta1 ≈ 0.5-2.0, beta2 ≈ 0.01-0.5
+ * - Combines power-law and exponential decay behaviors
+ * - Input x can be distance (meters) or time (seconds)
+ */
+export interface CombinedDecayParameters {
+    type: 'combined';
+    beta1: number;
+    beta2: number;
+}
+
+/**
+ * Parameters for logistic decay function: f(x) = 1 / (1 + exp(beta * (x - x0)))
+ *
+ * Constraints:
+ * - beta must be > 0 (typical range: 0.1 to 1.0)
+ * - x0 must be a finite number (inflection point where decay rate is maximum)
+ * - Produces an S-shaped decay curve (sigmoid function)
+ * - x0 represents the midpoint of the transition (in same units as input x)
+ * - Larger beta values produce steeper transitions at x0
+ * - Input x can be distance (meters) or time (seconds)
+ */
+export interface LogisticDecayParameters {
+    type: 'logistic';
+    beta: number;
+    x0: number;
+}
+
+/**
+ * Union type for all decay function parameters
+ */
+export type DecayFunctionParameters =
+    | PowerDecayParameters
+    | ExponentialDecayParameters
+    | GammaDecayParameters
+    | CombinedDecayParameters
+    | LogisticDecayParameters;


### PR DESCRIPTION
Add DecayFunctionCalculator service implementing distance and time decay functions for gravity-based accessibility and weighting models. Supports five decay function types:
- Power: f(x) = x^(-beta)
- Exponential: f(x) = exp(-beta * x)
- Gamma: f(x) = a * x^(-b) * exp(-c * x)
- Combined: f(x) = x^(-beta1) * exp(-beta2 * x)
- Logistic: f(x) = 1 / (1 + exp(beta * (x - x0)))

The calculator accepts DecayInputValue objects containing both distance and time values, with xType parameter determining which value to use. Includes parameter validation, threshold handling for minimum values, and comprehensive test coverage.

Add types.ts with type definitions for decay function parameters and input values. Test suite includes validation tests, calculation tests for all function types, and edge case handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds configurable decay models (power, exponential, gamma, combined, logistic), minimum distance/time thresholds, input validation, and clear error responses for invalid configurations.
* **Tests**
  * Adds comprehensive tests covering calculations, parameter validation, boundary and edge cases, error handling, cross-type scenarios, and extreme values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->