### PR TITLE
networkDesign frontend: fix update loop in simulation edit

### DIFF
--- a/packages/transition-frontend/src/components/forms/csv/GenericCsvImportAndMappingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/csv/GenericCsvImportAndMappingForm.tsx
@@ -118,7 +118,7 @@ const GenericCsvImportAndMappingForm: React.FunctionComponent<GenericCsvImportAn
             // Just uploaded, no need to upload it again
             setReadyToUpload(false);
         }
-    }, [uploadStatus.status, props.csvFieldMapper]);
+    }, [uploadStatus.status]); // csvFieldMapper should not be a dependency, even if used in the function, otherwise it loops. This effect just listens to the upload status update
 
     const csvFileFields = props.csvFieldMapper.getCsvFields();
 

--- a/packages/transition-frontend/src/components/forms/networkDesign/widgets/OptionsDescriptorWidgets.tsx
+++ b/packages/transition-frontend/src/components/forms/networkDesign/widgets/OptionsDescriptorWidgets.tsx
@@ -203,7 +203,7 @@ const OptionsEditComponent: React.FunctionComponent<OptionsEditComponentProps<an
     props: OptionsEditComponentProps<any>
 ) => {
     const { t } = useTranslation(['transit', 'main']);
-    const options = props.optionsDescriptor.getOptions();
+    const options = React.useMemo(() => props.optionsDescriptor.getOptions(), [props.optionsDescriptor]);
     const optionWidgets = Object.keys(options).map((optionName) => {
         const option = options[optionName];
         return (


### PR DESCRIPTION
The `csvFieldMapper` prop should not be in the dependency list of the upload status update, otherwise it loops. If the mapper changed, the parent is already aware, this effect just needs to listen for upload status updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed an update loop in the simulation edit UI by scoping the upload status effect to its status only, and reduced re-renders by memoizing option retrieval.

- **Bug Fixes**
  - GenericCsvImportAndMappingForm: useEffect now depends only on uploadStatus.status to prevent loops when csvFieldMapper changes.
  - OptionsDescriptorWidgets: wrapped getOptions() in useMemo keyed by optionsDescriptor to avoid unnecessary recomputation.

<sup>Written for commit e2edaf2eeaa5127490a3c2e3624a497fe765f937. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

