### PR TITLE
add missing side_road multipliers for cycling and walking

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/cycling.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/cycling.lua
@@ -32,6 +32,7 @@ function setup()
     default_speed             = default_speed,
     walking_speed             = walking_speed,
     oneway_handling           = true,
+    side_road_multiplier      = 1.0, -- Needs to be defined for way_handlers.penalties
     turn_penalty              = 5,
     turn_bias                 = 1.4,
     use_public_transport      = false,

--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_no_penalty.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_no_penalty.lua
@@ -23,6 +23,7 @@ function setup()
     default_mode            = mode.walking,
     default_speed           = walking_speed,
     oneway_handling         = 'specific',     -- respect 'oneway:foot' but not 'oneway'
+    side_road_multiplier    = 1.0, -- Needs to be defined for way_handlers.penalties
 
     barrier_blacklist = Set {
       'yes',

--- a/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_roads_only.lua
+++ b/packages/chaire-lib-backend/src/utils/processManagers/osrmProfiles/walking_roads_only.lua
@@ -23,6 +23,7 @@ function setup()
     default_mode            = mode.walking,
     default_speed           = walking_speed,
     oneway_handling         = 'specific',     -- respect 'oneway:foot' but not 'oneway'
+    side_road_multiplier    = 1.0, -- Needs to be defined for way_handlers.penalties
 
     barrier_blacklist = Set {
       'yes',


### PR DESCRIPTION
these are required for way_handlers.penalties to not crash while extracting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cycling and walking routing profiles with refined road type penalty calculations. These updates improve route accuracy and navigation recommendations by better accounting for terrain and road characteristics when determining optimal paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->