### PR TITLE
networkDesign backend: fix network design unit tests

### DIFF
--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/__tests__/LineAndNumberOfVehiclesGeneration.test.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/__tests__/LineAndNumberOfVehiclesGeneration.test.ts
@@ -7,6 +7,7 @@
 import random from 'random';
 import _cloneDeep from 'lodash/cloneDeep';
 import { v4 as uuidV4 } from 'uuid';
+import EventEmitter from 'events';
 
 import Generation, { generateFirstCandidates } from '../LineAndNumberOfVehiclesGeneration';
 import * as AlgoTypes from '../../internalTypes';
@@ -14,14 +15,20 @@ import Line from 'transition-common/lib/services/line/Line';
 import Service from 'transition-common/lib/services/service/Service';
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
-import SimulationRun from '../../../simulation/SimulationRun';
+import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollection';
 import CandidateClass from '../../candidate/LineAndNumberOfVehiclesNetworkCandidate';
+import { EvolutionaryTransitNetworkDesignJobParameters, EvolutionaryTransitNetworkDesignJobType } from '../../../networkDesign/transitNetworkDesign/evolutionary/types';
+import { ExecutableJob } from '../../../executableJob/ExecutableJob';
+import jobsDbQueries from '../../../../models/db/jobs.db.queries';
+import { createMockJobExecutor } from '../../../networkDesign/transitNetworkDesign/__tests__/MockTransitNetworkDesignJobWrapper';
+import Scenario from 'transition-common/lib/services/scenario/Scenario';
 
 // Setup mocks
 const mockPrepareCandidate = jest.fn();
 const mockSimulate = jest.fn();
 CandidateClass.prototype.prepareScenario = mockPrepareCandidate;
 CandidateClass.prototype.simulate = mockSimulate;
