### PR TITLE
capnp: fix trip's unexisting `schedule_id` field

### DIFF
--- a/packages/transition-backend/src/models/capnpCache/transitLines.cache.queries.ts
+++ b/packages/transition-backend/src/models/capnpCache/transitLines.cache.queries.ts
@@ -70,11 +70,12 @@ const importParser = function (cacheObject: CacheObjectClass) {
         };
 
         const periodsCache = scheduleCache.getPeriods();
-        const periods: Partial<SchedulePeriod>[] = [];
+        const periods: SchedulePeriod[] = [];
 
         periodsCache.forEach((periodCache) => {
             const periodShortname = periodCache.getPeriodShortname();
-            const period: Partial<SchedulePeriod> = {
+            const period: SchedulePeriod = {
+                id: periodCache.getUuid(),
                 period_shortname: periodShortname,
                 schedule_id: schedule.integer_id,
                 outbound_path_id: periodCache.getOutboundPathUuid(),
@@ -91,16 +92,17 @@ const importParser = function (cacheObject: CacheObjectClass) {
                 end_at_hour: periodCache.getEndAtSeconds() / 3600,
                 interval_seconds: minusOneToUndefined(periodCache.getIntervalSeconds()),
                 number_of_units: minusOneToUndefined(periodCache.getNumberOfUnits()),
-                is_frozen: int8ToBool(periodCache.getIsFrozen())
+                is_frozen: int8ToBool(periodCache.getIsFrozen()),
+                data: {},
+                trips: []
             };
 
             const tripsCache = periodCache.getTrips();
-            const trips: Partial<SchedulePeriodTrip>[] = [];
+            const trips: SchedulePeriodTrip[] = [];
 
             tripsCache.forEach((tripCache) => {
                 const trip = {
                     id: tripCache.getUuid(),
-                    schedule_id: schedule.id,
                     path_id: tripCache.getPathUuid(),
                     departure_time_seconds: tripCache.getDepartureTimeSeconds(),
                     arrival_time_seconds: tripCache.getArrivalTimeSeconds(),
@@ -119,7 +121,8 @@ const importParser = function (cacheObject: CacheObjectClass) {
                     block_id: _emptyStringToNull(tripCache.getBlockUuid()),
                     total_capacity: minusOneToUndefined(tripCache.getTotalCapacity()),
                     seated_capacity: minusOneToUndefined(tripCache.getSeatedCapacity()),
-                    is_frozen: int8ToBool(tripCache.getIsFrozen())
+                    is_frozen: int8ToBool(tripCache.getIsFrozen()),
+                    data: {}
                 };
 
                 trips.push(trip);

--- a/services/json2capnp/src/routers/line_router.rs
+++ b/services/json2capnp/src/routers/line_router.rs
@@ -79,7 +79,6 @@ mod tests {
                                     "trips": [
                                         {
                                             "id": "6650ebc1-75c8-4ae6-abef-ce4dbc1c3a5f",
-                                            "schedule_id": "d36f377c-6691-4f70-8c0f-3f35d6958314",
                                             "schedule_period_id": "bddc12af-6c9f-4048-a800-a79ee187aaaa",
                                             "path_id": "cb01fe06-e450-4e6d-991c-a6e843cf30db",
                                             "departure_time_seconds": 14400,
@@ -94,7 +93,6 @@ mod tests {
                                         },
                                         {
                                             "id": "dd1eec4b-4b88-4d75-82b0-2005707fc0bf",
-                                            "schedule_id": "d36f377c-6691-4f70-8c0f-3f35d6958314",
                                             "schedule_period_id": "bddc12af-6c9f-4048-a800-a79ee187aaaa",
                                             "path_id": "e39e0b59-9af4-4cc0-ae7e-84f01e293f0b",
                                             "departure_time_seconds": 14413,
@@ -123,7 +121,6 @@ mod tests {
                                     "trips": [
                                         {
                                             "id":"a1f5fbc9-f692-49f3-a00f-430e5075c25f",
-                                            "schedule_id": "d36f377c-6691-4f70-8c0f-3f35d6958314",
                                             "schedule_period_id": "bddc12af-6c9f-4048-a800-a79ee18bbbbb",
                                             "path_id":"cb01fe06-e450-4e6d-991c-a6e843cf30db",
                                             "departure_time_seconds": 21600,
@@ -216,7 +213,6 @@ mod tests {
                                     "trips": [
                                         {
                                             "id": "6650ebc1-75c8-4ae6-abef-ce4dbc1c3a5f",
-                                            "schedule_id": "d36f377c-6691-4f70-8c0f-3f35d6958314",
                                             "schedule_period_id": "bddc12af-6c9f-4048-a800-a79ee187aaaa",
                                             "path_id": "cb01fe06-e450-4e6d-991c-a6e843cf30db",
                                             "departure_time_seconds": 14400,
@@ -232,7 +228,6 @@ mod tests {
                                         },
                                         {
                                             "id": "dd1eec4b-4b88-4d75-82b0-2005707fc0bf",
-                                            "schedule_id": "d36f377c-6691-4f70-8c0f-3f35d6958314",
                                             "schedule_period_id": "bddc12af-6c9f-4048-a800-a79ee187aaaa",
                                             "path_id": "e39e0b59-9af4-4cc0-ae7e-84f01e293f0b",
                                             "departure_time_seconds": 14413,
@@ -264,7 +259,6 @@ mod tests {
                                     "trips": [
                                         {
                                             "id":"a1f5fbc9-f692-49f3-a00f-430e5075c25f",
-                                            "schedule_id": "d36f377c-6691-4f70-8c0f-3f35d6958314",
                                             "schedule_period_id": "bddc12af-6c9f-4048-a800-a79ee18bbbbb",
                                             "path_id":"cb01fe06-e450-4e6d-991c-a6e843cf30db",
                                             "departure_time_seconds": 21600,

--- a/services/json2capnp/transition_capnp_data/src/serialization/line.rs
+++ b/services/json2capnp/transition_capnp_data/src/serialization/line.rs
@@ -309,7 +309,6 @@ pub fn read_object(
                                 "total_capacity": minus_one_i64_to_null(trip.get_total_capacity() as i64),
                                 "seated_capacity": minus_one_i64_to_null(trip.get_seated_capacity() as i64),
                                 "is_frozen": i8_to_json_boolean(period.get_is_frozen()),
-                                "schedule_id": empty_str_to_json_null(schedule.get_uuid()?),
                                 "schedule_period_id": empty_str_to_json_null(period.get_uuid()?)
                             });
 


### PR DESCRIPTION
This field was removed from the `Trip` type, so it should not be returned by the capnp reader.

This caused lines retrieved from cache to not save correctly to the database after, as the schedule_id field was set and it does not exist anymore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the non-existent Trip.schedule_id from Cap’n Proto serialization and cache import, fixing failed saves when reloading lines from cache.

- **Bug Fixes**
  - Stop returning schedule_id for Trip in capnp serialization and router tests.
  - Update cache import: remove trip.schedule_id, add period id, and initialize period/trip data fields to prevent type mismatches.

<sup>Written for commit 7ce3f1988d1a657d6a682c9e81c792efda95b725. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal transit schedule data caching to improve data organization and consistency.
  * Removed redundant field from trip serialization to streamline data transmission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->