### PR TITLE
Add accessibility weight calculation feature

### DIFF
--- a/docs/weighting/IntrinsicAndAccessibilityWeights.md
+++ b/docs/weighting/IntrinsicAndAccessibilityWeights.md
@@ -1,12 +1,28 @@
-# Weighting POIs, Homes, Destinations, and Transit Nodes Attractiveness
+# Intrinsic and Accessibility Weights: Weighting POIs, Homes, Destinations, and Transit Nodes Attractiveness
 
-**Weighting in transport modeling** assigns relative attractiveness values to destinations, points of interest (POIs), homes, and transit nodes/facilities based on their capacity to generate or attract trips. A downtown skyscraper with 5,000 jobs and thousands of customers carries far more weight than a suburban office with a small number of employees and few shops; a major shopping mall with a residential tower attracts more trips than a corner store in a suburb with only detached single-household homes. This differential weighting, combined with distance/travel time decay functions recognizing people travel shorter distances more willingly, forms the mathematical foundation of spatial interaction models predicting how travel demand distributes across networks.
+**Weighting in transport modeling** assigns relative values to destinations, points of interest (POIs), homes, and transit nodes/facilities based on their capacity to generate or attract trips and their position in the network.
 
-These models matter profoundly for transportation planning, especially transit planning. A bus stop surrounded by 10,000 residents within 400 meters has fundamentally different ridership potential than an isolated stop serving 500 people. Gravity-based accessibility measures quantify this by summing weighted opportunities ($\sum W_j / \text{distance}^\beta$) within catchment areas. Distance can always be replaced by walking/cycling/transit or driving travel time for more accurate modeling in congested or multi-modal contexts.
+Two distinct concepts are essential to distinguish:
+
+1.  **Intrinsic Weight** ($W_j$): The property of the location itself—what it generates or contains (employees, residents, measured ridership, floor area, etc.).
+2.  **Accessibility Weight** ($A_i$): A measure derived from the environment—what a location can "reach" or "capture" based on its location relative to intrinsic weights, calculated via a gravity model.
+
+A downtown skyscraper with 5,000 jobs (high **intrinsic weight**) carries far more potential than a suburban office with few employees. However, the **accessibility weight** of a place (e.g. a transit stop, a home, or a POI) depends on how many of these high-intrinsic-weight locations are within reach.
+
+This distinction forms the mathematical foundation of spatial interaction models predicting how travel demand distributes across networks.
+
+These models matter profoundly for transportation planning, especially transit planning. For example, a bus stop surrounded by 10,000 residents within 400 meters has fundamentally different ridership potential than an isolated stop serving 500 people. Gravity-based **accessibility weights** quantify this by summing opportunities weighted by distance ($\sum W_{intrinsic,j} / \text{distance}^\beta$) within catchment areas. Distance can always be replaced by walking/cycling/transit or driving travel time for more accurate modeling in congested or multi-modal contexts.
 
 ## Foundational concepts in gravity modeling
 
-Hansen's seminal 1959 work established accessibility as "potential for opportunities for interaction", introducing the gravity-based formulation: $A_i = \sum_j (W_j \times f(d_{ij}))$. The **gravity model** for trip distribution writes $T_{ij} = k \times (P_i^\lambda \times P_j^\alpha) / d_{ij}^\beta$, where $T_{ij}$ represents trips from origin $i$ to destination $j$, $P_i$ and $P_j$ are respective populations or attractiveness measures, $d_{ij}$ is separation distance (or travel time), and $\beta$ is the critical distance-decay parameter. Wilson's doubly-constrained gravity model (1967) ensures trip origins and destinations sum to known totals, making it the workhorse of four-step travel demand models worldwide.
+Hansen's seminal 1959 work established accessibility as "potential for opportunities for interaction", introducing the gravity-based formulation: $A_i = \sum_j (W_j \times f(d_{ij}))$.
+
+In our terminology:
+*   $A_i$ is the **Accessibility Weight** of location $i$
+*   $W_j$ is the **Intrinsic Weight** of destination $j$
+*   $f(d_{ij})$ is the decay function based on distance or time
+
+The **gravity model** for trip distribution writes $T_{ij} = k \times (P_i^\lambda \times P_j^\alpha) / d_{ij}^\beta$, where $T_{ij}$ represents trips from origin $i$ to destination $j$, $P_i$ and $P_j$ are respective populations or **intrinsic weights**, $d_{ij}$ is separation distance (or travel time), and $\beta$ is the critical distance-decay parameter. Wilson's doubly-constrained gravity model (1967) ensures trip origins and destinations sum to known totals, making it the workhorse of four-step travel demand models worldwide.
 
 ### Distance and travel time decay functions
 
@@ -144,11 +160,11 @@ Standard planning practice specifies catchment areas based on typical walking ti
 
 Note: Catchment analysis is not yet implemented in Transition
 
-## POI weighting methodologies by activity type
+## Intrinsic Weight methodologies by activity type
 
-Points of Interest require differential weighting reflecting their trip generation/attraction capacity:
+Points of Interest require differential **intrinsic weighting** reflecting their trip generation/attraction capacity:
 
-| Weight Type | Methodology | Typical Values/Conversions | Data Source | Application |
+| Intrinsic Weight Type | Methodology | Typical Values/Conversions | Data Source | Application |
 |-------------|-------------|---------------------------|-------------|-------------|
 | **Employment** | Weight = Jobs | Sector-specific refinement | LEHD LODES | Work travel modeling (gold standard) |
 | **Floor area** | $\text{Weight} = \text{Area} \times \text{Trip rate}$ | Retail: 35-45 trips/1000ft²<br>Office: 10-15 trips/1000ft²<br>Residential: 8-10 trips/unit | ITE Trip Generation Manual | When employment unavailable |
@@ -175,31 +191,37 @@ The Institute of Transportation Engineers Trip Generation Manual provides empiri
 - Internal capture for mixed-use: Use NCHRP Report 684 methodology
 - Using OD trips from travel surveys are very useful to adjust and calibrate trip generation rates by type of POI or home, but more research is needed to get meaningful results.
 
-## Gravity-based transit stop attractiveness formulas
+### Aggregation Example: Shopping Mall
 
-Transit stop attractiveness combines service quality with surrounding land use through gravity-weighted accessibility measures.
+When assigning intrinsic weights to complex venues like a shopping mall, two approaches are possible:
+1.  **Disaggregated**: Treat each shop as a distinct POI with its own intrinsic weight (e.g., specific floor area or employment), mapping each to its specific entrance inside the mall.
+2.  **Aggregated**: Sum the intrinsic weights of all individual shops to get a single, cumulative intrinsic weight to the mall as a whole and assign it to the main entrance.
+
+## Gravity-based accessibility weight formulas
+
+**Accessibility weight** is a measure that can be calculated for any location (Home, POI, Transit Node). When applied to transit stops, it often combines service quality with surrounding land use through gravity-weighted accessibility measures.
 
 ### Basic formulas
 
 | Measure | Formula | Application | Reference |
 |---------|---------|-------------|-----------|
-| **Basic accessibility** | $A_{\text{stop}} = \sum (\text{Weight POI} / \text{distance}^\beta)$ | POI-weighted catchment | Hansen (1959) |
-| **Service-weighted** | $A_{\text{stop}} = \text{Frequency} \times \sum (\text{Weight POI} / \text{distance}^\beta)$ | Combines service & land use | Standard four-step modeling |
+| **Basic accessibility** | $A_i = \sum (\text{Intrinsic Weight}_ j / \text{distance}^\beta)$ | POI-weighted catchment for any place $i$ | Hansen (1959) |
+| **Service-weighted** | $A_{\text{stop}} = \text{Frequency} \times \sum (\text{Intrinsic Weight}_ j / \text{distance}^\beta)$ | Combines service & land use for stops | Standard four-step modeling |
 | **Population-weighted** | $\text{Pop weighted} = \sum (\text{Pop}_ i \times \exp(-\beta \times \text{distance}_ i))$ | Trip generation potential | Bartzokas-Tsiompras (2019) |
 | **Employment accessibility** | $\text{Jobs access} = \sum (\text{Jobs}_ j \times \exp(-\beta \times \text{transit time}_ {ij}))$ | Job access equity metric | Geurs & van Wee (2004) |
 | **Combined index** | $I_{\text{stop}} = \sum w_i \times \text{Component}_ i$ | Multi-factor integration | Calibrated via regression |
 
 **Combined index components:** frequency, population-weighted, employment-weighted, retail-weighted, network centrality
 
-### Travel time-based transit accessibility
+### Travel time-based accessibility
 
-**Hansen accessibility with travel time:**
+**Hansen accessibility weight with travel time:**
 
 $$A_i = \sum_j (O_j \times \exp(-\beta \times t_{ij}))$$
 
 **Where:**
-- $A_i$ = accessibility index for location $i$
-- $O_j$ = opportunities at destination $j$ (jobs, services, POIs). Could also include homes. Each of the opportunities can be weighted for its own attractivity as explained previously (would become $W_j$).
+- $A_i$ = **accessibility weight** / index for location $i$ (e.g. a home, a POI or a transit stop)
+- $O_j$ = **intrinsic weight** / opportunities at destination $j$ (jobs, services, POIs). Could also include homes. Each of the opportunities can be weighted for its own attractivity as explained previously (would become $W_j$).
 - $t_{ij}$ = travel time from $i$ to $j$ (minutes)
 - $\beta$ = time decay parameter (0.08-0.12 for employment)
 
