### PR TITLE
Update zoom level visibility for rail

### DIFF
--- a/packages/transition-frontend/src/config/layers.config.ts
+++ b/packages/transition-frontend/src/config/layers.config.ts
@@ -277,12 +277,12 @@ const layersConfig = {
 
     transitPaths: {
         type: 'line',
-        minzoom: 9,
+        minzoom: 5,
         defaultFilter: [
             'any',
             ['all', ['==', ['string', ['get', 'mode']], 'bus'], ['>=', ['zoom'], 11]],
-            ['all', ['==', ['string', ['get', 'mode']], 'rail'], ['>=', ['zoom'], 9]],
-            ['all', ['==', ['string', ['get', 'mode']], 'highSpeedRail'], ['>=', ['zoom'], 9]],
+            ['all', ['==', ['string', ['get', 'mode']], 'rail'], ['>=', ['zoom'], 5]],
+            ['all', ['==', ['string', ['get', 'mode']], 'highSpeedRail'], ['>=', ['zoom'], 5]],
             ['all', ['==', ['string', ['get', 'mode']], 'metro'], ['>=', ['zoom'], 9]],
             ['all', ['==', ['string', ['get', 'mode']], 'monorail'], ['>=', ['zoom'], 10]],
             ['all', ['==', ['string', ['get', 'mode']], 'tram'], ['>=', ['zoom'], 10]],
@@ -589,12 +589,12 @@ const layersConfig = {
 
     transitPathsForServices: {
         type: 'line',
-        minzoom: 9,
+        minzoom: 5,
         defaultFilter: [
             'any',
             ['all', ['==', ['string', ['get', 'mode']], 'bus'], ['>=', ['zoom'], 11]],
-            ['all', ['==', ['string', ['get', 'mode']], 'rail'], ['>=', ['zoom'], 9]],
-            ['all', ['==', ['string', ['get', 'mode']], 'highSpeedRail'], ['>=', ['zoom'], 9]],
+            ['all', ['==', ['string', ['get', 'mode']], 'rail'], ['>=', ['zoom'], 5]],
+            ['all', ['==', ['string', ['get', 'mode']], 'highSpeedRail'], ['>=', ['zoom'], 5]],
             ['all', ['==', ['string', ['get', 'mode']], 'metro'], ['>=', ['zoom'], 9]],
             ['all', ['==', ['string', ['get', 'mode']], 'monorail'], ['>=', ['zoom'], 10]],
             ['all', ['==', ['string', ['get', 'mode']], 'tram'], ['>=', ['zoom'], 10]],


### PR DESCRIPTION
Rail often span large region, so to be able to visualize them they should be viewable at smaller zoom level.

Setting it to 5, good for multiprovincial project. Ideally could be set at 4.5, but keeping whole number for now. Needed to update the global minzoom also.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transit paths and rail services are now visible at lower zoom levels, improving map discoverability when viewing at a zoomed-out perspective.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->