### PR TITLE
Add trRoutingJobParameters to the BatchRouteJobType

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/BatchRoutingJob.ts
+++ b/packages/transition-backend/src/services/transitRouting/BatchRoutingJob.ts
@@ -7,6 +7,7 @@
 import { TransitBatchRoutingDemandAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import { TrRoutingBatchJobParameters } from './TrRoutingBatchJobParameters';
 import { OdTripRouteResult } from './types';
 
 export type BatchRouteJobType = {
@@ -15,6 +16,7 @@ export type BatchRouteJobType = {
         parameters: {
             demandAttributes: TransitBatchRoutingDemandAttributes;
             transitRoutingAttributes: BatchCalculationParameters;
+            trRoutingJobParameters?: TrRoutingBatchJobParameters; // Parameters to adjust trRouting startup
         };
         results?: Omit<TransitBatchCalculationResult, 'errors' | 'warnings'>;
     };

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -92,8 +92,8 @@ class TrRoutingBatch {
 
             // Start the trRouting instance for the odTrips
             const { threadCount: trRoutingThreadsCount, port: trRoutingPort } = await this.batchManager.startBatch(
-                odTripsCount
-                // TODO add options with cachePath
+                odTripsCount,
+                this.job.attributes.data.parameters.trRoutingJobParameters
             );
 
             // Prepare indexes for calculations and progress report


### PR DESCRIPTION
A TrRoutingBatchJobParameters type was previously created for the TrRoutingBatchManager object to pass parameter to the creation of trRouting processes. This add the object to the TrRoutingBatch as an optional parameter. It's passed directly to the TrRoutingBatchManager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch routing jobs now accept optional routing job parameters, including a custom cache directory option to control where temporary routing data is stored.

* **Tests**
  * Added tests confirming batch routing honors the custom cache directory parameter and retains existing behavior when none is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->