### PR TITLE
Do apt update in latex workflow

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -7,9 +7,10 @@ on:
     # Runs on all push to main, to make sure there's no other side effet
   pull_request:
     branches: [ main ]
-    # But only runs on PR that touches tex files
+    # But only runs on PR that touches tex files and this workflow
     paths:
       - '**/*.tex'
+      - '**/workflows/latex.yml'
 
 jobs:
   latex-compile:
@@ -17,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install latex packages
-        run: sudo apt install texlive-latex-base texlive-latex-extra
+        run: |
+          sudo apt update
+          sudo apt install -y texlive-latex-base texlive-latex-extra
       - name: Builds latex files
         working-directory: packages/transition-backend/file/definitions
         run: |

--- a/.github/workflows/osrmprofile.yml
+++ b/.github/workflows/osrmprofile.yml
@@ -11,6 +11,7 @@ on:
     # But only runs on PR that touches lua files
     paths:
       - '**/*.lua'
+      - '**/workflows/osrmprofile.yml'
 
 jobs:
   compile-lua:
@@ -22,8 +23,8 @@ jobs:
 
     - name: Setup Lua
       run: |
-        sudo apt-get update
-        sudo apt-get install -y lua5.3  # Install Lua version 5.3
+        sudo apt update
+        sudo apt install -y lua5.3  # Install Lua version 5.3
 
     - name: Compile Lua script
       run: luac5.3 -p packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/*.lua  # Compile all Lua OSRM profiles


### PR DESCRIPTION
Let's make sure we call update before running install when running apt

Also consolidate on using apt instead of the old apt-get





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure GitHub Actions runs apt update before apt install and standardizes on apt across the LaTeX and OSRM profile workflows to prevent failed installs and keep CI consistent. Also trigger these workflows when their workflow files change.

<sup>Written for commit 0e212abc96f5cabf19e5845c77366e3d46a36c0d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to also trigger when their workflow definitions change.
  * Workflow setup steps improved to refresh package lists and reliably install required LaTeX and Lua packages, enhancing build consistency and reproducibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->