### PR TITLE
fix: Remove hostname expansion from email subject line.

### DIFF
--- a/locales/en/server.json
+++ b/locales/en/server.json
@@ -3,7 +3,7 @@
     "confirmByAdminSubject": "Transition: New User Confirmation",
     "confirmByUserText": "Hi {{name}},\n\nYou have requested access to Transition.\n\nTo confirm your access, please click on the link below, or copy-paste the following URL {{userConfirmationUrl}}.\n\nThank you",
     "confirmByUserSubject": "Transition: New User Confirmation",
-    "pendingConfirmByAdminSubject": "Transition: account creation confirmation pending on {{host}}",
+    "pendingConfirmByAdminSubject": "Transition: account creation confirmation pending",
     "pendingConfirmByAdminText": "Hi {{name}},\n\nyour access request to Transition ({{host}}) will be reviewed by an administrator shortly.\n\nThank you",
     "confirmedByAdminEmailSubject": "Transition: account confirmed",
     "confirmedByAdminEmailText": "Hi {{name}},\n\nyour access request to Transition ({{host}}) has been confirmed. You can now use your account.",

--- a/locales/fr/server.json
+++ b/locales/fr/server.json
@@ -3,7 +3,7 @@
     "confirmByAdminSubject": "Transition: Confirmation d'un nouvel utilisateur",
     "confirmByUserText": "Bonjour {{name}},\n\nVous avez demandé l'accès à Transition.\n\nPour confirmer votre accès, veuillez cliquer sur le lien ci-dessous, ou copier-coller l'URL dans votre navigateur {{userConfirmationUrl}}.\n\nMerci",
     "confirmByUserSubject": "Transition: Confirmation d'un nouvel utilisateur",
-    "pendingConfirmByAdminSubject": "Transition: compte en attente de confirmation par un administrateur sur {{host}}",
+    "pendingConfirmByAdminSubject": "Transition: compte en attente de confirmation par un administrateur",
     "pendingConfirmByAdminText": "Bonjour {{name}},\n\nVotre accès à Transition ({{host}}) doit d'abord être validé par un administrateur.\n\nMerci",
     "confirmedByAdminEmailSubject": "Transition: compte confirmé",
     "confirmedByAdminEmailText": "Bonjour {{name}},\n\nVotre accès à Transition ({{host}}) a été confirmé. Vous pouvez maintenant utiliser votre compte.",


### PR DESCRIPTION
We don't do variable substitution on subject, so do not put variable there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pending account confirmation notification subjects by removing the host variable reference from English and French translations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->