+CandidateClass.prototype.getScenario = jest.fn().mockReturnValue(new Scenario({ id: uuidV4() }, false));
 // Mock random, cloning with seed does not seem to work for those tests
 jest.mock('random', () => ({
     float: jest.fn(),
@@ -29,6 +36,10 @@ jest.mock('random', () => ({
 }));
 const mockedRandomFloat = random.float as jest.MockedFunction<typeof random.float>;
 const mockedRandomInt = random.integer as jest.MockedFunction<typeof random.integer>;
+
+// Mock the job loader
+jest.mock('../../../../models/db/jobs.db.queries');
+const mockJobsDbQueries = jobsDbQueries as jest.Mocked<typeof jobsDbQueries>;
 
 const line1 = new Line({  
     id                       : uuidV4(),
@@ -60,57 +71,59 @@ const line6 = new Line(Object.assign({}, line1.attributes, { id: uuidV4() }), fa
 // One one service is required, the content is not important for this test.
 const service = new Service({ id: uuidV4()}, false);
 
-const simMethodId = 'test';
-const simulationRun = new SimulationRun({
-    seed: '235132',
-    data: {
-        routingAttributes: {
-            maxTotalTravelTimeSeconds: 1000
+const createMockJobExecutorForTest = async (parameters: Partial<EvolutionaryTransitNetworkDesignJobParameters>) => {
+    const mockJobAttributes = {
+        id: 1,
+        name: 'evolutionaryTransitNetworkDesign' as const,
+        user_id: 123,
+        status: 'pending' as const,
+        internal_data: {},
+        data: {
+            parameters: {
+                transitNetworkDesignParameters: {
+                    maxTimeBetweenPassages: 30,
+                    nbOfVehicles: 7,
+                    simulatedAgencies: ['arbitrary'],
+                    numberOfLinesMin: 3,
+                    numberOfLinesMax: 4
+                },
+                algorithmConfiguration: {
+                    type: 'evolutionaryAlgorithm',
+                    config: {
+                        populationSizeMin: 2,
+                        populationSizeMax: 2,
+                        numberOfElites: 0,
+                        numberOfRandoms: 0,
+                        crossoverNumberOfCuts: 1,
+                        crossoverProbability: 1,
+                        mutationProbability: 0,
+                        tournamentSize: 2,
+                        tournamentProbability: 1,
+                        numberOfGenerations: 3,
+                        shuffleGenes: false,
+                        keepCandidates: 1,
+                        keepGenerations: 1
+                    }
+                },
+                ...parameters
+            } as EvolutionaryTransitNetworkDesignJobParameters
         },
-        transitNetworkDesignParameters: {
-            maxTimeBetweenPassages: 30,
-            nbOfVehicles: 7,
-            simulatedAgencies: ['arbitrary'],
-            numberOfLinesMin: 3,
-            numberOfLinesMax: 4
-        },
-        algorithmConfiguration: {
-            type: 'evolutionaryAlgorithm',
-            config: {
-                populationSizeMin: 3,
-                populationSizeMax: 4,
-                numberOfElites: 1,
-                numberOfRandoms: 0,
-                crossoverNumberOfCuts: 1,
-                crossoverProbability: 0.3,
-                mutationProbability: 0.5,
-                tournamentSize: 2,
-                tournamentProbability: 0.6,
-                shuffleGenes: true
+        resources: {
+            files: {
+                transitDemand: 'demand.csv',
+                nodeWeight: 'weights.csv'
             }
         }
-    },
-    status: 'pending' as const,
-    simulation_id: uuidV4(),
-    results: {},
-    options: {
-        numberOfThreads: 1,
-        fitnessSorter: 'maximize',
-        functions: {
-            [simMethodId]: { weight: 1 }
-        },
-        trRoutingStartingPort: 14000
-    }
-}, true);
+    };
 
-const options: AlgoTypes.RuntimeAlgorithmData = {
-    agencies: [],
-    randomGenerator: random,
-    simulationRun: simulationRun,
-    lineCollection: new LineCollection([line1, line2, line3, line4, line5, line6], {}),
-    linesToKeep: [],
-    services: new ServiceCollection([service], {}),
-    lineServices: {
+    mockJobsDbQueries.read.mockResolvedValueOnce(mockJobAttributes);
+    const job = await ExecutableJob.loadTask(1);
+    
+    const lineCollection = new LineCollection([line1, line2, line3, line4, line5, line6], {});
+    const agencyCollection = new AgencyCollection([], {});
+    const serviceCollection = new ServiceCollection([service], {});
+    
+    const lineServices: AlgoTypes.LineServices = {
         [line1.getId()]: [
             {
                 numberOfVehicles: 4,
@@ -171,25 +184,16 @@ const options: AlgoTypes.RuntimeAlgorithmData = {
                 service: new Service({ id: uuidV4()}, false)
             }
         ]
-    },
-    nonSimulatedServices: [],
-    populationSize: 2,
-    options: {
-        populationSizeMin: 2,
-        populationSizeMax: 2,
-        numberOfElites: 0,
-        numberOfRandoms: 0,
-        crossoverNumberOfCuts: 1,
-        crossoverProbability: 1,
-        mutationProbability: 0,
-        tournamentSize: 2,
-        tournamentProbability: 1,
-        numberOfGenerations: 3,
-        shuffleGenes: false,
-        keepCandidates: 1,
-        keepGenerations: 1
-    }
-}
+    };
+
+    return createMockJobExecutor(job as ExecutableJob<EvolutionaryTransitNetworkDesignJobType>, {
+        lineCollection,
+        agencyCollection,
+        serviceCollection,
+        simulatedLineCollection: lineCollection,
+        lineServices
+    });
+};
 
 describe('Test generation of first candidates', () => {
 
@@ -197,7 +201,12 @@ describe('Test generation of first candidates', () => {
         mockedRandomInt.mockReturnValueOnce(3);
         mockedRandomInt.mockReturnValueOnce(4);
         mockedRandomFloat.mockReturnValue(0.5);
-        const candidates = generateFirstCandidates(options);
+        
+        const jobExecutor = await createMockJobExecutorForTest({});
+        // Set the population size, which should have randomly been set already
+        jobExecutor.job.attributes.internal_data.populationSize = 2;
+
+        const candidates = generateFirstCandidates(jobExecutor);
         expect(candidates.length).toEqual(2);
         const nbLinesFirstCandidate = candidates[0].getChromosome().lines.filter(active => active === true).length;
         expect(nbLinesFirstCandidate).toEqual(3);
@@ -209,21 +218,35 @@ describe('Test generation of first candidates', () => {
 
 describe('Test simulation and results', () => {
 
+    
     beforeEach(() => {
         mockSimulate.mockClear();
     });
 
-    test('Test successful simulation, sorted descending', async () => {
-        simulationRun.attributes.options.fitnessSorter = 'maximize';
+    test('Test successful simulation, sorted descending, with AccessibilityMapSimulation', async () => {
+        const simultionMethodAccessibility = {
+            type: 'AccessibilityMapSimulation' as const,
+            config: {
+                dataSourceId: 'someDataSourceId',
+                sampleRatio: 0.05
+            }
+        };
+
         mockedRandomInt.mockReturnValueOnce(3);
         mockedRandomInt.mockReturnValueOnce(4);
         mockedRandomFloat.mockReturnValue(0.5);
-        const candidates = generateFirstCandidates(options);
+        
+        const jobExecutor = await createMockJobExecutorForTest({simulationMethod: simultionMethodAccessibility});
+        // Set the population size, which should have randomly been set already
+        jobExecutor.job.attributes.internal_data.populationSize = 2;
+
+        // Generate the first candidates
+        const candidates = generateFirstCandidates(jobExecutor);
         candidates.forEach((candidate, index) => {
             candidate.getResult = jest.fn().mockReturnValue({
                 totalFitness: 1000 + index * 100,
                 results: {
-                    [simMethodId]: { fitness: 1000 + index * 100 }
+                    AccessibilityMapSimulation: { fitness: 1000 + index * 100 }
                 }
             });
             candidate.serialize = jest.fn().mockReturnValue({
@@ -234,7 +257,7 @@ describe('Test simulation and results', () => {
                 }
             });
         })
-        const generation = new Generation(candidates, options);
+        const generation = new Generation(candidates, jobExecutor, 1);
         await generation.simulate();
         expect(mockSimulate).toHaveBeenCalledTimes(candidates.length);
         const serialized = generation.serializeBestResult();
@@ -247,17 +270,57 @@ describe('Test simulation and results', () => {
         });
     });
 
-    test('Test successful simulation, sorted ascending', async () => {
-        simulationRun.attributes.options.fitnessSorter = 'minimize';
+    test('Test successful simulation, sorted ascending, with OdTripSimulation', async () => {
+        const simulationMethodConfigurationOdTrip = {
+            type: 'OdTripSimulation' as const,
+            config: {
+                demandAttributes: {
+                    type: 'csv' as const,
+                    fileAndMapping: {
+                        csvFile: { location: 'upload' as const, filename: 'demand.csv', uploadFilename: 'demand.csv'},
+                        fieldMappings: {
+                            id: 'id',
+                            originLat: 'origin_lat',
+                            originLon: 'origin_lon',
+                            destinationLat: 'destination_lat',
+                            destinationLon: 'destination_lon',
+                        }
+                    },
+                    csvFields: []
+                },
+                transitRoutingAttributes: {
+                    minWaitingTimeSeconds: 180,
+                    maxTransferTravelTimeSeconds: 900,
+                    maxAccessEgressTravelTimeSeconds: 900,
+                    maxWalkingOnlyTravelTimeSeconds: 3600,
+                    maxFirstWaitingTimeSeconds: 900,
+                    maxTotalTravelTimeSeconds: 3600,
+                    walkingSpeedMps: 1.3,
+                    walkingSpeedFactor: 1,
+                },
+                evaluationOptions: {
+                    sampleRatio: 0.05,
+                    odTripFitnessFunction: 'travelTimeCost',
+                    fitnessFunction: 'hourlyUserPlusOperatingCosts'
+                }
+            }
+        };
+
         mockedRandomInt.mockReturnValueOnce(3);
         mockedRandomInt.mockReturnValueOnce(4);
         mockedRandomFloat.mockReturnValue(0.5);
-        const candidates = generateFirstCandidates(options);
+        
+        const jobExecutor = await createMockJobExecutorForTest({simulationMethod: simulationMethodConfigurationOdTrip});
+        // Set the population size, which should have randomly been set already
+        jobExecutor.job.attributes.internal_data.populationSize = 2;
+
+        // Generate the first candidates
+        const candidates = generateFirstCandidates(jobExecutor);
         candidates.forEach((candidate, index) => {
             candidate.getResult = jest.fn().mockReturnValue({
                 totalFitness: 1000 + index * 100,
                 results: {
-                    [simMethodId]: { fitness: 1000 + index * 100 }
+                    OdTripSimulation: { fitness: 1000 + index * 100 }
                 }
             });
             candidate.serialize = jest.fn().mockReturnValue({
@@ -268,7 +331,7 @@ describe('Test simulation and results', () => {
                 }
             });
         })
-        const generation = new Generation(candidates, options);
+        const generation = new Generation(candidates, jobExecutor, 1);
         await generation.simulate();
         expect(mockSimulate).toHaveBeenCalledTimes(candidates.length);
         const serialized = generation.serializeBestResult();
@@ -285,20 +348,53 @@ describe('Test simulation and results', () => {
 
 describe('Test sort candidates after results', () => {
 
-    beforeEach(() => {
-        simulationRun.attributes.options.fitnessSorter = 'maximize';
-    });
+    test('Test sort with OdTripSimulation, should minimize', async () => {
+        const simulationMethod = {
+            type: 'OdTripSimulation' as const,
+            config: {
+                demandAttributes: {
+                    type: 'csv' as const,
+                    fileAndMapping: {
+                        csvFile: { location: 'upload' as const, filename: 'demand.csv', uploadFilename: 'demand.csv'},
+                        fieldMappings: {
+                            id: 'id',
+                            originLat: 'origin_lat',
+                            originLon: 'origin_lon',
+                            destinationLat: 'destination_lat',
+                            destinationLon: 'destination_lon',
+                        }
+                    },
+                    csvFields: []
+                },
+                transitRoutingAttributes: {
+                    minWaitingTimeSeconds: 180,
+                    maxTransferTravelTimeSeconds: 900,
+                    maxAccessEgressTravelTimeSeconds: 900,
+                    maxWalkingOnlyTravelTimeSeconds: 3600,
+                    maxFirstWaitingTimeSeconds: 900,
+                    maxTotalTravelTimeSeconds: 3600,
+                    walkingSpeedMps: 1.3,
+                    walkingSpeedFactor: 1,
+                },
+                evaluationOptions: {
+                    sampleRatio: 0.05,
+                    odTripFitnessFunction: 'travelTimeCost',
+                    fitnessFunction: 'hourlyUserPlusOperatingCosts'
+                }
+            }
+        };
 
-    test('Test sort with one method', async () => {
+        const simMethodId = 'OdTripSimulation'
+        const jobExecutor = await createMockJobExecutorForTest({ simulationMethod });
         // Create candidates, chromosomes does not matter here, we'll just need the results
         const candidates = [
-            new CandidateClass({ lines: [true, false], name: 'test1'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test2'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test3'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test4'}, options),
+            new CandidateClass({ lines: [true, false], name: 'test1'}, jobExecutor),
+            new CandidateClass({ lines: [true, false], name: 'test2'}, jobExecutor),
+            new CandidateClass({ lines: [true, false], name: 'test3'}, jobExecutor),
+            new CandidateClass({ lines: [true, false], name: 'test4'}, jobExecutor),
         ];
         const originalCandidates = _cloneDeep(candidates);
-        // With fitness modifier, we maximize, so index 2 should be first, then 0, then 1 then 3
+        // With fitness modifier, even candidates have higher fitness than even, so index 3 should be first, then 1, then 0, then 2
         candidates.forEach((candidate, index) => {
             const fitnessModifier = index % 2 === 0 ? index * 100 : -index * 100;
             candidate.getResult = jest.fn().mockReturnValue({
@@ -308,117 +404,17 @@ describe('Test sort candidates after results', () => {
                 }
             });
         });
-        const generation = new Generation(candidates, options);
+        const generation = new Generation(candidates, jobExecutor);
         generation.sortCandidates();
         const actualCandidates = candidates.map(candidate => candidate.getChromosome().name);
         expect(actualCandidates).toEqual([
-            originalCandidates[2].getChromosome().name, 
-            originalCandidates[0].getChromosome().name, 
+            originalCandidates[3].getChromosome().name, 
             originalCandidates[1].getChromosome().name, 
-            originalCandidates[3].getChromosome().name
+            originalCandidates[0].getChromosome().name, 
+            originalCandidates[2].getChromosome().name
         ]);
         const actualCandidateFitnesses = candidates.map(candidate => candidate.getResult().totalFitness);
         expect(actualCandidateFitnesses).toEqual([1, 2, 3, 4]);
-    });
-
-    test('Test sort with multiple methods of equal weight', async () => {
-        // Add a second method and prepare options
-        const simMethod2 = 'simMethod2';
-        const optionsWithNewMethod = _cloneDeep(options);
-        const simulationRunAttribs = _cloneDeep(simulationRun.attributes);
-        simulationRunAttribs.options.functions[simMethodId] = { weight: 0.5 };
-        simulationRunAttribs.options.functions[simMethod2] = { weight: 0.5 };
-        const simulationRunWith2Methods = new SimulationRun(simulationRunAttribs, false);
-        optionsWithNewMethod.simulationRun = simulationRunWith2Methods;
-
-        // Create candidates, chromosomes does not matter here, we'll just need the results
-        const candidates = [
-            new CandidateClass({ lines: [true, false], name: 'test1'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test2'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test3'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test4'}, options),
-        ];
-        const originalCandidates = _cloneDeep(candidates);
-        
-        // For sim method 1, we use a fitness modifier, ranks should be [2, 0, 1, 3]
-        // For sim method 2, we add a value given the index, so ranks should be [3, 2, 1, 0]
-        // Total score for each candidate is [(2 ^ 0.5) * (4 ^ 0.5), (3 ^ 0.5) * (3 ^ 0.5), (1 ^ 0.5) * (2 ^ 0.5), (4 ^ 0.5) * (1 ^ 0.5)] 
-        // ==> [2.83, 3, 1.41, 2], final sort order should thus be [2, 3, 0, 1]
-        candidates.forEach((candidate, index) => {
-            const fitnessModifier = index % 2 === 0 ? index * 100 : -index * 100;
-            candidate.getResult = jest.fn().mockReturnValue({
-                totalFitness: Number.NaN,
-                results: {
-                    [simMethodId]: { fitness: 1000 + fitnessModifier },
-                    [simMethod2]: { fitness: 1000 + index * 100 }
-                }
-            });
-        });
-        const generation = new Generation(candidates, optionsWithNewMethod);
-        generation.sortCandidates();
-        const actualCandidates = candidates.map(candidate => candidate.getChromosome().name);
-        expect(actualCandidates).toEqual([
-            originalCandidates[2].getChromosome().name, 
-            originalCandidates[3].getChromosome().name, 
-            originalCandidates[0].getChromosome().name, 
-            originalCandidates[1].getChromosome().name
-        ]);
-        
-        const actualCandidateFitnesses = candidates.map(candidate => candidate.getResult().totalFitness);
-        expect(actualCandidateFitnesses[0]).toBeCloseTo(1.41, 2);
-        expect(actualCandidateFitnesses[1]).toBeCloseTo(2, 2);
-        expect(actualCandidateFitnesses[2]).toBeCloseTo(2.83, 2);
-        expect(actualCandidateFitnesses[3]).toBeCloseTo(3, 2);
-    });
-
-    test('Test sort with multiple methods of unequal weight', async () => {
-        // Same asprevious test, only the weights change
-        // Add a second method and prepare options
-        const simMethod2 = 'simMethod2';
-        const optionsWithNewMethod = _cloneDeep(options);
-        const simulationRunAttribs = _cloneDeep(simulationRun.attributes);
-        simulationRunAttribs.options.functions[simMethodId] = { weight: 0.8 };
-        simulationRunAttribs.options.functions[simMethod2] = { weight: 0.2 };
-        const simulationRunWith2Methods = new SimulationRun(simulationRunAttribs, false);
-        optionsWithNewMethod.simulationRun = simulationRunWith2Methods;
-
-        // Create candidates, chromosomes does not matter here, we'll just need the results
-        const candidates = [
-            new CandidateClass({ lines: [true, false], name: 'test1'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test2'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test3'}, options),
-            new CandidateClass({ lines: [true, false], name: 'test4'}, options),
-        ];
-        const originalCandidates = _cloneDeep(candidates);
-        
-        // For sim method 1, we use a fitness modifier, ranks should be [2, 0, 1, 3]
-        // For sim method 2, we add a value given the index, so ranks should be [3, 2, 1, 0]
-        // Total score for each candidate is [(2 ^ 0.8) * (4 ^ 0.2), (3 ^ 0.8) * (3 ^ 0.2), (1 ^ 0.8) * (2 ^ 0.2), (4 ^ 0.8) * (1 ^ 0.2)] 
-        // ==> [2.297, 3, 1.15, 3.03], final sort order should thus be [2, 0, 1, 3]
-        candidates.forEach((candidate, index) => {
-            const fitnessModifier = index % 2 === 0 ? index * 100 : -index * 100;
-            candidate.getResult = jest.fn().mockReturnValue({
-                totalFitness: Number.NaN,
-                results: {
-                    [simMethodId]: { fitness: 1000 + fitnessModifier },
-                    [simMethod2]: { fitness: 1000 + index * 100 }
-                }
-            });
-        });
-        const generation = new Generation(candidates, optionsWithNewMethod);
-        generation.sortCandidates();
-        const actualCandidates = candidates.map(candidate => candidate.getChromosome().name);
-        expect(actualCandidates).toEqual([
-            originalCandidates[2].getChromosome().name, 
-            originalCandidates[0].getChromosome().name, 
-            originalCandidates[1].getChromosome().name, 
-            originalCandidates[3].getChromosome().name
-        ]);
-        const actualCandidateFitnesses = candidates.map(candidate => candidate.getResult().totalFitness);
-        expect(actualCandidateFitnesses[0]).toBeCloseTo(1.15, 2);
-        expect(actualCandidateFitnesses[1]).toBeCloseTo(2.297, 2);
-        expect(actualCandidateFitnesses[2]).toBeCloseTo(3, 2);
-        expect(actualCandidateFitnesses[3]).toBeCloseTo(3.03, 2);
     });
 
 });

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/preparation/__tests__/ServicePreparation.test.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/preparation/__tests__/ServicePreparation.test.ts
@@ -21,7 +21,7 @@ import ServiceCollection from 'transition-common/lib/services/service/ServiceCol
 import { EvolutionaryTransitNetworkDesignJobParameters, EvolutionaryTransitNetworkDesignJobType } from '../../../networkDesign/transitNetworkDesign/evolutionary/types';
 import { ExecutableJob } from '../../../executableJob/ExecutableJob';
 import jobsDbQueries from '../../../../models/db/jobs.db.queries';
-import { TransitNetworkDesignJobWrapper } from '../../../networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper';
+import { createMockJobExecutor } from '../../../networkDesign/transitNetworkDesign/__tests__/MockTransitNetworkDesignJobWrapper';
 
 const mockedScheduleGeneration = jest.fn();
 Schedule.prototype.generateForPeriod = mockedScheduleGeneration;
@@ -207,7 +207,9 @@ const getJobExecutor = async (parameters: Partial<EvolutionaryTransitNetworkDesi
     testJobParameters.data.parameters = parameters;
     mockJobsDbQueries.read.mockResolvedValueOnce(testJobParameters);
     const job = await ExecutableJob.loadTask(1);
-    return new TransitNetworkDesignJobWrapper(job as ExecutableJob<EvolutionaryTransitNetworkDesignJobType>, { progressEmitter: new EventEmitter(), isCancelled: () => false });
+    
+    // Use the mock executor instead of the real one
+    return createMockJobExecutor(job as ExecutableJob<EvolutionaryTransitNetworkDesignJobType>);
 }
 
 beforeEach(() => {

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/__tests__/MockTransitNetworkDesignJobWrapper.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/__tests__/MockTransitNetworkDesignJobWrapper.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+import { TransitNetworkDesignJobWrapper } from '../TransitNetworkDesignJobWrapper';
+import { TransitNetworkDesignJobType } from '../types';
+import { ExecutableJob } from '../../../executableJob/ExecutableJob';
+import LineCollection from 'transition-common/lib/services/line/LineCollection';
+import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollection';
+import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
+import { LineServices } from '../../../evolutionaryAlgorithm/internalTypes';
+
+/**
+ * Mock implementation of TransitNetworkDesignJobWrapper for testing purposes.
+ * Allows tests to provide controlled data without actual server loading or cache preparation.
+ */
+export class MockTransitNetworkDesignJobWrapper<TJobType extends TransitNetworkDesignJobType = TransitNetworkDesignJobType> 
+    extends TransitNetworkDesignJobWrapper<TJobType> {
+    
+    private mockLineCollection: LineCollection | undefined;
+    private mockAgencyCollection: AgencyCollection | undefined;
+    private mockServiceCollection: ServiceCollection | undefined;
+    private mockCacheDirectory: string = '/tmp/test-cache';
+
+    constructor(wrappedJob: ExecutableJob<TJobType>, executorOptions: {
+        progressEmitter: EventEmitter;
+        isCancelled: () => boolean;
+    }) {
+        super(wrappedJob, executorOptions);
+    }
+
+    /**
+     * Set the mock data that will be returned by the getter methods
+     */
+    setMockData(data: {
+        lineCollection?: LineCollection;
+        agencyCollection?: AgencyCollection;
+        serviceCollection?: ServiceCollection;
+        simulatedLineCollection?: LineCollection;
+        lineServices?: LineServices;
+        cacheDirectory?: string;
+    }): void {
+        if (data.lineCollection) {
+            this.mockLineCollection = data.lineCollection;
+        }
+        if (data.agencyCollection) {
+            this.mockAgencyCollection = data.agencyCollection;
+        }
+        if (data.serviceCollection) {
+            this.mockServiceCollection = data.serviceCollection;
+        }
+        if (data.simulatedLineCollection) {
+            this.simulatedLineCollection = data.simulatedLineCollection;
+        }
+        if (data.lineServices) {
+            this.setLineServices(data.lineServices);
+        }
+        if (data.cacheDirectory) {
+            this.mockCacheDirectory = data.cacheDirectory;
+        }
+    }
+
+    // Override getter methods to return mock data
+    get allLineCollection(): LineCollection {
+        if (this.mockLineCollection === undefined) {
+            throw new Error('Mock line collection not set. Call setMockData() first.');
+        }
+        return this.mockLineCollection;
+    }
+
+    get agencyCollection(): AgencyCollection {
+        if (this.mockAgencyCollection === undefined) {
+            throw new Error('Mock agency collection not set. Call setMockData() first.');
+        }
+        return this.mockAgencyCollection;
+    }
+
+    get serviceCollection(): ServiceCollection {
+        if (this.mockServiceCollection === undefined) {
+            throw new Error('Mock service collection not set. Call setMockData() first.');
+        }
+        return this.mockServiceCollection;
+    }
+
+    getCacheDirectory = (): string => {
+        return this.mockCacheDirectory;
+    }
+
+    // Override methods that perform actual server operations to be no-ops for testing
+    loadServerData = jest.fn().mockResolvedValue(undefined);
+    prepareCacheDirectory = jest.fn();
+}
+
+/**
+ * Factory function to create a mock job executor with default test data
+ */
+export const createMockJobExecutor = <TJobType extends TransitNetworkDesignJobType = TransitNetworkDesignJobType>(
+    job: ExecutableJob<TJobType>,
+    mockData?: {
+        lineCollection?: LineCollection;
+        agencyCollection?: AgencyCollection;
+        serviceCollection?: ServiceCollection;
+        simulatedLineCollection?: LineCollection;
+        lineServices?: LineServices;
+        cacheDirectory?: string;
+    }
+): MockTransitNetworkDesignJobWrapper<TJobType> => {
+    const executor = new MockTransitNetworkDesignJobWrapper(job, {
+        progressEmitter: new EventEmitter(),
+        isCancelled: () => false
+    });
+
+    if (mockData) {
+        executor.setMockData(mockData);
+    }
+
+    return executor;
+};


### PR DESCRIPTION
Add a mock class for the `EvolutionaryTransitNetworkDesignJob`, to specify the data to prepare (lines, services, etc), that can be used in individual unit tests.

Update the tests so they work with the new code.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mock job executor for Evolutionary Transit Network Design and updates unit tests to use it, fixing failures and aligning tests with the new job executor and simulation APIs.

- **New Features**
  - Added MockTransitNetworkDesignJobWrapper with setters for lines, agencies, services, line services, and cache dir.
  - Added createMockJobExecutor factory for simple, controlled test setup.
  - Mock executor overrides loadServerData and prepareCacheDirectory as no-ops.

- **Bug Fixes**
  - Refactored candidate, generation, and service preparation tests to use the mock executor and load job parameters via jobsDbQueries.
  - Mocked OdTripSimulation.simulate and updated expectations to results.OdTripSimulation with totalFitness set appropriately.
  - Simplified generation sorting tests to match method-specific behavior (AccessibilityMapSimulation maximizes, OdTripSimulation minimizes).
  - Ensured simulated lines have scheduleByServiceId set before running candidate simulations.

<sup>Written for commit 24b2d3d4332b760bb420cf843ac5f18b2c81b90b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



