### PR TITLE
trRouting: Do not attempt a retry on error code 400

### DIFF
--- a/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
+++ b/packages/chaire-lib-backend/src/utils/trRouting/TrRoutingServiceBackend.ts
@@ -30,7 +30,8 @@ class TrRoutingServiceBackend {
         for (let i = 0; i < maxAttempts; i++) {
             try {
                 const response = await fetch(trRoutingRequest, { method: 'GET' });
-                if (!response.ok) {
+                // 200 and 400 are both valid response from TrRouting and are handled by the parsers
+                if (![200, 400].includes(response.status)) {
                     throw new Error(`TrRouting request failed with status ${response.status}`);
                 }
                 return await response.json();

--- a/packages/chaire-lib-backend/src/utils/trRouting/__tests__/TrRoutingServerBackend.test.ts
+++ b/packages/chaire-lib-backend/src/utils/trRouting/__tests__/TrRoutingServerBackend.test.ts
@@ -298,4 +298,17 @@ describe('Retry and timeout behavior', () => {
         expect(result).toEqual({ status: 'success' });
     });
 
+    test('Should not retry on 400 Bad Request error', async () => {
+        const errorResponse = new Response(JSON.stringify({ error: 'Bad request' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+        });
+        // Mock fetch to return a 400 error
+        mockedFetch.mockResolvedValueOnce(errorResponse);
+        const result = await TrRoutingServiceBackend.route(defaultParameters);
+
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({ error: 'Bad request' });
+    });
+
 });


### PR DESCRIPTION
A 400 code from trRouting means that the query parameters are invalid. There's no point in doing a retry at that point since the query will remain invalid.

Closes: #1606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routing service now treats HTTP 200 and 400 responses as valid and processes them immediately; 400 (Bad Request) responses fail fast instead of triggering retries, reducing unnecessary retry attempts.

* **Tests**
  * Added a test confirming 400 Bad Request responses are not retried and are handled exactly once.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->