### PR TITLE
jobs: allow jobs to type their specific internal_data field

### DIFF
--- a/packages/transition-common/src/services/jobs/__tests__/Job.test.ts
+++ b/packages/transition-common/src/services/jobs/__tests__/Job.test.ts
@@ -20,14 +20,28 @@ type TestJobType = {
     }
 }
 
+type TestJobTypeWithInternalData = TestJobType &{
+    internal_data: {
+        internal_value1?: string;
+        internal_value2?: {
+            nestedKey: number;
+        } 
+    }
+}
+
 const jobAttributes: JobAttributes<TestJobType> = {
     id: 1,
     name: 'test' as const,
     user_id: 3,
     status: 'pending',
-    internal_data: {},
+    internal_data: { },
     data: { parameters: { foo: 'bar' } },
     resources: { files: { testFile: 'path/to/file' } }
+};
+
+const jobAttributesWithInternalData: JobAttributes<TestJobTypeWithInternalData> = {
+    ...jobAttributes,
+    internal_data: { checkpoint: 100, internal_value1: 'value1' }
 };
 
 test('Test constructor', () => {
@@ -44,3 +58,17 @@ test('Test constructor: without resources', () => {
     expect(mainJobObj.attributes.name).toEqual('test');
     expect((mainJobObj.attributes as any).status).toBeUndefined();
 });
+
+test('Test setting internal data', () => {
+    const mainJobObj = new Job<TestJobTypeWithInternalData>(jobAttributesWithInternalData);
+    expect(mainJobObj.attributes.internal_data).toEqual(jobAttributesWithInternalData.internal_data);
+    // Set new values for internal data
+    mainJobObj.attributes.internal_data.internal_value2 = { nestedKey: 42 };
+    mainJobObj.attributes.internal_data.internal_value1 = 'new value';
+    mainJobObj.attributes.internal_data.checkpoint = 200;
+    expect(mainJobObj.attributes.internal_data).toEqual({
+        checkpoint: 200,
+        internal_value1: 'new value',
+        internal_value2: { nestedKey: 42 }
+    });
+})


### PR DESCRIPTION
The internal helps a job manage its internal state. Currently, there is a single `checkpoint` field that allows to resume a `Job` at a specific point. Batch route and accessibility map jobs make use of it.

But there may be additional internal data that a job may store, for example the evolutionary algorithm network design Job may want to save various states and/or calculated cost data for each generation. An additional type gives more flexibility to the job type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs now support optional internal state storage with built-in checkpoint tracking to improve recovery and resumability.
  * Job attributes accept custom internal metadata alongside the default checkpoint field for flexible per-job volatile state.

* **Tests**
  * Added tests covering initialization, mutation, and checkpointing of internal job state to validate persistence and recovery behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->