### PR TITLE
csv mapping form: remove a dependency to useEffect

### DIFF
--- a/packages/transition-frontend/src/components/forms/csv/GenericCsvImportAndMappingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/csv/GenericCsvImportAndMappingForm.tsx
@@ -118,7 +118,7 @@ const GenericCsvImportAndMappingForm: React.FunctionComponent<GenericCsvImportAn
             // Just uploaded, no need to upload it again
             setReadyToUpload(false);
         }
-    }, [uploadStatus.status, props.csvFieldMapper]);
+    }, [uploadStatus.status]); // csvFieldMapper should not be a dependency, even if used in the function: the parent is already aware of the change and adding it will create an update loop. This effect just listens to the upload status update.
 
     const csvFileFields = props.csvFieldMapper.getCsvFields();
 


### PR DESCRIPTION
The parent should already be aware of the `csvFieldMapper` dependency update, so the `onUpdate` does not need to be called when this prop is updated. This effect is only to listen to the upload status update. If the `csvFieldMapper` is part of the dependency, this may cause an update loop depending on how the parent handles the value change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed csvFieldMapper from the useEffect dependency in GenericCsvImportAndMappingForm to prevent an update loop. The effect now only listens to uploadStatus changes, avoiding unnecessary onUpdate calls and repeated uploads.

<sup>Written for commit 571af7279920972b159221595c342f5b36fe2f72. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CSV import form's effect handling to improve performance and prevent unnecessary re-renders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->