@@ -209,7 +231,7 @@ $$A_{\text{stop}} = f_{\text{stop}} \times \sum_j (W_j \times \exp(-\beta_{\text
 
 **Where:**
 - $f_{\text{stop}}$ = service frequency (departures/hour)
-- $W_j$ = weight of POI/destination $j$
+- $W_j$ = **intrinsic weight** of POI/destination $j$
 - $t_{\text{walk},ij}$ = walking time from stop to POI $j$ (minutes)
 - $\beta_{\text{walk}}$ = walking time decay parameter (typically 0.20-0.30)
 
@@ -217,14 +239,14 @@ $$A_{\text{stop}} = f_{\text{stop}} \times \sum_j (W_j \times \exp(-\beta_{\text
 
 $$A_{i,\text{transit}} = \sum_{\text{stops}} \sum_{\text{jobs}} (\text{Jobs}_ j \times \exp(-\beta_{\text{walk}} \times t_{\text{walk}} - \beta_{\text{wait}} \times t_{\text{wait}} - \beta_{\text{IVT}} \times t_{\text{IVT}}))$$
 
-**Example calculation:** Transit stop job accessibility with 6 departures/hour:
+**Example calculation:** Transit stop job accessibility (accessibility weight) with 6 departures/hour:
 
 $$A_{\text{stop}} = 6 \times \sum(\text{Jobs}_ j \times \exp(-0.25 \times \text{walking time in minutes}_ j))$$
 
 For jobs within 10-minute walk:
-- 1000 jobs at 3 min walk: $1000 \times \exp(-0.75) = 472$ effective jobs
-- 2000 jobs at 7 min walk: $2000 \times \exp(-1.75) = 347$ effective jobs
-- Total accessibility: $6 \times (472 + 347) = 4914$ job-departures/hour
+- 1000 jobs (**intrinsic**) at 3 min walk: $1000 \times \exp(-0.75) = 472$ effective jobs
+- 2000 jobs (**intrinsic**) at 7 min walk: $2000 \times \exp(-1.75) = 347$ effective jobs
+- Total **accessibility weight**: $6 \times (472 + 347) = 4914$ job-departures/hour
 
 ### Example illustration
 
@@ -239,11 +261,11 @@ This image illustrates a simple pedestrian network connecting points of interest
 
 For instance, if we set a maximum access/egress walking time of 6 min, we can see that some stops can be reached by more than one set of POIs/green dots. This overlap is normal because each POI has a choice of accessible nodes nearby, allowing for multiple paths and node options in accessibility calculations.
 
-### Example Weight Calculation
+### Example Accessibility Weight Calculation
 
-Using a simple gravity model with impedance function $f(t) = 1 / t^2$ (power of 2), assuming each POI (green dots) has a weight of 1:
+Using a simple gravity model with impedance function $f(t) = 1 / t^2$ (power of 2), assuming each POI (green dots) has an **intrinsic weight** of 1:
 
-| Transit Node | Connected POIs with access time | Weight calculation $\sum(1/t^2)$ | Total Node Weight |
+| Transit Node | Connected POIs with access time | Accessibility Weight calculation $\sum(1/t^2)$ | Total Accessibility Weight |
 |--------------|-------------------------------|---------------------------|--------------|
 | A | 3 POIs at 3 min, 2 POIs at 2 min | $3 / 3^2 + 2 / 2^2$ | 0.833 |
 | B | 1 POI at 3 min, 2 POIs at 1 min, 1 POI at 4 min, 3 POIs at 6 min| $1 / 3^2 + 2 / 1^2 + 1 / 4^2 + 3 / 6^2$ | 2.257 |
@@ -254,8 +276,8 @@ Using a simple gravity model with impedance function $f(t) = 1 / t^2$ (power of 
 Travel surveys provide observed destination choice patterns that validate and calibrate theoretical accessibility models. Survey respondents' actual destinations reveal how people make spatial choices.
 
 **Key considerations:**
-- **Survey weights application**: Use trip weights for total trips estimation: $\text{Trips annual} = \sum(\text{trip weight}_ i \times \text{trips}_ i)$; use person weights for destination choice probabilities
-- **Destination choice modeling**: Multinomial logit where POI weight (employment, floor area, composite) appears in utility function: $P_{ij} = \exp(V_{ij}) / \sum_k \exp(V_{ik})$ where $V_{ij} = \alpha \times \ln(\text{Size}_ j) - \beta \times \text{TravelCost}_ {ij} + \gamma \times \text{Attributes}_ j$
+- **Survey weights application**: Use trip weights for total trips estimation: $\text{Trips annual} = \sum(\text{trip weight}_ i \times \text{trips}_ i)$; use person weights for destination choice probabilities. Note that survey weights are distinct from intrinsic/accessibility weights.
+- **Destination choice modeling**: Multinomial logit where **intrinsic weight** (employment, floor area, composite) appears in utility function: $P_{ij} = \exp(V_{ij}) / \sum_k \exp(V_{ik})$ where $V_{ij} = \alpha \times \ln(\text{Intrinsic Weight}_ j) - \beta \times \text{TravelCost}_ {ij} + \gamma \times \text{Attributes}_ j$
 - **Model validation**: Compare predicted vs. observed trip distributions (target $R^2 > 0.85$); match trip length distributions
 
 For a summarized survey weighting description, see [companion document on travel survey weighting](travelSurveyWeighting.md).
@@ -298,7 +320,7 @@ Bertolini's node-place model (1999) provides an elegant framework for evaluating
 **Results:**
 - Distance-based: $f(d) = \exp(-0.10 \times 5) = 0.607$
 - Time-based (auto): $f(t) = \exp(-0.08 \times 15) = 0.301$
-- Time-based (walk): $f(t) = \exp(-0.25 \times 60) = 1.5 \times 10^{-7}$
+- Time-based (walk): $f(t) = \exp(-0.25 \times 60) = 3.06 \times 10^{-7}$
 
 **Conclusion:** Time-based functions better capture mode-specific accessibility differences, especially in multi-modal and congested contexts.
 

--- a/docs/weighting/IntrinsicAndAccessibilityWeights_fr.md
+++ b/docs/weighting/IntrinsicAndAccessibilityWeights_fr.md
@@ -1,12 +1,28 @@
 # Pondération des points d'intérêt, domiciles, destinations et attractivité des nœuds de transport collectif
 
-**La pondération en modélisation des transports** attribue des valeurs d'attractivité relatives aux destinations, points d'intérêt (POI), domiciles et nœuds/stations de transport collectif en fonction de leur capacité à générer ou attirer des déplacements. Un édifice du centre-ville avec 5000 emplois et des milliers de clients a un poids bien plus important qu'un bureau de banlieue avec un petit nombre d'employés et quelques commerces; un grand centre commercial avec une tour résidentielle attire plus de déplacements qu'un dépanneur dans une banlieue composée uniquement de maisons unifamiliales détachées. Cette pondération différentielle, combinée à des fonctions de décroissance en fonction de la distance ou du temps de déplacement reconnaissant que les gens voyagent plus volontiers sur de courtes distances, constitue le fondement mathématique des modèles d'interaction spatiale qui prédisent comment la demande de déplacement se distribue sur les réseaux.
+**La pondération en modélisation des transports** attribue des valeurs relatives aux destinations, points d'intérêt (POI), domiciles et nœuds/stations de transport collectif en fonction de leur capacité à générer ou attirer des déplacements.
 
-Ces modèles sont d'une importance capitale pour la planification du transport, en particulier la planification du transport collectif. Un arrêt de bus entouré de 10 000 résidents dans un rayon de 400 mètres a un potentiel d'achalandage fondamentalement différent d'un arrêt isolé desservant 500 personnes. Les mesures d'accessibilité basées sur la gravité quantifient cela en additionnant les opportunités pondérées ($\sum W_j / \text{distance}^\beta$) dans les zones de desserte. La distance peut être remplacée par le temps de déplacement à pied/à vélo/en transport collectif ou en voiture pour une modélisation plus précise dans des contextes de congestion ou multimodaux.
+Deux concepts distincts sont essentiels à distinguer :
+
+1.  **Poids propre** (*Intrinsic Weight*, $W_j$) : La propriété intrinsèque du lieu lui-même — ce qu'il génère ou contient (employés, résidents, achalandage mesuré, surface de plancher, etc.).
+2.  **Poids d'accessibilité** (*Accessibility Weight*, $A_i$) : Une mesure dérivée de l'environnement — ce que le lieu peut "capter" ou "atteindre" selon sa localisation par rapport aux poids propres, calculée via un modèle gravitaire.
+
+Un édifice du centre-ville avec 5000 emplois (haut **poids propre**) a un potentiel bien plus important qu'un bureau de banlieue. Cependant, le **poids d'accessibilité** d'un lieu (ex: un arrêt de transport, un domicile ou un POI) dépend de combien de ces lieux à haut poids propre sont à sa portée.
+
+Cette distinction constitue le fondement mathématique des modèles d'interaction spatiale qui prédisent comment la demande de déplacement se distribue sur les réseaux.
+
+Ces modèles sont d'une importance capitale pour la planification du transport, en particulier la planification du transport collectif. Par exemple, un arrêt de bus entouré de 10 000 résidents dans un rayon de 400 mètres a un potentiel d'achalandage fondamentalement différent d'un arrêt isolé desservant 500 personnes. Les **poids d'accessibilité** basés sur la gravité quantifient cela en additionnant les opportunités pondérées ($\sum W_{propre,j} / \text{distance}^\beta$) dans les zones de desserte. La distance peut être remplacée par le temps de déplacement à pied/à vélo/en transport collectif ou en voiture pour une modélisation plus précise dans des contextes de congestion ou multimodaux.
 
 ## Concepts fondamentaux de la modélisation gravitaire
 
-Les travaux de Hansen en 1959 ont établi l'accessibilité comme un "potentiel d'opportunités d'interaction", introduisant la formulation basée sur la gravité: $A_i = \sum_j (W_j \times f(d_{ij}))$. Le **modèle gravitaire** pour la distribution des déplacements s'écrit $T_{ij} = k \times (P_i^\lambda \times P_j^\alpha) / d_{ij}^\beta$, où $T_{ij}$ représente les déplacements de l'origine $i$ vers la destination $j$, $P_i$ et $P_j$ sont les populations respectives ou les mesures d'attractivité, $d_{ij}$ est la distance de séparation (ou le temps de déplacement), et $\beta$ est le paramètre critique de décroissance en fonction de la distance. Le modèle gravitaire doublement contraint de Wilson (1967) assure que les origines et destinations des déplacements totalisent des valeurs connues, ce qui en fait le pilier des modèles de demande de transport en quatre étapes dans le monde entier.
+Les travaux de Hansen en 1959 ont établi l'accessibilité comme un "potentiel d'opportunités d'interaction", introduisant la formulation basée sur la gravité: $A_i = \sum_j (W_j \times f(d_{ij}))$.
+
+Dans notre terminologie :
+*   $A_i$ est le **Poids d'accessibilité** du lieu $i$
+*   $W_j$ est le **Poids propre** de la destination $j$
+*   $f(d_{ij})$ est la fonction de décroissance selon la distance ou le temps
+
+Le **modèle gravitaire** pour la distribution des déplacements s'écrit $T_{ij} = k \times (P_i^\lambda \times P_j^\alpha) / d_{ij}^\beta$, où $T_{ij}$ représente les déplacements de l'origine $i$ vers la destination $j$, $P_i$ et $P_j$ sont les populations respectives ou les **poids propres** (mesures d'attractivité), $d_{ij}$ est la distance de séparation (ou le temps de déplacement), et $\beta$ est le paramètre critique de décroissance en fonction de la distance. Le modèle gravitaire doublement contraint de Wilson (1967) assure que les origines et destinations des déplacements totalisent des valeurs connues, ce qui en fait le pilier des modèles de demande de transport en quatre étapes dans le monde entier.
 
 ### Fonctions de décroissance en fonction de la distance et du temps de déplacement
 
@@ -102,7 +118,7 @@ Les études empiriques montrent que les valeurs de $\beta$ varient considérable
 4. Zones de desserte du transport collectif avec des vitesses de marche variées
 5. Modélisation de la demande de transport en quatre étapes (norme NCHRP 716)
 
-Transition utilise les résultats de temps de parcours retournés par les engins de calcul de chemin intégrés pour la marche, le vélo, le transport collectif et la voiture, mais peut également utiliser la distance réseau ou la distance Euclidienne/à vol d'oiseau lorsque les engins de calcul de chemins ne sont pas disponibles ou pour compléter des tests.
+Transition utilise les résultats de temps de parcours retournés par les engins de calcul de chemin intégrés pour la marche, le vélo, le transport collectif et la voiture, mais peut également utiliser la distance réseau ou la distance euclidienne/à vol d'oiseau lorsque les engins de calcul de chemins ne sont pas disponibles ou pour compléter des tests.
 
 **Facteurs de conversion typiques:**
 
@@ -135,7 +151,7 @@ La pratique de planification standard spécifie des zones de desserte basées su
 | Station SRB | 600 m | 7.5 min | 0.7× | 0.9× additionnel | ~380 m | ITDP (2017); Deng & Nelson (2011) |
 
 **Approches de calcul:**
-- **Circulaire (Euclidienne)**: Simple mais surestime de 20 à 40%
+- **Circulaire (euclidienne)**: Simple mais surestime de 20 à 40%
 - **Distance réseau**: Utilise les chemins piétons réels, plus précis
 - **Basée sur l'énergie**: Tient compte de la topographie—un gain d'élévation de 30m ajoute 20% de temps, 35% d'énergie (Bartzokas-Tsiompras & Photis, 2019)
 - **Basée sur le temps de déplacement**: Plus précis pour les contextes multimodaux et congestionnés
@@ -144,11 +160,11 @@ La pratique de planification standard spécifie des zones de desserte basées su
 
 Note: Les zones de desserte/attractivité des arrêts ne sont pas encore prises en compte dans Transition.
 
-## Méthodologies de pondération des POI par type d'activité
+## Méthodologies de pondération des POI (Poids propre) par type d'activité
 
-Les points d'intérêt nécessitent une pondération différentielle reflétant leur capacité de génération/attraction de déplacements:
+Les points d'intérêt nécessitent une **pondération intrinsèque (poids propre)** différentielle reflétant leur capacité de génération/attraction de déplacements:
 
-| Type de poids | Méthodologie | Valeurs/conversions typiques | Source de données | Application |
+| Type de poids propre | Méthodologie | Valeurs/conversions typiques | Source de données | Application |
 |---------------|--------------|------------------------------|-------------------|-------------|
 | **Emploi** | Poids = Emplois | Raffinement spécifique au secteur | LEHD LODES | Modélisation des déplacements domicile-travail (étalon-or) |
 | **Surface de plancher** | $\text{Poids} = \text{Surface} \times \text{Taux de déplacement}$ | Commerce: 35-45 dép./1000pi²<br>Bureau: 10-15 dép./1000pi²<br>Résidentiel: 8-10 dép./unité | Manuel de génération de déplacements ITE | Quand l'emploi n'est pas disponible |
@@ -175,31 +191,37 @@ Le manuel de génération de déplacements de l'Institute of Transportation Engi
 - Capture interne pour usage mixte: Utiliser la méthodologie du rapport NCHRP 684
 - L'utilisation de déplacements OD à partir d'enquêtes de mobilité est très utile pour ajuster et calibrer les taux de génération par type de lieu ou domicile, mais davantage de travaux de recherche sont requis pour obtenir des résultats probants.
 
-## Formules d'attractivité des arrêts de transport collectif basées sur la gravité
+### Exemple d'agrégation : Centre commercial
 
-L'attractivité des arrêts de transport collectif combine la qualité du service avec l'usage du sol environnant à travers des mesures d'accessibilité pondérées par gravité.
+Lors de l'attribution de poids propres à des lieux complexes comme un centre commercial, deux approches sont possibles :
+1.  **Désagrégée** : Traiter chaque commerce comme un POI distinct avec son propre poids propre (ex : surface de plancher ou emploi spécifique), en cartographiant chacun à son entrée spécifique dans le centre.
+2.  **Agrégée** : Somme des poids propres de tous les commerces individuels pour obtenir un poids propre unique et cumulatif à l'ensemble du centre commercial, assigné ensuite à la porte principale.
+
+## Formules de poids d'accessibilité basées sur la gravité
+
+Le **poids d'accessibilité** est une mesure qui peut être calculée pour n'importe quel lieu (Domicile, POI, Nœud de transport). Lorsqu'appliqué aux arrêts de transport collectif, il combine souvent la qualité du service avec l'usage du sol environnant à travers des mesures d'accessibilité pondérées par gravité.
 
 ### Formules de base
 
 | Mesure | Formule | Application | Référence |
 |--------|---------|-------------|-----------|
-| **Accessibilité de base** | $A_{\text{arrêt}} = \sum (\text{Poids POI} / \text{distance}^\beta)$ | Zone de desserte pondérée par POI | Hansen (1959) |
-| **Pondérée par le service** | $A_{\text{arrêt}} = \text{Fréquence} \times \sum (\text{Poids POI} / \text{distance}^\beta)$ | Combine le service et l'usage du sol | Modélisation standard en quatre étapes |
+| **Accessibilité de base** | $A_i = \sum (\text{Poids propre POI} / \text{distance}^\beta)$ | Zone de desserte pondérée pour tout lieu $i$ | Hansen (1959) |
+| **Pondérée par le service** | $A_{\text{arrêt}} = \text{Fréquence} \times \sum (\text{Poids propre POI} / \text{distance}^\beta)$ | Combine le service et l'usage du sol pour les arrêts | Modélisation standard en quatre étapes |
 | **Pondérée par la population** | $\text{Pop pondérée} = \sum (\text{Pop}_ i \times \exp(-\beta \times \text{distance}_ i))$ | Potentiel de génération de déplacements | Bartzokas-Tsiompras (2019) |
 | **Accessibilité à l'emploi** | $\text{Accès emplois} = \sum (\text{Emplois}_ j \times \exp(-\beta \times \text{temps TC},ij))$ | Métrique d'équité d'accès aux emplois | Geurs & van Wee (2004) |
 | **Indice combiné** | $I_{\text{arrêt}} = \sum w_i \times \text{Composante}_ i$ | Intégration multi-facteurs | Calibré via régression |
 
 **Composantes de l'indice combiné:** fréquence, pondérée par la population, pondérée par l'emploi, pondérée par le commerce de détail, centralité du réseau
 
-### Accessibilité du transport collectif basée sur le temps de déplacement
+### Accessibilité basée sur le temps de déplacement
 
-**Accessibilité de Hansen avec temps de déplacement:**
+**Poids d'accessibilité de Hansen avec temps de déplacement:**
 
 $$A_i = \sum_j (O_j \times \exp(-\beta \times t_{ij}))$$
 
 **Où:**
-- $A_i$ = indice d'accessibilité pour l'emplacement $i$
-- $O_j$ = opportunités à la destination $j$ (emplois, services, POI). Peut également inclure les domiciles. Chacune des opportunités peut être pondérée pour sa propre attractivité comme expliqué précédemment (deviendrait $W_j$).
+- $A_i$ = **poids d'accessibilité** / indice d'accessibilité pour l'emplacement $i$ (ex: un domicile, un POI ou un arrêt de transport)
+- $O_j$ = **poids propre** / opportunités à la destination $j$ (emplois, services, POI). Peut également inclure les domiciles. Chacune des opportunités peut être pondérée pour sa propre attractivité comme expliqué précédemment (deviendrait $W_j$).
 - $t_{ij}$ = temps de déplacement de $i$ à $j$ (minutes)
 - $\beta$ = paramètre de décroissance temporelle (0.08-0.12 pour l'emploi)
 
@@ -209,7 +231,7 @@ $$A_{\text{arrêt}} = f_{\text{arrêt}} \times \sum_j (W_j \times \exp(-\beta_{\
 
 **Où:**
 - $f_{\text{arrêt}}$ = fréquence de service (départs/heure)
-- $W_j$ = poids du POI/destination $j$
+- $W_j$ = **poids propre** du POI/destination $j$
 - $t_{\text{marche},ij}$ = temps de marche de l'arrêt au POI $j$ (minutes)
 - $\beta_{\text{marche}}$ = paramètre de décroissance du temps de marche (typiquement 0.20-0.30)
 
@@ -217,14 +239,14 @@ $$A_{\text{arrêt}} = f_{\text{arrêt}} \times \sum_j (W_j \times \exp(-\beta_{\
 
 $$A_{i,\text{TC}} = \sum_{\text{arrêts}} \sum_{\text{emplois}} (\text{Emplois}_ j \times \exp(-\beta_{\text{marche}} \times t_{\text{marche}} - \beta_{\text{attente}} \times t_{\text{attente}} - \beta_{\text{IVT}} \times t_{\text{IVT}}))$$
 
-**Exemple de calcul:** Accessibilité aux emplois d'un arrêt de transport collectif avec 6 départs/heure:
+**Exemple de calcul:** Accessibilité aux emplois (poids d'accessibilité) d'un arrêt de transport collectif avec 6 départs/heure:
 
 $$A_{\text{arrêt}} = 6 \times \sum(\text{Emplois}_ j \times \exp(-0.25 \times \text{temps de marche en minutes}_ j))$$
 
 Pour les emplois dans un rayon de 10 minutes de marche:
-- 1000 emplois à 3 min de marche: $1000 \times \exp(-0.75) = 472$ emplois effectifs
-- 2000 emplois à 7 min de marche: $2000 \times \exp(-1.75) = 347$ emplois effectifs
-- Accessibilité totale: $6 \times (472 + 347) = 4\,914$ emplois-départs/heure
+- 1000 emplois (**poids propre**) à 3 min de marche: $1000 \times \exp(-0.75) = 472$ emplois effectifs
+- 2000 emplois (**poids propre**) à 7 min de marche: $2000 \times \exp(-1.75) = 347$ emplois effectifs
+- **Poids d'accessibilité** total: $6 \times (472 + 347) = 4\,914$ emplois-départs/heure
 
 ### Illustration d'exemple
 
@@ -239,11 +261,11 @@ Cette image illustre un réseau piéton simple reliant des points d'intérêt (P
 
 Si nous fixons par exemple un temps de marche d'accès maximum de 6 min, nous pouvons voir que certains nœuds peuvent être atteints par plus d'un ensemble de POI/points verts. Ce chevauchement est normal car chaque POI a le choix de nœuds accessibles à proximité, permettant de multiples chemins et options de nœuds dans les calculs d'accessibilité.
 
-### Exemple de Calcul de Poids
+### Exemple de Calcul de Poids d'Accessibilité
 
-En utilisant un modèle gravitaire simple avec fonction d'impédance $f(t) = 1 / t^2$ (puissance de 2) et en supposant des poids de 1 pour chaque POI (points verts):
+En utilisant un modèle gravitaire simple avec fonction d'impédance $f(t) = 1 / t^2$ (puissance de 2) et en supposant des **poids propres** de 1 pour chaque POI (points verts):
 
-| Nœud d'arrêt | POI connectés avec temps d'accès | Calcul du poids $\sum(1/t^2)$ | Poids total du nœud |
+| Nœud d'arrêt | POI connectés avec temps d'accès | Calcul du poids d'accessibilité $\sum(1/t^2)$ | Poids d'accessibilité total du nœud |
 |--------------|-------------------------------|---------------------------|--------------|
 | A | 3 POIs à 3 min, 2 POIs à 2 min | $3 / 3^2 + 2 / 2^2$ | 0.833 |
 | B | 1 POI à 3 min, 2 POIs à 1 min, 1 POI à 4 min, 3 POIs à 6 min| $1 / 3^2 + 2 / 1^2 + 1 / 4^2 + 3 / 6^2$ | 2.257 |
@@ -254,8 +276,8 @@ En utilisant un modèle gravitaire simple avec fonction d'impédance $f(t) = 1 /
 Les enquêtes de déplacements fournissent des modèles de choix de destination observés qui valident et calibrent les modèles d'accessibilité théoriques. Les destinations réelles des répondants aux enquêtes révèlent comment les gens font des choix spatiaux.
 
 **Considérations clés:**
-- **Application des poids d'enquête**: Utiliser les poids de déplacement pour l'estimation des déplacements totaux : $\text{Déplacements annuels} = \sum(\text{poids déplacement}_ i \times \text{déplacements}_ i)$; utiliser les poids de personne pour les probabilités de choix de destination
-- **Modélisation du choix de destination**: Logit multinomial où le poids du POI (emploi, surface de plancher, composite) apparaît dans la fonction d'utilité: $P_{ij} = \exp(V_{ij}) / \sum_k \exp(V_{ik})$ où $V_{ij} = \alpha \times \ln(\text{Taille}_ j) - \beta \times \text{Coût déplacement}_ {ij} + \gamma \times \text{Attributs}_ j$
+- **Application des poids d'enquête**: Utiliser les poids de déplacement pour l'estimation des déplacements totaux : $\text{Déplacements annuels} = \sum(\text{poids déplacement}_ i \times \text{déplacements}_ i)$; utiliser les poids de personne pour les probabilités de choix de destination. Noter que les poids d'enquête sont distincts des poids propres/d'accessibilité.
+- **Modélisation du choix de destination**: Logit multinomial où le **poids propre** du POI (emploi, surface de plancher, composite) apparaît dans la fonction d'utilité: $P_{ij} = \exp(V_{ij}) / \sum_k \exp(V_{ik})$ où $V_{ij} = \alpha \times \ln(\text{Poids Propre}_ j) - \beta \times \text{Coût déplacement}_ {ij} + \gamma \times \text{Attributs}_ j$
 - **Validation du modèle**: Comparer les distributions de déplacements prédites vs observées (cible $R^2 > 0.85$); faire correspondre les distributions de longueur de déplacement
 
 Pour la méthodologie détaillée de pondération des enquêtes, voir le [document complémentaire sur la pondération des enquêtes de déplacements](travelSurveyWeighting_fr.md).

--- a/docs/weighting/README.md
+++ b/docs/weighting/README.md
@@ -1,9 +1,9 @@
-# Weighting Documentation
+# Weighting and Weight Types Documentation
 
-This directory contains documentation on weighting methodologies for transportation planning. We provide [summary and generalized information on POI and transit node/stops weighting](poiAndTransitNodeWeighting.md), an [explanation of travel survey weighting](travelSurveyWeighting.md), and a link to the [Transition-specific methodology](transitionMethodology.md).
+This directory contains documentation on weighting methodologies and weight types for transportation planning. We provide [summary and generalized information on the two types of weights: intrinsic and accessibility weights](IntrinsicAndAccessibilityWeights.md), an [explanation of travel survey weighting](travelSurveyWeighting.md), and a link to the [Transition-specific methodology](transitionMethodology.md).
 
 ## Table of Contents
 
-- [POI and Transit Node/Stop Weighting](poiAndTransitNodeWeighting.md)
+- [Intrinsic and Accessibility Weights](IntrinsicAndAccessibilityWeights.md)
 - [Travel Survey Weighting](travelSurveyWeighting.md)
-- [Transition Methodology](transitionMethodology.md)
+- [Transition-specific Methodology](transitionMethodology.md)

--- a/docs/weighting/README_fr.md
+++ b/docs/weighting/README_fr.md
@@ -1,9 +1,9 @@
-# Documentation sur la Pondération
+# Documentation sur la pondération et les types de poids
 
-Ce répertoire contient de la documentation sur les méthodologies de pondération pour la planification des transports. Nous fournissons un [résumé et des informations généralisées sur la pondération des POI et des nœuds/arrêts de transport collectif](poiAndTransitNodeWeighting_fr.md), une [explication de la pondération des enquêtes de déplacement](travelSurveyWeighting_fr.md), et un lien vers la [méthodologie spécifique à Transition](transitionMethodology_fr.md).
+Ce répertoire contient de la documentation sur les méthodologies de pondération et les types de poids en planification des transports. Nous fournissons un [résumé et des informations généralisées sur les deux types de poids: poids propres et d'accessibilité](IntrinsicAndAccessibilityWeights_fr.md), une [explication de la pondération des enquêtes de déplacement](travelSurveyWeighting_fr.md), et un lien vers la [méthodologie spécifique à Transition](transitionMethodology_fr.md).
 
 ## Table des Matières
 
-- [Pondération des POI et des Nœuds/Arrêts de Transport Collectif](poiAndTransitNodeWeighting_fr.md)
+- [Poids propres et d'accessibilité](IntrinsicAndAccessibilityWeights_fr.md)
 - [Pondération des Enquêtes de Déplacement](travelSurveyWeighting_fr.md)
 - [Méthodologie de Transition](transitionMethodology_fr.md)

--- a/docs/weighting/transitionMethodology.md
+++ b/docs/weighting/transitionMethodology.md
@@ -2,7 +2,7 @@
 
 ## Weighting of Stop Nodes and Paths
 
-Transition implements multiple decay formulas and can use distance or travel time as the input variable for the [formula](poiAndTransitNodeWeighting.md#distance-and-travel-time-decay-functions). See [weighting types](/packages/transition-backend/src/services/weighting/types.ts) for more info.
+Transition implements multiple decay formulas and can use distance or travel time as the input variable for the [formula](IntrinsicAndAccessibilityWeights.md#distance-and-travel-time-decay-functions). See [weighting types](/packages/transition-backend/src/services/weighting/types.ts) for more info.
 
 ### Decay Formulas Available in Transition
 
@@ -14,18 +14,18 @@ Transition implements multiple decay formulas and can use distance or travel tim
 
 ### Weighting Steps and Specifications
 
-- Import of points of interest, homes and/or OD origins/destinations (POIs) by uploading a CSV or GeoJSON file
+- Import of points of interest, homes and/or OD origins/destinations (POIs) by uploading a CSV or GeoJSON file. **Note: The input file must include a weight column containing pre-calculated intrinsic weights for each POI. Transition does not calculate intrinsic weights.**
 - Calculation of walking path between POIs and stop nodes within 1.67 km or less as the crow flies (20 min at 5km/h).
-- Calculation of the weight of each POI using the decay formula (using network distance, Euclidean/bird's-eye distance or walking travel time according to the user's choice)
-- Calculation of the sum of the weights of accessible POIs for each stop node
-- If transit paths are present: for each path, calculate the sum of the weights of the served nodes to characterize its total weighted attractiveness.
+- Application of the decay formula to each POI's **intrinsic weight** (using network distance, Euclidean/bird's-eye distance or walking travel time according to the user's choice) to calculate the contribution of the POI to the stop node's accessibility weight.
+- Calculation of the sum of the contributions of accessible POIs for each stop node (the **accessibility weight**).
+- If transit paths are present: for each path, calculate the sum of the **accessibility weights** of the served nodes to characterize its total weighted attractiveness.
 
 ### Use Cases
 
 #### Preparation for Node Weighting
 
-To obtain the weights of the different stop nodes and paths, the user must first import or create the stop nodes for their network. Once the nodes are obtained, they upload a file of points of interest (POIs), choose the decay formula, the decay variable (travel time, network distance or bird's-eye distance) and the value of each required variable according to the formula choice ($\beta$, $\beta_1$, $\beta_2$, $a$, $b$, $c$, $d_0$ or $t_0$). TODO: detail how to import data for node weighting (not yet implemented)
+To obtain the **accessibility weights** of the different stop nodes and paths, the user must first import or create the stop nodes for their network. Once the nodes are obtained, they upload a file of points of interest (POIs) or trip destinations that **must include a weight column with pre-calculated intrinsic weights** (Transition does not provide intrinsic weighting). The user then chooses the decay formula, the decay variable (travel time, network distance or bird's-eye distance) and the value of each required variable according to the formula choice ($\beta$, $\beta_1$, $\beta_2$, $a$, $b$, $c$, $d_0$ or $t_0$).
 
 #### Genetic Algorithm
 
-To determine the number of vehicles to assign to each line in a candidate network, the genetic algorithm uses the weights assigned to the stop nodes, whose totals have been added to the paths of each line (for symmetrical bidirectional lines, the total weight of the outbound and return paths of the line will be used). During configuration, the user chooses their data source for weighting, which has already been associated with a decay formula and for which the weights have already been calculated.
+To determine the number of vehicles to assign to each line in a candidate network, the genetic algorithm uses the **accessibility weights** assigned to the stop nodes, whose totals have been added to the paths of each line (for symmetrical bidirectional lines, the total weight of the outbound and return paths of the line will be used). During configuration, the user chooses their data source for weighting, which has already been associated with a decay formula and for which the **accessibility weights** have already been calculated.

--- a/docs/weighting/transitionMethodology_fr.md
+++ b/docs/weighting/transitionMethodology_fr.md
@@ -2,7 +2,7 @@
 
 ## Pondération des nœuds d'arrêt et des trajets
 
-Transition implémente plusieurs formules de décroissance et utilise soit la distance ou le temps de parcours comme variable d'entrée de la [formule](poiAndTransitNodeWeighting_fr.md#fonctions-de-décroissance-en-fonction-de-la-distance-et-du-temps-de-déplacement). Voir les [types pour la pondération](/packages/transition-backend/src/services/weighting/types.ts) pour plus d'information.
+Transition implémente plusieurs formules de décroissance et utilise soit la distance ou le temps de parcours comme variable d'entrée de la [formule](IntrinsicAndAccessibilityWeights_fr.md#fonctions-de-décroissance-en-fonction-de-la-distance-et-du-temps-de-déplacement). Voir les [types pour la pondération](/packages/transition-backend/src/services/weighting/types.ts) pour plus d'information.
 
 ### Formules de décroissance disponibles dans Transition
 
@@ -14,18 +14,18 @@ Transition implémente plusieurs formules de décroissance et utilise soit la di
 
 ### Étapes de pondération et spécification
 
-- Importation des lieux d'intérêt, domiciles et/ou origines/destinations OD (POIs) par le téléversement d'un fichier CSV ou GeoJSON
+- Importation des lieux d'intérêt, domiciles et/ou origines/destinations OD (POIs) par le téléversement d'un fichier CSV ou GeoJSON. **Note: Le fichier d'entrée doit inclure une colonne de poids contenant les poids propres pré-calculés pour chaque POI. Transition ne calcule pas les poids propres.**
 - Calcul de chemin à pied entre les POIs et les nœuds d'arrêt distants de 1.67 km ou moins à vol d'oiseau (20 min à 5km/h).
-- Calcul du poids de chaque POI au moyen de la formule de décroissance (utilisant la distance réseau, la distance Euclidienne/à vol d'oiseau ou le temps de parcours à pied selon le choix de l'utilisateur)
-- Calcul de la somme des poids des POIs accessibles pour chaque nœud d'arrêt
-- Si présence de trajets: pour chaque trajet (path), calculer la somme des poids des nœuds desservis afin de caractériser son attractivité pondérée totale.
+- Application de la formule de décroissance au **poids propre** de chaque POI (utilisant la distance réseau, la distance Euclidienne/à vol d'oiseau ou le temps de parcours à pied selon le choix de l'utilisateur) pour calculer la contribution du POI au poids d'accessibilité du nœud d'arrêt.
+- Calcul de la somme des contributions des POIs accessibles pour chaque nœud d'arrêt (le **poids d'accessibilité**).
+- Si présence de trajets: pour chaque trajet (path), calculer la somme des **poids d'accessibilité** des nœuds desservis afin de caractériser son attractivité pondérée totale.
 
 ### Cas d'utilisation
 
 #### Préparation de la pondération des nœuds
 
-Pour obtenir les poids des différents nœuds d'arrêt et des trajets, l'utilisateur doit d'abord importer ou créer les nœuds d'arrêt pour son réseau. Une fois les nœuds obtenus, il téléverse un fichier de lieux d'intérêt (POIs), choisit la formule de décroissance, la variable de décroissance (temps de parcours, distance réseau ou distance à vol d'oiseau) et la valeur de chacune des variables requises selon le choix de formule ($\beta$, $\beta_1$, $\beta_2$, $a$, $b$, $c$, $d_0$ ou $t_0$). TODO: détailler la procédure exacte (pas encore implémenté).
+Pour obtenir les **poids d'accessibilité** des différents nœuds d'arrêt et des trajets, l'utilisateur doit d'abord importer ou créer les nœuds d'arrêt pour son réseau. Une fois les nœuds obtenus, il téléverse un fichier de lieux d'intérêt (POIs) ou de destinations de déplacements qui **doit inclure une colonne de poids avec les poids propres pré-calculés** (Transition ne fournit pas de pondération propre). L'utilisateur choisit ensuite la formule de décroissance, la variable de décroissance (temps de parcours, distance réseau ou distance à vol d'oiseau) et la valeur de chacune des variables requises selon le choix de formule ($\beta$, $\beta_1$, $\beta_2$, $a$, $b$, $c$, $d_0$ ou $t_0$).
 
 ### Algorithme génétique
 
-Afin de déterminer le nombre de véhicules à attribuer à chaque ligne d'un réseau candidat, l'algorithme génétique utilise les poids assignés aux nœuds d'arrêt et dont le total a été ajouté aux trajets de chaque ligne (pour des lignes bidirectionnelles symétriques, le poids total des trajets aller et retour de la ligne sera utilisé). Lors de la configuration, l'utilisateur choisit sa source de données pour la pondération, qui a déjà été associée à une formule de décroissance et dont les poids ont déjà été calculés.
+Afin de déterminer le nombre de véhicules à attribuer à chaque ligne d'un réseau candidat, l'algorithme génétique utilise les **poids d'accessibilité** assignés aux nœuds d'arrêt et dont le total a été ajouté aux trajets de chaque ligne (pour des lignes bidirectionnelles symétriques, le poids total des trajets aller et retour de la ligne sera utilisé). Lors de la configuration, l'utilisateur choisit sa source de données pour la pondération, qui a déjà été associée à une formule de décroissance et dont les **poids d'accessibilité** ont déjà été calculés.

--- a/docs/weighting/travelSurveyWeighting.md
+++ b/docs/weighting/travelSurveyWeighting.md
@@ -16,6 +16,15 @@ Calibration completes the process by adjusting weighted sample distributions to 
 
 Travel surveys inherently collect nested data: households contain persons who make trips. This structure requires possibly three related but distinct sets of weights, each building on the previous level while adding appropriate adjustments. Some surveys weight only households,  some weight both the households and persons, and some others weight households, persons and trips separately.
 
+## Connection to Intrinsic Weights
+
+The final weights calculated through this process (design weights adjusted by calibration) attached to a trip destination, a person, or a household effectively become its **Intrinsic Weight** ($W_j$) in gravity models and accessibility calculations.
+
+For example:
+- If a surveyed trip to a shopping mall has a final weight of 50, that destination contributes 50 units of "attraction" (**intrinsic weight**) to the accessibility calculation of nearby transit nodes.
+- If a household has a weight of 20, it represents 20 households at that location, contributing to the **intrinsic weight** of that origin point for trip generation.
+- To weight a residential building, we usually use the sum of the **intrinsic weights** of all households or persons living in the whole building, depending if we want a household weight or a person weight.
+
 ## Key references
 
 [UK Department for Transport (2024). National Travel Survey Weighting Review.](https://www.gov.uk/government/publications/future-developments-for-the-nts/)

--- a/docs/weighting/travelSurveyWeighting_fr.md
+++ b/docs/weighting/travelSurveyWeighting_fr.md
@@ -16,6 +16,15 @@ La calibration complète le processus en ajustant les distributions d'échantill
 
 Les enquêtes de déplacement collectent intrinsèquement des données imbriquées: les ménages contiennent des personnes qui effectuent des déplacements. Cette structure nécessite potentiellement trois ensembles de poids distincts mais liés, chacun s'appuyant sur le niveau précédent tout en ajoutant des ajustements appropriés. Certaines enquêtes pondèrent uniquement les ménages, d'autres pondèrent à la fois les ménages et les personnes, et d'autres encore pondèrent séparément les ménages, les personnes et les déplacements.
 
+## Lien avec les Poids Propres
+
+Les poids finaux calculés par ce processus (poids de conception ajustés par calibration) attachés à une destination de déplacement, une personne ou un ménage deviennent effectivement son **Poids Propre** ($W_j$) dans les modèles gravitaires et les calculs d'accessibilité.
+
+Par exemple :
+- Si un déplacement enquêté vers un centre commercial a un poids final de 50, cette destination contribue pour 50 unités d'« attraction » (**poids propre**) au calcul de l'accessibilité des nœuds de transport à proximité.
+- Si un ménage a un poids de 20, il représente 20 ménages à cet endroit, contribuant au **poids propre** de ce point d'origine pour la génération de déplacements.
+- Pour pondérer un immeuble résidentiel, on utilise généralement la somme des **poids propres** de tous les ménages ou personnes résidant dans l'immeuble entier (selon si on veut un poids ménage ou un poids personnes).
+
 ## Références clés
 
 [UK Department for Transport (2024). National Travel Survey Weighting Review.](https://www.gov.uk/government/publications/future-developments-for-the-nts/)

--- a/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
+++ b/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
@@ -397,6 +397,20 @@ const defaultPreferences: PreferencesModel = {
             }
         }
     },
+    // maxAccessibilityWeightsBirdDistancesMeters should be >= maxAccessibilityWeightsNetworkDistancesMeters
+    // because it is used as a first step to filter out POIs that are too far away.
+    maxAccessibilityWeightsBirdDistancesMeters: {
+        walking: 2500 // ~30 minutes at 5 km/h
+        // more modes could be added later on.
+    },
+    maxAccessibilityWeightsNetworkDistancesMeters: {
+        walking: 2500 // Maximum network distance in meters for node weight calculations
+        // more modes could be added later on.
+    },
+    maxAccessibilityWeightsTravelTimeSeconds: {
+        walking: 1800 // ~30 minutes maximum travel time for node weight calculations
+        // more modes could be added later on.
+    },
     proj4Projections: {
         [String(constants.geographicCoordinateSystem.srid)]: constants.geographicCoordinateSystem,
         '2950': {

--- a/packages/transition-backend/src/services/weighting/AccessibilityWeightCalculator.ts
+++ b/packages/transition-backend/src/services/weighting/AccessibilityWeightCalculator.ts
@@ -1,0 +1,748 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import GeoJSON from 'geojson';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import routingServiceManager from 'chaire-lib-common/lib/services/routing/RoutingServiceManager';
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+
+import transitNodesDbQueries from '../../models/db/transitNodes.db.queries';
+import { DecayFunctionCalculator } from './DecayFunctionCalculator';
+import {
+    DecayFunctionParameters,
+    DecayInputValueType,
+    DecayInputValue,
+    WeightingRoutingMode,
+    AccessibilityWeights,
+    WeightDecayInputType
+} from './types';
+import {
+    getPOIsWithinBirdDistanceFromPlaces,
+    getPOIsWithinBirdDistanceFromNodes
+} from '../../models/db/geometryUtils.db.queries';
+
+export type AccessibilityWeightCalculationParameters = {
+    decayFunctionParameters: DecayFunctionParameters;
+    decayInputType: WeightDecayInputType; // Type of input value for decay function: birdDistance, networkDistance, or travelTime
+    poisFeatureCollection: GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }>; // GeoJSON FeatureCollection of POIs with intrinsic weight in properties
+    placesFeatureCollection: GeoJSON.FeatureCollection<GeoJSON.Point>; // GeoJSON FeatureCollection of places to calculate accessibility weights for
+    maxBirdDistanceMeters?: number; // Optional: maximum bird distance in meters (from preferences if not provided)
+    maxNetworkDistanceMeters?: number; // Optional: maximum network distance in meters (from preferences if not provided)
+    maxTravelTimeSeconds?: number; // Optional: maximum travel time in seconds (from preferences if not provided)
+    routingMode?: WeightingRoutingMode;
+};
+
+// FIXME: Use a class to encapsulate the calculation data and methods and reduce the need to pass that many parameters around.
+
+type PreparedCalculationData = {
+    validPOIsFeatureCollection: GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }>;
+    decayInputValueType: DecayInputValueType;
+    maxBirdDistance: number;
+    maxNetworkDistance: number;
+    maxTravelTime: number;
+    routingService: ReturnType<typeof routingServiceManager.getRoutingServiceForEngine>;
+};
+
+type CalculateWeightForEntityParameters = {
+    entityFeature: GeoJSON.Feature<GeoJSON.Point>;
+    poisInBirdDistance: Array<{ id: number; weight: number; distance: number; geography: GeoJSON.Point }>;
+    decayInputType: WeightDecayInputType;
+    preparedData: PreparedCalculationData;
+    decayFunctionParameters: DecayFunctionParameters;
+    routingMode: WeightingRoutingMode;
+};
+
+/**
+ * Service to calculate accessibility weights for places based on intrinsic weighted POIs and decay functions.
+ *
+ * This calculator can be used with any type of place (transit nodes, points of interest, home, etc.)
+ * as attractors for POIs. The accessibility weight of each place is calculated based on the proximity and
+ * intrinsic weights of surrounding POIs, using configurable decay functions to model how POI influence
+ * decreases with distance or travel time.
+ */
+export class AccessibilityWeightCalculator {
+    /**
+     * Validate and prepare POIs for accessibility weight calculation.
+     * Filters POIs with valid geometry and ensures they have numeric IDs.
+     * Auto-generates numeric IDs for POIs that are missing or have invalid IDs.
+     *
+     * @param poisFeatureCollection Input POIs FeatureCollection
+     * @returns Status with valid POIs FeatureCollection with numeric IDs
+     */
+    private static validateAndPreparePOIs(
+        poisFeatureCollection: GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }>
+    ): Status.Status<GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }>> {
+        // Validate POIs FeatureCollection
+        if (!poisFeatureCollection || !poisFeatureCollection.features || poisFeatureCollection.features.length === 0) {
+            return Status.createError(
+                new TrError(
+                    'poisFeatureCollection is required and must contain at least one feature',
+                    'AWC0001',
+                    'AccessibilityWeightCalculationError'
+                )
+            );
+        }
+
+        // Filter POIs with valid geometry
+        const validPOIs = poisFeatureCollection.features.filter(
+            (feature) => feature.geometry && feature.geometry.coordinates
+        );
+
+        if (validPOIs.length === 0) {
+            // No valid POIs, return empty FeatureCollection
+            return Status.createOk({
+                type: 'FeatureCollection',
+                features: []
+            });
+        }
+
+        // Generate new integer IDs from scratch, ignoring original POI IDs
+        let nextId = 1;
+        const validPOIsWithNumericIds = validPOIs.map((poi) => {
+            return {
+                ...poi,
+                id: nextId++
+            } as GeoJSON.Feature<GeoJSON.Point, { weight?: number }> & { id: number };
+        });
+
+        // Create FeatureCollection with valid POIs that have numeric ids
+        return Status.createOk({
+            type: 'FeatureCollection',
+            features: validPOIsWithNumericIds
+        });
+    }
+
+    /**
+     * Validate calculation parameters.
+     *
+     * @param maxBirdDistanceMeters Optional maximum bird distance
+     * @param maxNetworkDistanceMeters Optional maximum network distance
+     * @param maxTravelTimeSeconds Optional maximum travel time
+     * @returns Status indicating validation success or failure
+     */
+    private static validateParameters(
+        maxBirdDistanceMeters?: number,
+        maxNetworkDistanceMeters?: number,
+        maxTravelTimeSeconds?: number
+    ): Status.Status<void> {
+        if (maxBirdDistanceMeters !== undefined && maxBirdDistanceMeters <= 0) {
+            return Status.createError(
+                new TrError(
+                    'maxBirdDistanceMeters must be a positive number',
+                    'AWC0002',
+                    'AccessibilityWeightCalculationError'
+                )
+            );
+        }
+        if (maxNetworkDistanceMeters !== undefined && maxNetworkDistanceMeters <= 0) {
+            return Status.createError(
+                new TrError(
+                    'maxNetworkDistanceMeters must be a positive number',
+                    'AWC0003',
+                    'AccessibilityWeightCalculationError'
+                )
+            );
+        }
+        if (maxTravelTimeSeconds !== undefined && maxTravelTimeSeconds <= 0) {
+            return Status.createError(
+                new TrError(
+                    'maxTravelTimeSeconds must be a positive number',
+                    'AWC0004',
+                    'AccessibilityWeightCalculationError'
+                )
+            );
+        }
+        return Status.createOk(undefined);
+    }
+
+    /**
+     * Get max distances and travel time from preferences if not provided.
+     *
+     * @param routingMode Routing mode
+     * @param maxBirdDistanceMeters Optional maximum bird distance
+     * @param maxNetworkDistanceMeters Optional maximum network distance
+     * @param maxTravelTimeSeconds Optional maximum travel time
+     * @returns Object with max distances and travel time
+     */
+    private static getMaxDistancesAndTime(
+        routingMode: WeightingRoutingMode,
+        maxBirdDistanceMeters?: number,
+        maxNetworkDistanceMeters?: number,
+        maxTravelTimeSeconds?: number
+    ): { maxBirdDistance: number; maxNetworkDistance: number; maxTravelTime: number } {
+        // Compute values with order of precedence: explicit arg, preference, default
+        const computedMaxBirdDistance =
+            maxBirdDistanceMeters ??
+            Preferences.get(`maxAccessibilityWeightsBirdDistancesMeters.${routingMode}`) ??
+            2500;
+        const computedMaxNetworkDistance =
+            maxNetworkDistanceMeters ??
+            Preferences.get(`maxAccessibilityWeightsNetworkDistancesMeters.${routingMode}`) ??
+            2500;
+        const computedMaxTravelTime =
+            maxTravelTimeSeconds ?? Preferences.get(`maxAccessibilityWeightsTravelTimeSeconds.${routingMode}`) ?? 1800;
+
+        // Validate each computed value: must be finite and strictly positive
+        // Replace invalid values with safe defaults
+        const maxBirdDistance =
+            Number.isFinite(computedMaxBirdDistance) && computedMaxBirdDistance > 0 ? computedMaxBirdDistance : 2500;
+        const maxNetworkDistance =
+            Number.isFinite(computedMaxNetworkDistance) && computedMaxNetworkDistance > 0
+                ? computedMaxNetworkDistance
+                : 2500;
+        const maxTravelTime =
+            Number.isFinite(computedMaxTravelTime) && computedMaxTravelTime > 0 ? computedMaxTravelTime : 1800;
+
+        return {
+            maxBirdDistance,
+            maxNetworkDistance,
+            maxTravelTime
+        };
+    }
+
+    /**
+     * Prepare common calculation data (POIs, decay type, max distances, routing service).
+     *
+     * @param parameters Calculation parameters
+     * @returns Status with prepared calculation data
+     */
+    private static prepareCalculationData(parameters: {
+        poisFeatureCollection: GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }>;
+        decayInputType: WeightDecayInputType;
+        maxBirdDistanceMeters?: number;
+        maxNetworkDistanceMeters?: number;
+        maxTravelTimeSeconds?: number;
+        routingMode?: WeightingRoutingMode;
+    }): Status.Status<PreparedCalculationData> {
+        const {
+            poisFeatureCollection,
+            decayInputType,
+            maxBirdDistanceMeters,
+            maxNetworkDistanceMeters,
+            maxTravelTimeSeconds,
+            routingMode = 'walking'
+        } = parameters;
+
+        // Validate and prepare POIs
+        const poisStatus = AccessibilityWeightCalculator.validateAndPreparePOIs(poisFeatureCollection);
+        if (Status.isStatusError(poisStatus)) {
+            return poisStatus;
+        }
+        const validPOIsFeatureCollection = poisStatus.result;
+
+        if (validPOIsFeatureCollection.features.length === 0) {
+            // Return empty data structure - caller should handle empty results
+            return Status.createOk({
+                validPOIsFeatureCollection,
+                decayInputValueType: decayInputType === 'travelTime' ? 'time' : 'distance',
+                maxBirdDistance: 0,
+                maxNetworkDistance: 0,
+                maxTravelTime: 0,
+                routingService: routingServiceManager.getRoutingServiceForEngine('engine')
+            });
+        }
+
+        // Validate parameters
+        const validationStatus = AccessibilityWeightCalculator.validateParameters(
+            maxBirdDistanceMeters,
+            maxNetworkDistanceMeters,
+            maxTravelTimeSeconds
+        );
+        if (Status.isStatusError(validationStatus)) {
+            return validationStatus;
+        }
+
+        // Get max distances and travel time
+        const { maxBirdDistance, maxNetworkDistance, maxTravelTime } =
+            AccessibilityWeightCalculator.getMaxDistancesAndTime(
+                routingMode,
+                maxBirdDistanceMeters,
+                maxNetworkDistanceMeters,
+                maxTravelTimeSeconds
+            );
+
+        // Map decayInputType to DecayInputValueType for the decay function
+        // The decay function only cares about 'distance' or 'time', not the source
+        const decayInputValueType: DecayInputValueType = decayInputType === 'travelTime' ? 'time' : 'distance';
+
+        return Status.createOk({
+            validPOIsFeatureCollection,
+            decayInputValueType,
+            maxBirdDistance,
+            maxNetworkDistance,
+            maxTravelTime,
+            routingService: routingServiceManager.getRoutingServiceForEngine('engine')
+        });
+    }
+
+    /**
+     * Calculate accessibility weight for a single entity (place or node).
+     *
+     * @param parameters Calculation parameters
+     * @returns Status with calculated accessibility weight
+     */
+    private static async calculateWeightForEntity(
+        parameters: CalculateWeightForEntityParameters
+    ): Promise<Status.Status<number>> {
+        const {
+            entityFeature,
+            poisInBirdDistance,
+            decayInputType,
+            preparedData,
+            decayFunctionParameters,
+            routingMode
+        } = parameters;
+
+        if (poisInBirdDistance.length === 0) {
+            return Status.createOk(0);
+        }
+
+        if (decayInputType === 'birdDistance') {
+            return Status.createOk(
+                AccessibilityWeightCalculator.calculateAccessibilityWeightUsingBirdDistance(
+                    poisInBirdDistance,
+                    preparedData.maxBirdDistance,
+                    preparedData.decayInputValueType,
+                    decayFunctionParameters
+                )
+            );
+        } else {
+            return await AccessibilityWeightCalculator.calculateAccessibilityWeightUsingRouting(
+                entityFeature,
+                poisInBirdDistance,
+                decayInputType,
+                preparedData.maxNetworkDistance,
+                preparedData.maxTravelTime,
+                preparedData.decayInputValueType,
+                decayFunctionParameters,
+                preparedData.routingService,
+                routingMode
+            );
+        }
+    }
+
+    /**
+     * Calculate place accessibility weights based on POI proximity and decay functions.
+     * Any place can be used as an attractor for POIs - the places are provided as a
+     * GeoJSON FeatureCollection of Point features.
+     *
+     * @param parameters Calculation parameters
+     * @param progressCallback Optional callback for progress updates (0.0 to 1.0)
+     * @returns Status with dictionary mapping place IDs to their calculated accessibility weights: { id1: weight1, id2: weight2, ... }
+     */
+    static async calculateWeights(
+        parameters: AccessibilityWeightCalculationParameters,
+        progressCallback?: (progress: number) => void
+    ): Promise<Status.Status<AccessibilityWeights>> {
+        const { placesFeatureCollection, decayFunctionParameters, decayInputType, ...restParams } = parameters;
+
+        // Validate places FeatureCollection
+        if (
+            !placesFeatureCollection ||
+            !placesFeatureCollection.features ||
+            placesFeatureCollection.features.length === 0
+        ) {
+            return Status.createError(
+                new TrError(
+                    'placesFeatureCollection is required and must contain at least one feature',
+                    'AWC0005',
+                    'AccessibilityWeightCalculationError'
+                )
+            );
+        }
+
+        // Prepare common calculation data
+        const preparedDataStatus = AccessibilityWeightCalculator.prepareCalculationData({
+            ...restParams,
+            decayInputType
+        });
+
+        if (Status.isStatusError(preparedDataStatus)) {
+            return preparedDataStatus;
+        }
+
+        const preparedData = preparedDataStatus.result;
+
+        if (preparedData.validPOIsFeatureCollection.features.length === 0) {
+            return Status.createOk({});
+        }
+
+        // Filter places with valid geometry
+        const validPlaces = placesFeatureCollection.features.filter(
+            (feature) => feature.geometry && feature.geometry.coordinates && feature.id !== undefined
+        );
+
+        if (validPlaces.length === 0) {
+            return Status.createOk({});
+        }
+
+        const results: AccessibilityWeights = {};
+
+        // Create a FeatureCollection with only valid places
+        const validPlacesFeatureCollection: GeoJSON.FeatureCollection<GeoJSON.Point> = {
+            type: 'FeatureCollection',
+            features: validPlaces
+        };
+
+        // Get POIs within bird distance for all places in a single batch query
+        // This creates a single temporary table for all places and POIs
+        const poisByPlaceId = await getPOIsWithinBirdDistanceFromPlaces(
+            validPlacesFeatureCollection,
+            preparedData.maxBirdDistance,
+            preparedData.validPOIsFeatureCollection
+        );
+
+        // Process each place
+        for (let placeIndex = 0; placeIndex < validPlaces.length; placeIndex++) {
+            const place = validPlaces[placeIndex];
+
+            // Update progress
+            if (progressCallback) {
+                progressCallback(placeIndex / validPlaces.length);
+            }
+
+            // Skip places without valid geometry (shouldn't happen after filtering, but double-check)
+            if (!place.geometry || !place.geometry.coordinates || place.id === undefined) {
+                continue;
+            }
+
+            const placeId = typeof place.id === 'string' ? place.id : String(place.id);
+
+            // Get POIs within bird distance from the batch results
+            const poisInBirdDistance = poisByPlaceId[placeId] || [];
+
+            // Calculate accessibility weight for this place
+            const weightStatus = await AccessibilityWeightCalculator.calculateWeightForEntity({
+                entityFeature: place,
+                poisInBirdDistance,
+                decayInputType,
+                preparedData,
+                decayFunctionParameters,
+                routingMode: parameters.routingMode || 'walking'
+            });
+
+            if (Status.isStatusError(weightStatus)) {
+                return weightStatus;
+            }
+
+            results[placeId] = weightStatus.result;
+        }
+
+        // Final progress update
+        if (progressCallback) {
+            progressCallback(1.0);
+        }
+
+        return Status.createOk(results);
+    }
+
+    /**
+     * Calculate node accessibility weights based on POI proximity and decay functions.
+     * This method uses the existing tr_transit_nodes table and only creates a temporary POIs table,
+     * making it more efficient for transit node calculations.
+     *
+     * @param parameters Calculation parameters (with nodeIds instead of placesFeatureCollection)
+     * @param progressCallback Optional callback for progress updates (0.0 to 1.0)
+     * @returns Status with dictionary mapping node IDs to their calculated accessibility weights: { id1: weight1, id2: weight2, ... }
+     */
+    static async calculateNodeAccessibilityWeights(
+        parameters: Omit<AccessibilityWeightCalculationParameters, 'placesFeatureCollection'> & { nodeIds?: string[] },
+        progressCallback?: (progress: number) => void
+    ): Promise<Status.Status<AccessibilityWeights>> {
+        const { nodeIds, decayFunctionParameters, decayInputType, ...restParams } = parameters;
+
+        // Early return if nodeIds is an empty array (means "no nodes")
+        // This avoids calling getPOIsWithinBirdDistanceFromNodes and transitNodesDbQueries.collection unnecessarily
+        if (nodeIds !== undefined && nodeIds.length === 0) {
+            return Status.createOk({});
+        }
+
+        // Prepare common calculation data
+        const preparedDataStatus = AccessibilityWeightCalculator.prepareCalculationData({
+            ...restParams,
+            decayInputType
+        });
+
+        if (Status.isStatusError(preparedDataStatus)) {
+            return preparedDataStatus;
+        }
+
+        const preparedData = preparedDataStatus.result;
+
+        if (preparedData.validPOIsFeatureCollection.features.length === 0) {
+            return Status.createOk({});
+        }
+
+        const results: AccessibilityWeights = {};
+
+        // Get POIs within bird distance for all nodes in a single batch query
+        // This uses the existing tr_transit_nodes table and only creates a temporary POIs table
+        // If nodeIds is undefined, calculates for all enabled nodes. If empty array, returns {} immediately.
+        const poisByNodeId = await getPOIsWithinBirdDistanceFromNodes(
+            preparedData.maxBirdDistance,
+            preparedData.validPOIsFeatureCollection,
+            nodeIds
+        );
+
+        // Get node data from database for routing
+        // If nodeIds is not provided, fetches all enabled nodes
+        const nodesCollection = await transitNodesDbQueries.collection({ nodeIds });
+
+        // Create a map of node IDs to node features for easier lookup
+        const nodeMap = new Map<string, GeoJSON.Feature<GeoJSON.Point>>();
+        for (const node of nodesCollection) {
+            if (node.geography && node.id) {
+                nodeMap.set(node.id, {
+                    type: 'Feature',
+                    id: node.id,
+                    geometry: node.geography,
+                    properties: {}
+                });
+            }
+        }
+
+        // Get list of node IDs to process (from provided nodeIds or from database results)
+        const nodeIdsToProcess =
+            nodeIds && nodeIds.length > 0
+                ? nodeIds
+                : nodesCollection.map((node) => node.id).filter((id): id is string => id !== undefined);
+
+        // Process each node
+        for (let nodeIndex = 0; nodeIndex < nodeIdsToProcess.length; nodeIndex++) {
+            const nodeId = nodeIdsToProcess[nodeIndex];
+
+            // Update progress
+            if (progressCallback) {
+                progressCallback(nodeIndex / nodeIdsToProcess.length);
+            }
+
+            // Get node feature from map
+            const nodeFeature = nodeMap.get(nodeId);
+            if (!nodeFeature || !nodeFeature.geometry || !nodeFeature.geometry.coordinates) {
+                // Node not found or invalid geometry, accessibility weight is 0
+                results[nodeId] = 0;
+                continue;
+            }
+
+            // Get POIs within bird distance from the batch results
+            const poisInBirdDistance = poisByNodeId[nodeId] || [];
+
+            // Calculate accessibility weight for this node
+            const weightStatus = await AccessibilityWeightCalculator.calculateWeightForEntity({
+                entityFeature: nodeFeature,
+                poisInBirdDistance,
+                decayInputType,
+                preparedData,
+                decayFunctionParameters,
+                routingMode: parameters.routingMode || 'walking'
+            });
+
+            if (Status.isStatusError(weightStatus)) {
+                return weightStatus;
+            }
+
+            results[nodeId] = weightStatus.result;
+        }
+
+        // Final progress update
+        if (progressCallback) {
+            progressCallback(1.0);
+        }
+
+        return Status.createOk(results);
+    }
+
+    /**
+     * Calculate place accessibility weight using bird distance (straight-line distance).
+     * This method skips routing and uses the bird distance directly from the POI query results.
+     *
+     * @param poisInBirdDistance Array of POIs within bird distance
+     * @param maxBirdDistance Maximum bird distance threshold
+     * @param decayInputValueType Type of input value for decay function ('distance' or 'time')
+     * @param decayFunctionParameters Decay function parameters
+     * @returns Calculated accessibility weight for the place
+     */
+    private static calculateAccessibilityWeightUsingBirdDistance(
+        poisInBirdDistance: Array<{ id: number; weight: number; distance: number; geography: GeoJSON.Point }>,
+        maxBirdDistance: number,
+        decayInputValueType: DecayInputValueType,
+        decayFunctionParameters: DecayFunctionParameters
+    ): number {
+        let placeAccessibilityWeight = 0;
+
+        for (const poi of poisInBirdDistance) {
+            const birdDistance = poi.distance;
+
+            // Filter by max bird distance threshold
+            if (birdDistance > maxBirdDistance) {
+                continue;
+            }
+
+            // Calculate decay value using bird distance
+            const inputValue: DecayInputValue = {
+                distanceMeters: birdDistance
+            };
+
+            try {
+                const decayValue = DecayFunctionCalculator.calculateDecay(
+                    inputValue,
+                    decayInputValueType,
+                    decayFunctionParameters
+                );
+
+                // Add weighted contribution: placeWeight += poiWeight * decayValue
+                placeAccessibilityWeight += poi.weight * decayValue;
+            } catch (error) {
+                console.warn(`Error calculating decay for POI ${poi.id}: ${error}`);
+            }
+        }
+
+        return placeAccessibilityWeight;
+    }
+
+    /**
+     * Calculate place accessibility weight using routing (network distance or travel time).
+     * This method uses OSRM routing to calculate network distances and travel times.
+     *
+     * @param place Place feature to calculate accessibility weight for
+     * @param poisInBirdDistance Array of POIs within bird distance
+     * @param decayInputType Type of decay input ('networkDistance' or 'travelTime')
+     * @param maxNetworkDistance Maximum network distance threshold
+     * @param maxTravelTime Maximum travel time threshold
+     * @param decayInputValueType Type of input value for decay function ('distance' or 'time')
+     * @param decayFunctionParameters Decay function parameters
+     * @param routingService Routing service instance
+     * @param routingMode Routing mode
+     * @returns Status with calculated accessibility weight for the place
+     */
+    private static async calculateAccessibilityWeightUsingRouting(
+        place: GeoJSON.Feature<GeoJSON.Point>,
+        poisInBirdDistance: Array<{ id: number; weight: number; distance: number; geography: GeoJSON.Point }>,
+        decayInputType: WeightDecayInputType,
+        maxNetworkDistance: number,
+        maxTravelTime: number,
+        decayInputValueType: DecayInputValueType,
+        decayFunctionParameters: DecayFunctionParameters,
+        routingService: ReturnType<typeof routingServiceManager.getRoutingServiceForEngine>,
+        routingMode: WeightingRoutingMode
+    ): Promise<Status.Status<number>> {
+        // Convert POIs to GeoJSON features for routing
+        const poiGeographies: GeoJSON.Feature<GeoJSON.Point>[] = poisInBirdDistance.map((poi) => ({
+            type: 'Feature',
+            geometry: poi.geography,
+            properties: {
+                poiId: poi.id,
+                weight: poi.weight ?? 0,
+                birdDistance: poi.distance
+            }
+        }));
+
+        // Calculate network distances and travel times using OSRM
+        const placeFeature: GeoJSON.Feature<GeoJSON.Point> = {
+            type: 'Feature',
+            geometry: place.geometry,
+            properties: {}
+        };
+
+        const routingResult = await routingService.tableFrom({
+            mode: routingMode,
+            origin: placeFeature,
+            destinations: poiGeographies
+        });
+
+        // Extract durations and distances from routing result
+        const durations = routingResult.durations || [];
+        const distances = routingResult.distances || [];
+
+        let placeAccessibilityWeight = 0;
+
+        for (let i = 0; i < poiGeographies.length; i++) {
+            const poiFeature = poiGeographies[i];
+            if (!poiFeature.properties) {
+                continue;
+            }
+
+            const poiWeight = (poiFeature.properties.weight as number) ?? 0;
+            const travelTimeSeconds = durations[i];
+            const distanceMeters = distances[i];
+
+            // Validate and filter based on decay input type
+            // Skip POIs that are not accessible (null/undefined is acceptable, but NaN indicates an error)
+            if (decayInputType === 'travelTime') {
+                // For travel time: skip if null/undefined (POI not accessible), but throw if NaN (error)
+                if (travelTimeSeconds === null || travelTimeSeconds === undefined) {
+                    continue; // POI not accessible, skip it
+                }
+                if (isNaN(travelTimeSeconds)) {
+                    const poiId = poiFeature.properties.poiId as number;
+                    return Status.createError(
+                        new TrError(
+                            `Travel time is NaN for decay input type 'travelTime' for POI ${poiId}`,
+                            'AWC0007',
+                            'AccessibilityWeightCalculationError'
+                        )
+                    );
+                }
+                // Filter based on travel time threshold
+                if (travelTimeSeconds > maxTravelTime) {
+                    continue;
+                }
+            } else if (decayInputType === 'networkDistance') {
+                // For network distance: skip if null/undefined (POI not accessible), but throw if NaN (error)
+                if (distanceMeters === null || distanceMeters === undefined) {
+                    continue; // POI not accessible, skip it
+                }
+                if (isNaN(distanceMeters)) {
+                    const poiId = poiFeature.properties.poiId as number;
+                    return Status.createError(
+                        new TrError(
+                            `Network distance is NaN for decay input type 'networkDistance' for POI ${poiId}`,
+                            'AWC0008',
+                            'AccessibilityWeightCalculationError'
+                        )
+                    );
+                }
+                // Filter based on network distance threshold
+                if (distanceMeters > maxNetworkDistance) {
+                    continue;
+                }
+            } else {
+                // For birdDistance, we shouldn't reach here (handled in the if branch above)
+                return Status.createError(
+                    new TrError(
+                        `Unexpected decay input type: ${decayInputType}`,
+                        'AWC0009',
+                        'AccessibilityWeightCalculationError'
+                    )
+                );
+            }
+
+            // Calculate decay value
+            const inputValue: DecayInputValue = {
+                distanceMeters,
+                travelTimeSeconds
+            };
+
+            try {
+                const decayValue = DecayFunctionCalculator.calculateDecay(
+                    inputValue,
+                    decayInputValueType,
+                    decayFunctionParameters
+                );
+
+                // Add weighted contribution: placeWeight += poiWeight * decayValue
+                placeAccessibilityWeight += poiWeight * decayValue;
+            } catch (error) {
+                const poiId = poiFeature.properties.poiId as number;
+                console.warn(`Error calculating decay for POI ${poiId}: ${error}`);
+            }
+        }
+
+        return Status.createOk(placeAccessibilityWeight);
+    }
+}

--- a/packages/transition-backend/src/services/weighting/__tests__/AccessibilityWeightCalculator.test.ts
+++ b/packages/transition-backend/src/services/weighting/__tests__/AccessibilityWeightCalculator.test.ts
@@ -1,0 +1,931 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import GeoJSON from 'geojson';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { RoutingServiceManagerMock } from 'chaire-lib-common/lib/test';
+
+// Mock database and related modules BEFORE importing anything that uses them
+// Mock knex-postgis first to prevent initialization errors when transitNodes.db.queries loads
+jest.mock('knex-postgis', () => {
+    return jest.fn(() => ({
+        geomFromGeoJSON: jest.fn()
+    }));
+});
+
+jest.mock('../../../models/db/transitNodes.db.queries', () => {
+    // Use a factory function that returns the mock
+    return {
+        __esModule: true,
+        default: {
+            collection: jest.fn()
+        }
+    };
+});
+
+jest.mock('../../../models/db/geometryUtils.db.queries', () => ({
+    getPOIsWithinBirdDistanceFromPoint: jest.fn(),
+    getPOIsWithinBirdDistanceFromPlaces: jest.fn(),
+    getPOIsWithinBirdDistanceFromNodes: jest.fn()
+}));
+
+// Enable RoutingServiceManager mock (similar to other tests)
+RoutingServiceManagerMock.enableMocks();
+
+import { AccessibilityWeightCalculator, AccessibilityWeightCalculationParameters } from '../AccessibilityWeightCalculator';
+import {
+    PowerDecayParameters,
+    WeightingRoutingMode,
+    WeightDecayInputType
+} from '../types';
+import {
+    getPOIsWithinBirdDistanceFromPoint,
+    getPOIsWithinBirdDistanceFromNodes,
+    getPOIsWithinBirdDistanceFromPlaces
+} from '../../../models/db/geometryUtils.db.queries';
+import transitNodesDbQueries from '../../../models/db/transitNodes.db.queries';
+
+const mockedGetPOIsWithinBirdDistanceFromPoint = getPOIsWithinBirdDistanceFromPoint as jest.MockedFunction<typeof getPOIsWithinBirdDistanceFromPoint>;
+const mockedGetPOIsWithinBirdDistanceFromNodes = getPOIsWithinBirdDistanceFromNodes as jest.MockedFunction<typeof getPOIsWithinBirdDistanceFromNodes>;
+const mockedGetPOIsWithinBirdDistanceFromPlaces = getPOIsWithinBirdDistanceFromPlaces as jest.MockedFunction<typeof getPOIsWithinBirdDistanceFromPlaces>;
+// Use RoutingServiceManagerMock like other tests do
+const mockTableFrom = RoutingServiceManagerMock.routingServiceManagerMock.getRoutingServiceForEngine('engine').tableFrom;
+// Get the mocked collection function from the imported module
+const mockCollection = transitNodesDbQueries.collection as jest.MockedFunction<typeof transitNodesDbQueries.collection>;
+
+describe('AccessibilityWeightCalculator', () => {
+    const place1Id = uuidV4();
+    const place2Id = uuidV4();
+    const poi1Id = 1;
+    const poi2Id = 2;
+
+    const defaultPlaces: GeoJSON.FeatureCollection<GeoJSON.Point> = {
+        type: 'FeatureCollection',
+        features: [
+            {
+                type: 'Feature' as const,
+                id: place1Id,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                },
+                properties: {
+                    foo: 'bar'
+                }
+            },
+            {
+                type: 'Feature' as const,
+                id: place2Id,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.5, 45.6]
+                },
+                properties: {
+                    bar: 'foo'
+                }
+            }
+        ]
+    };
+
+
+
+    const decayParameters: PowerDecayParameters = {
+        type: 'power',
+        beta: 2
+    };
+
+    const defaultPOIs: GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }> = {
+        type: 'FeatureCollection',
+        features: [
+            {
+                type: 'Feature' as const,
+                id: poi1Id,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                },
+                properties: {
+                    weight: 1.0
+                }
+            },
+            {
+                type: 'Feature' as const,
+                id: poi2Id,
+                geometry: {
+                    type: 'Point' as const,
+                    coordinates: [-73.5, 45.6]
+                },
+                properties: {
+                    weight: 2.0
+                }
+            }
+        ]
+    };
+
+    const defaultParameters: AccessibilityWeightCalculationParameters = {
+        decayFunctionParameters: decayParameters,
+        decayInputType: 'networkDistance' as WeightDecayInputType,
+        poisFeatureCollection: defaultPOIs,
+        placesFeatureCollection: defaultPlaces,
+        maxBirdDistanceMeters: 10000,
+        routingMode: 'walking' as WeightingRoutingMode
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockTableFrom.mockClear();
+        mockCollection.mockClear();
+        mockedGetPOIsWithinBirdDistanceFromPoint.mockClear();
+        mockedGetPOIsWithinBirdDistanceFromPlaces.mockClear();
+        // Reset mockTableFrom to return empty arrays by default
+        mockTableFrom.mockResolvedValue({
+            query: '',
+            durations: [],
+            distances: []
+        });
+        // Default mock for getPOIsWithinBirdDistanceFromPlaces returns empty object
+        mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValue({});
+    });
+
+    describe('calculateWeights', () => {
+        test('should return error status when POIs array is empty', async () => {
+            const parametersWithoutPOIs = {
+                ...defaultParameters,
+                poisFeatureCollection: {
+                    type: 'FeatureCollection' as const,
+                    features: []
+                }
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parametersWithoutPOIs);
+            expect(Status.isStatusError(result)).toBe(true);
+            if (Status.isStatusError(result)) {
+                expect(result.error).toBeInstanceOf(TrError);
+                expect((result.error as TrError).message).toContain(
+                    'poisFeatureCollection is required and must contain at least one feature'
+                );
+            }
+        });
+
+        test('should return error status when no places provided', async () => {
+            const parametersWithoutPlaces = {
+                ...defaultParameters,
+                placesFeatureCollection: {
+                    type: 'FeatureCollection' as const,
+                    features: []
+                }
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parametersWithoutPlaces);
+            expect(Status.isStatusError(result)).toBe(true);
+            if (Status.isStatusError(result)) {
+                expect(result.error).toBeInstanceOf(TrError);
+                expect((result.error as TrError).message).toContain(
+                    'placesFeatureCollection is required and must contain at least one feature'
+                );
+            }
+        });
+
+        test('should return empty results when placesFeatureCollection has no valid features', async () => {
+            const parametersWithInvalidPlaces = {
+                ...defaultParameters,
+                placesFeatureCollection: {
+                    type: 'FeatureCollection' as const,
+                    features: [
+                        {
+                            type: 'Feature' as const,
+                            geometry: null,
+                            properties: {}
+                        } as unknown as GeoJSON.Feature<GeoJSON.Point>
+                    ]
+                }
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parametersWithInvalidPlaces);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toEqual({});
+            }
+        });
+
+        test('should return error status when maxBirdDistanceMeters is not positive', async () => {
+            const parameters = {
+                ...defaultParameters,
+                maxBirdDistanceMeters: -100
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusError(result)).toBe(true);
+            if (Status.isStatusError(result)) {
+                expect(result.error).toBeInstanceOf(TrError);
+                expect((result.error as TrError).message).toContain(
+                    'maxBirdDistanceMeters must be a positive number'
+                );
+            }
+        });
+
+        test('should return error status when maxNetworkDistanceMeters is not positive', async () => {
+            const parameters = {
+                ...defaultParameters,
+                maxNetworkDistanceMeters: 0
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusError(result)).toBe(true);
+            if (Status.isStatusError(result)) {
+                expect(result.error).toBeInstanceOf(TrError);
+                expect((result.error as TrError).message).toContain(
+                    'maxNetworkDistanceMeters must be a positive number'
+                );
+            }
+        });
+
+        test('should return error status when maxTravelTimeSeconds is not positive', async () => {
+            const parameters = {
+                ...defaultParameters,
+                maxTravelTimeSeconds: -50
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusError(result)).toBe(true);
+            if (Status.isStatusError(result)) {
+                expect(result.error).toBeInstanceOf(TrError);
+                expect((result.error as TrError).message).toContain(
+                    'maxTravelTimeSeconds must be a positive number'
+                );
+            }
+        });
+
+        test('should skip places without geography', async () => {
+            const placesWithoutGeography = {
+                type: 'FeatureCollection' as const,
+                features: [
+                    {
+                        type: 'Feature' as const,
+                        id: place1Id,
+                        geometry: null,
+                        properties: {}
+                    } as unknown as GeoJSON.Feature<GeoJSON.Point>
+                ]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: placesWithoutGeography
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(0);
+            }
+        });
+
+        test('should return zero weight when no POIs found', async () => {
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace
+            };
+
+            // Mock getPOIsWithinBirdDistanceFromPlaces to return empty array for this place
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: []
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                expect(result.result[place1Id]).toBe(0);
+            }
+        });
+
+        test('should calculate weight correctly with single POI', async () => {
+            const poi1 = {
+                id: poi1Id as number,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace
+            };
+
+            // Mock getPOIsWithinBirdDistanceFromPlaces to return POI for this place
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1]
+            });
+
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [300], // 5 minutes
+                distances: [500] // 500 meters
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                expect(result.result[place1Id]).toBeDefined();
+                // Weight = poiWeight * decayValue = 10.0 * (500^-2) = 10.0 * 0.000004 = 0.00004
+                expect(result.result[place1Id]).toBeCloseTo(10.0 * Math.pow(500, -2), 10);
+            }
+        });
+
+        test('should calculate weight correctly with multiple POIs', async () => {
+            const poi1 = {
+                id: poi1Id,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const poi2 = {
+                id: poi2Id as number,
+                weight: 5.0,
+                distance: 1000,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1, poi2]
+            });
+
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [300, 600],
+                distances: [500, 1000]
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                const expectedWeight =
+                    10.0 * Math.pow(500, -2) + // POI 1 contribution
+                    5.0 * Math.pow(1000, -2); // POI 2 contribution
+                expect(result.result[place1Id]).toBeCloseTo(expectedWeight, 10);
+            }
+        });
+
+        test('should include POIs even if network distance exceeds bird distance + 100 tolerance', async () => {
+            const poi1 = {
+                id: poi1Id as number,
+                weight: 10.0,
+                distance: 500, // Bird distance
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1]
+            });
+
+            // Network distance (700) exceeds bird distance (500) + 100 threshold = 600
+            // The current implementation does NOT filter out POIs based on network/bird distance discrepancy.
+            // It simply uses the network distance for the decay calculation if network distance mode is selected.
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [420],
+                distances: [700] // Network distance exceeds bird distance + 100 (600)
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                // POI is included despite the large discrepancy between bird and network distance
+                expect(result.result[place1Id]).toBeGreaterThan(0);
+            }
+        });
+
+        test('should skip POIs with null routing results', async () => {
+            const poi1 = {
+                id: poi1Id as number,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1]
+            });
+
+            // Return arrays with undefined/null values to simulate failed routing
+            // which _isBlank will catch
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [],
+                distances: []
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                expect(result.result[place1Id]).toBe(0);
+            }
+        });
+
+        test('should calculate weights for multiple places', async () => {
+            const poi1 = {
+                id: poi1Id,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1], // POI for place1
+                [place2Id]: [] // No POIs for place2
+            });
+
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [300],
+                distances: [500]
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(defaultParameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(2);
+                expect(result.result[place1Id]).toBeDefined();
+                expect(result.result[place1Id]).toBeGreaterThan(0);
+                expect(result.result[place2Id]).toBeDefined();
+                expect(result.result[place2Id]).toBe(0);
+            }
+        });
+
+        test('should calculate weights for a single place', async () => {
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: []
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                expect(result.result[place1Id]).toBe(0);
+            }
+        });
+
+        test('should use travelTime decayInputType when specified', async () => {
+            const poi1 = {
+                id: poi1Id,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace,
+                decayInputType: 'travelTime' as WeightDecayInputType
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1]
+            });
+
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [300], // 5 minutes
+                distances: [500]
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+                // Weight = poiWeight * decayValue = 10.0 * (300^-2) = 10.0 * 0.000011111... = 0.000111...
+                expect(result.result[place1Id]).toBeCloseTo(10.0 * Math.pow(300, -2), 10);
+            }
+        });
+
+        test('should call progress callback during calculation', async () => {
+            const progressCallback = jest.fn();
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [],
+                [place2Id]: []
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(defaultParameters, progressCallback);
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            expect(progressCallback).toHaveBeenCalled();
+            expect(progressCallback).toHaveBeenCalledWith(1.0); // Final progress
+        });
+
+        test('should handle decay calculation errors gracefully', async () => {
+            const poi1 = {
+                id: poi1Id,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const invalidParameters = {
+                ...defaultParameters,
+                placesFeatureCollection: singlePlace,
+                decayFunctionParameters: {
+                    type: 'power',
+                    beta: -1 // Invalid: negative beta
+                } as PowerDecayParameters
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1]
+            });
+
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [300],
+                distances: [500]
+            });
+
+            // Mock console.warn to avoid noise in test output
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+                // Suppress warnings in tests
+            });
+
+            // Should not return error status, but handle gracefully
+            const result = await AccessibilityWeightCalculator.calculateWeights(invalidParameters);
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(Object.keys(result.result)).toHaveLength(1);
+            }
+            consoleWarnSpy.mockRestore();
+        });
+
+        test('should use default routing mode when not specified', async () => {
+            const poi1 = {
+                id: poi1Id as number,
+                weight: 10.0,
+                distance: 500,
+                geography: {
+                    type: 'Point' as const,
+                    coordinates: [-73.6, 45.5]
+                } as GeoJSON.Point
+            };
+
+            const singlePlace = {
+                type: 'FeatureCollection' as const,
+                features: [defaultPlaces.features[0]]
+            };
+
+            const parameters = {
+                decayFunctionParameters: decayParameters,
+                decayInputType: 'networkDistance' as WeightDecayInputType,
+                poisFeatureCollection: defaultPOIs,
+                placesFeatureCollection: singlePlace,
+                maxBirdDistanceMeters: 10000
+                // routingMode not specified, should default to 'walking'
+            };
+
+            mockedGetPOIsWithinBirdDistanceFromPlaces.mockResolvedValueOnce({
+                [place1Id]: [poi1]
+            });
+
+            mockTableFrom.mockResolvedValueOnce({
+                query: '',
+                durations: [300],
+                distances: [500]
+            });
+
+            const result = await AccessibilityWeightCalculator.calculateWeights(parameters);
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            expect(mockTableFrom).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    mode: 'walking'
+                })
+            );
+        });
+    });
+
+    describe('calculateNodeAccessibilityWeights', () => {
+        const node1Id = uuidV4();
+        const node2Id = uuidV4();
+        const poi1Id = 1;
+        const poi2Id = 2;
+
+        const defaultPOIs: GeoJSON.FeatureCollection<GeoJSON.Point, { weight?: number }> = {
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature' as const,
+                    id: poi1Id,
+                    geometry: {
+                        type: 'Point' as const,
+                        coordinates: [-73.6, 45.5]
+                    },
+                    properties: {
+                        weight: 1.0
+                    }
+                },
+                {
+                    type: 'Feature' as const,
+                    id: poi2Id,
+                    geometry: {
+                        type: 'Point' as const,
+                        coordinates: [-73.5, 45.6]
+                    },
+                    properties: {
+                        weight: 2.0
+                    }
+                }
+            ]
+        };
+
+        const decayParameters: PowerDecayParameters = {
+            type: 'power',
+            beta: 2
+        };
+
+        const mockNode1 = {
+            id: node1Id,
+            geography: {
+                type: 'Point' as const,
+                coordinates: [-73.6, 45.5]
+            },
+            is_enabled: true
+        };
+
+        const mockNode2 = {
+            id: node2Id,
+            geography: {
+                type: 'Point' as const,
+                coordinates: [-73.5, 45.6]
+            },
+            is_enabled: true
+        };
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            mockedGetPOIsWithinBirdDistanceFromNodes.mockResolvedValue({});
+            mockCollection.mockResolvedValue([]);
+            mockTableFrom.mockResolvedValue({
+                query: '',
+                durations: [],
+                distances: []
+            });
+        });
+
+        test('should handle undefined nodeIds and query all enabled nodes', async () => {
+            mockCollection.mockResolvedValue([mockNode1, mockNode2]);
+            mockedGetPOIsWithinBirdDistanceFromNodes.mockResolvedValue({
+                [node1Id]: [
+                    {
+                        id: poi1Id,
+                        weight: 1.0,
+                        distance: 100,
+                        geography: {
+                            type: 'Point',
+                            coordinates: [-73.6, 45.5]
+                        }
+                    }
+                ],
+                [node2Id]: [
+                    {
+                        id: poi2Id,
+                        weight: 2.0,
+                        distance: 200,
+                        geography: {
+                            type: 'Point',
+                            coordinates: [-73.5, 45.6]
+                        }
+                    }
+                ]
+            });
+
+            const parameters = {
+                decayFunctionParameters: decayParameters,
+                decayInputType: 'birdDistance' as WeightDecayInputType,
+                poisFeatureCollection: defaultPOIs,
+                maxBirdDistanceMeters: 10000,
+                routingMode: 'walking' as WeightingRoutingMode
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateNodeAccessibilityWeights(parameters);
+
+            expect(mockCollection).toHaveBeenCalledWith({ nodeIds: undefined });
+            expect(mockedGetPOIsWithinBirdDistanceFromNodes).toHaveBeenCalledWith(
+                expect.any(Number),
+                expect.any(Object),
+                undefined
+            );
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(typeof result.result).toBe('object');
+            }
+        });
+
+        test('should handle empty nodeIds array and return empty result', async () => {
+            // Empty array means "no nodes" - returns {} immediately without database calls
+            const parameters = {
+                decayFunctionParameters: decayParameters,
+                decayInputType: 'birdDistance' as WeightDecayInputType,
+                poisFeatureCollection: defaultPOIs,
+                nodeIds: [],
+                maxBirdDistanceMeters: 10000,
+                routingMode: 'walking' as WeightingRoutingMode
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateNodeAccessibilityWeights(parameters);
+
+            // Empty nodeIds array should return early without calling database functions
+            expect(mockCollection).not.toHaveBeenCalled();
+            expect(mockedGetPOIsWithinBirdDistanceFromNodes).not.toHaveBeenCalled();
+            // Empty nodeIds array should result in empty weights object
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toEqual({});
+            }
+        });
+
+        test('should handle non-empty nodeIds array', async () => {
+            const specificNodeIds = [node1Id];
+            mockCollection.mockResolvedValue([mockNode1]);
+            mockedGetPOIsWithinBirdDistanceFromNodes.mockResolvedValue({
+                [node1Id]: [
+                    {
+                        id: poi1Id,
+                        weight: 1.0,
+                        distance: 100,
+                        geography: {
+                            type: 'Point',
+                            coordinates: [-73.6, 45.5]
+                        }
+                    }
+                ]
+            });
+
+            const parameters = {
+                decayFunctionParameters: decayParameters,
+                decayInputType: 'birdDistance' as WeightDecayInputType,
+                poisFeatureCollection: defaultPOIs,
+                nodeIds: specificNodeIds,
+                maxBirdDistanceMeters: 10000,
+                routingMode: 'walking' as WeightingRoutingMode
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateNodeAccessibilityWeights(parameters);
+
+            expect(mockCollection).toHaveBeenCalledWith({ nodeIds: specificNodeIds });
+            expect(mockedGetPOIsWithinBirdDistanceFromNodes).toHaveBeenCalledWith(
+                expect.any(Number),
+                expect.any(Object),
+                specificNodeIds
+            );
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toHaveProperty(node1Id);
+                expect(result.result[node1Id]).toBeGreaterThanOrEqual(0);
+            }
+        });
+
+        test('should return zero weight when nodeIds provided but nodes not found in database', async () => {
+            mockCollection.mockResolvedValue([]);
+            mockedGetPOIsWithinBirdDistanceFromNodes.mockResolvedValue({});
+
+            const parameters = {
+                decayFunctionParameters: decayParameters,
+                decayInputType: 'birdDistance' as WeightDecayInputType,
+                poisFeatureCollection: defaultPOIs,
+                nodeIds: [node1Id],
+                maxBirdDistanceMeters: 10000,
+                routingMode: 'walking' as WeightingRoutingMode
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateNodeAccessibilityWeights(parameters);
+
+            // When nodeIds are provided but nodes not found, they get weight 0
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toEqual({ [node1Id]: 0 });
+            }
+        });
+
+        test('should handle node without geography gracefully', async () => {
+            const nodeWithoutGeography = {
+                id: node1Id,
+                geography: null,
+                is_enabled: true
+            };
+            mockCollection.mockResolvedValue([nodeWithoutGeography]);
+            mockedGetPOIsWithinBirdDistanceFromNodes.mockResolvedValue({
+                [node1Id]: []
+            });
+
+            const parameters = {
+                decayFunctionParameters: decayParameters,
+                decayInputType: 'birdDistance' as WeightDecayInputType,
+                poisFeatureCollection: defaultPOIs,
+                nodeIds: [node1Id],
+                maxBirdDistanceMeters: 10000,
+                routingMode: 'walking' as WeightingRoutingMode
+            };
+
+            const result = await AccessibilityWeightCalculator.calculateNodeAccessibilityWeights(parameters);
+
+            // Node without geography should have weight 0
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result[node1Id]).toBe(0);
+            }
+        });
+    });
+});
+

