### PR TITLE
Add parseLocationFromCsvStream function to AccessMapLocationProvider

### DIFF
--- a/packages/transition-backend/src/services/accessMapLocation/__tests__/AccessMapLocationProvider.test.ts
+++ b/packages/transition-backend/src/services/accessMapLocation/__tests__/AccessMapLocationProvider.test.ts
@@ -4,25 +4,36 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { parseLocationsFromCsv } from '../AccessMapLocationProvider';
+import { parseLocationsFromCsv, parseLocationsFromCsvStream } from '../AccessMapLocationProvider';
+import fs from 'fs';
+import { Readable } from 'stream';
 
-let currentData: any = [];
+// Mock fs.existsSync
+jest.mock('fs', () => ({
+    ...jest.requireActual('fs'),
+    existsSync: jest.fn().mockReturnValue(true),
+    createReadStream: jest.fn().mockReturnValue({destroy: jest.fn()} as any)
+}));
 
-jest.mock('chaire-lib-backend/lib/services/files/CsvFile', () => {
-    return {
-        parseCsvFile: jest.fn().mockImplementation(async (filePath, rowCallback, _options) => {
-            const data = currentData;
-            if (data && data.length > 0) {
-                for (let i = 0; i < data.length; i++) {
-                    rowCallback(data[i], i);
-                }
-            }
-        })
-    }
-});
+// TODO Those helper functions are copied from odTripProvider.test.ts, should we have them in a common location?
+// Helper function to create a readable stream from CSV string
+const createCsvStream = (csvContent: string): Readable => {
+    const stream = new Readable();
+    stream.push(csvContent);
+    stream.push(null); // Signal end of stream
+    return stream;
+};
+
+// Helper function to convert data array to CSV string
+const dataToCsv = (data: any[], headers: string[]): string => {
+    const headerLine = headers.join(',');
+    const dataLines = data.map(row => headers.map(h => row[h] ?? '').join(','));
+    return headerLine + '\n' + dataLines.join('\n') + '\n';
+};
 
 beforeEach(() => {
-
+    // Reset mocks
+    jest.clearAllMocks();
 });
 
 test('Parse a csv file, 4326 projection, departure time, HMM times', async () => {
@@ -49,7 +60,7 @@ test('Parse a csv file, 4326 projection, departure time, HMM times', async () =>
             unused: '0500'
         }
     ];
-    currentData = data;
+
     const options = {
         projection: '4326',
         idAttribute: 'id',
@@ -59,6 +70,9 @@ test('Parse a csv file, 4326 projection, departure time, HMM times', async () =>
         timeFormat: 'HMM',
         timeAttribute: 'time',
     };
+
+    // Mock a CSV file stream based on the above test values
+    (fs.createReadStream as jest.Mock).mockReturnValueOnce(createCsvStream(dataToCsv(data, ['id','originX','originY','time','unused'])));
 
     const { locations, errors } = await parseLocationsFromCsv('path/to/file.csv', options);
     expect(locations.length).toEqual(3);
@@ -113,7 +127,7 @@ test('Parse a csv file, 2950 projection, arrival time, HH:MM times', async () =>
             unused: '0500'
         }
     ];
-    currentData = data;
+
     const options = {
         projection: '2950',
         idAttribute: 'id',
@@ -123,6 +137,8 @@ test('Parse a csv file, 2950 projection, arrival time, HH:MM times', async () =>
         timeFormat: 'HH:MM',
         timeAttribute: 'time'
     };
+    // Mock a CSV file stream based on the above test values
+    (fs.createReadStream as jest.Mock).mockReturnValueOnce(createCsvStream(dataToCsv(data, ['id','originX','originY','time','unused'])));
 
     const { locations, errors } = await parseLocationsFromCsv('path/to/file.csv', options);
     expect(locations.length).toEqual(3);
@@ -195,7 +211,7 @@ test('Parse a csv file, faulty lines and time in seconds', async () => {
             unused: '0500'
         }
     ];
-    currentData = data;
+
     const options = {
         projection: '4326',
         idAttribute: 'id',
@@ -205,23 +221,23 @@ test('Parse a csv file, faulty lines and time in seconds', async () => {
         timeFormat: 'secondsSinceMidnight',
         timeAttribute: 'time',
     };
+    // Mock a CSV file stream based on the above test values
+    (fs.createReadStream as jest.Mock).mockReturnValueOnce(createCsvStream(dataToCsv(data, ['id','originX','originY','destinationX','destinationY','time','unused'])));
 
     const { locations, errors } = await parseLocationsFromCsv('path/to/file.csv', options);
     expect(locations.length).toEqual(2);
-    expect(errors.length).toBeGreaterThan(currentData.length - 2);
+    expect(errors.length).toBeGreaterThan(data.length - 2);
     expect(locations[0]).toEqual(expect.objectContaining({
         id: data[3].id,
         geography: { type: 'Point' as const, coordinates: [data[3].originX, data[3].originY]},
         timeType: 'departure',
         timeOfTrip: 8 * 60 * 60,
-        data: data[3]
     }));
     expect(locations[1]).toEqual(expect.objectContaining({
         id: data[4].id,
         geography: { type: 'Point' as const, coordinates: [data[3].originX, data[3].originY]},
         timeType: 'departure',
         timeOfTrip: 0,
-        data: data[4]
     }));
 });
 
@@ -236,7 +252,7 @@ test('Parse a csv file, wrong coordinates format', async () => {
             unused: '0500'
         },
     ];
-    currentData = data;
+
     const options = {
         projection: '4326',
         idAttribute: 'id',
@@ -246,6 +262,8 @@ test('Parse a csv file, wrong coordinates format', async () => {
         timeFormat: 'secondsSinceMidnight',
         timeAttribute: 'time',
     };
+    // Mock a CSV file stream based on the above test values
+    (fs.createReadStream as jest.Mock).mockReturnValueOnce(createCsvStream(dataToCsv(data, ['id','originX','originY','time','unused'])));
 
     const { locations, errors } = await parseLocationsFromCsv('path/to/file.csv', options);
     expect(locations.length).toEqual(0);
@@ -253,15 +271,17 @@ test('Parse a csv file, wrong coordinates format', async () => {
     expect(errors).toEqual([
         {
             text: 'transit:transitRouting:errors:BatchRouteErrorOnLine',
-            params: { n: '1' }
+            params: { n: '2' }
         },
         'transit:transitRouting:errors:InvalidLocationCoordinates',
     ])
 });
 
 test('Parse a csv file, too many faulty lines', async () => {
-    const data = Array(20).fill({ foo: 'bar', unused: 'data' });
-    currentData = data;
+    const csvString = Array(20).fill("bar,data").join("\n");
+
+    (fs.createReadStream as jest.Mock).mockReturnValueOnce(createCsvStream(csvString));
+
     const options = {
         projection: '4326',
         idAttribute: 'id',
@@ -280,4 +300,109 @@ test('Parse a csv file, too many faulty lines', async () => {
     }
     expect(Array.isArray(exception)).toBeTruthy();
     expect((exception as any)[0]).toEqual('transit:transitRouting:errors:TooManyErrorsParsingFile');
+});
+
+describe('parseLocationsFromCsvStream', () => {
+    test('Parse a stream, 4326 projection, departure time, HMM times', async () => {
+        const csvContent = 'id,originX,originY,time,unused\n' +
+            'id1,-34,45,0800,0500\n' +
+            'id2,30,40,1032,0500\n';
+
+        const options = {
+            projection: '4326',
+            idAttribute: 'id',
+            xAttribute: 'originX',
+            yAttribute: 'originY',
+            timeAttributeDepartureOrArrival: 'departure' as const,
+            timeFormat: 'HMM',
+            timeAttribute: 'time',
+        };
+
+        const stream = createCsvStream(csvContent);
+        const { locations, errors } = await parseLocationsFromCsvStream(stream, options);
+
+        expect(locations.length).toEqual(2);
+        expect(errors.length).toEqual(0);
+        expect(locations[0]).toEqual(expect.objectContaining({
+            id: 'id1',
+            geography: { type: 'Point' as const, coordinates: [-34, 45]},
+            timeType: 'departure',
+            timeOfTrip: 8 * 60 * 60
+        }));
+        expect(locations[1]).toEqual(expect.objectContaining({
+            id: 'id2',
+            geography: { type: 'Point' as const, coordinates: [30, 40]},
+            timeType: 'departure',
+            timeOfTrip: 10 * 60 * 60 + 32 * 60
+        }));
+    });
+
+    test('Parse a stream with errors', async () => {
+        const csvContent = 'id,originX,originY,time,unused\n' +
+            'id1,invalid,invalid,0800,0500\n';
+
+        const options = {
+            projection: '4326',
+            idAttribute: 'id',
+            xAttribute: 'originX',
+            yAttribute: 'originY',
+            timeAttributeDepartureOrArrival: 'departure' as const,
+            timeFormat: 'HMM',
+            timeAttribute: 'time',
+        };
+
+        const stream = createCsvStream(csvContent);
+        const { locations, errors } = await parseLocationsFromCsvStream(stream, options);
+
+        expect(locations.length).toEqual(0);
+        expect(errors.length).toBeGreaterThan(0);
+    });
+
+    test('Parse a stream with arrival time and seconds format', async () => {
+        const csvContent = 'id,originX,originY,time,unused\n' +
+            'id1,-34,45,28800,0500\n' +
+            'id2,30,40,37920,0500\n';
+
+        const options = {
+            projection: '4326',
+            idAttribute: 'id',
+            xAttribute: 'originX',
+            yAttribute: 'originY',
+            timeAttributeDepartureOrArrival: 'arrival' as const,
+            timeFormat: 'secondsSinceMidnight',
+            timeAttribute: 'time',
+        };
+
+        const stream = createCsvStream(csvContent);
+        const { locations, errors } = await parseLocationsFromCsvStream(stream, options);
+
+        expect(locations.length).toEqual(2);
+        expect(errors.length).toEqual(0);
+        expect(locations[0]).toEqual(expect.objectContaining({
+            timeType: 'arrival',
+            timeOfTrip: 28800
+        }));
+        expect(locations[1]).toEqual(expect.objectContaining({
+            timeType: 'arrival',
+            timeOfTrip: 37920
+        }));
+    });
+});
+
+describe('File existence check', () => {
+    test('Throws error when file does not exist', async () => {
+        (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+        const options = {
+            projection: '4326',
+            idAttribute: 'id',
+            xAttribute: 'originX',
+            yAttribute: 'originY',
+            timeAttributeDepartureOrArrival: 'departure' as const,
+            timeFormat: 'HMM',
+            timeAttribute: 'time',
+        };
+
+        await expect(parseLocationsFromCsv('nonexistent.csv', options)).rejects.toEqual('CSV file does not exist');
+    });
 });


### PR DESCRIPTION
We move current code to a common function. The file base function will now simply create a stream from the file and pass it to that common function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream-based CSV parsing API added to accept readable streams for location imports.

* **Improvements**
  * File-existence validation and clearer progress reporting during CSV parsing.
  * Shared parsing path for file and stream inputs.

* **Tests**
  * Expanded tests for coordinate systems, time formats, streaming input, and file-missing errors.

* **Breaking change**
  * Parsed location records no longer include the original CSV line payload (now returned empty) — update downstream code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->