### PR TITLE
Disable vehicule number check in candidate generation

### DIFF
--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
@@ -88,7 +88,8 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
         }
 
         if (usedVehicles / nbVehicles < USED_VEHICLES_THRESHOLD) {
-            throw new TrError(`Too few vehicles (${usedVehicles}) were assigned for this combination`, 'GALNCND004');
+            console.warn(`Too few vehicles (${usedVehicles}) were assigned for this combination, but still using`);
+            //throw new TrError(`Too few vehicles (${usedVehicles}) were assigned for this combination`, 'GALNCND004');
         }
 
         return currentLvlIndexes.map((currentLvlIndex, index) =>


### PR DESCRIPTION
Just print a warning for the moment