--- a/packages/transition-backend/src/services/weighting/types.ts
+++ b/packages/transition-backend/src/services/weighting/types.ts
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import GeoJSON from 'geojson';
+
 /** Full documentation on the weighting methodology is available in the docs/weighting directory. */
 
 /**
@@ -13,9 +15,36 @@
 export type DecayFunctionType = 'power' | 'exponential' | 'gamma' | 'combined' | 'logistic';
 
 /**
- * Type of input value (distance or time)
+ * Type of input value (distance or time) for decay function calculations
  */
 export type DecayInputValueType = 'distance' | 'time';
+
+/**
+ * Type of input value for place weight calculations
+ * - birdDistance: Use bird distance (Euclidean distance) from PostGIS, no routing needed
+ * - networkDistance: Use network distance from routing engine
+ * - travelTime: Use travel time from routing engine
+ */
+export type WeightDecayInputType = 'birdDistance' | 'networkDistance' | 'travelTime';
+
+/**
+ * Routing mode for place weight calculations
+ * TODO: Add more modes (cycling, driving) when supported in preferences and use cases
+ */
+export type WeightingRoutingMode = 'walking';
+
+/**
+ * POI input type: GeoJSON Point feature with id as feature id and weight in properties
+ * Used for place weight calculations
+ */
+export type POIInput = GeoJSON.Feature<GeoJSON.Point, { weight?: number }> & { id: number };
+
+/**
+ * Place weights dictionary: maps place IDs to their calculated weights
+ * Format: { "id1": weight1, "id2": weight2, ... }
+ * Note: Numeric POI IDs are converted to strings for object keys
+ */
+export type AccessibilityWeights = Record<string, number>;
 
 /**
  * Value object containing both distance and time values for decay function calculations.


### PR DESCRIPTION
Implement backend service to calculate transit places and node accessibility weights based on POIs proximity and decay functions.

The service:
- Calculates places accessibility weights using POIs
- Supports three decay input types: birdDistance, networkDistance, and travelTime
- Uses PostGIS temporary tables for efficient spatial queries
- Integrates with OSRM routing for network distance and travel time calculations
- Supports filtering by specific node UUIDs
- Returns weights as a dictionary mapping node UUIDs to calculated weights

Add preferences for maximum distances and travel times:
- maxAccessibilityWeightsBirdDistancesMeters
- maxAccessibilityWeightsNetworkDistancesMeters
- maxAccessibilityWeightsTravelTimeSeconds

Add database query helper getPOIsWithinBirdDistanceFromPoint using temporary PostGIS tables for efficient spatial filtering.

Update documentation to add new weight types: intrinsic and accessibility weights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configuration options to set max distances/times for accessibility calculations
  * New accessibility-weight calculation service and support for querying POIs by point or nodes

* **Documentation**
  * Revised weighting docs to separate intrinsic (destination) weights from accessibility weights and updated workflows

* **Tests**
  * Added extensive unit and integration tests covering accessibility calculations, POI/node queries, and routing-based scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->