### PR TITLE
Add accessibility map POIs to API

### DIFF
--- a/docs/APIv1/accessibilityMap.yml
+++ b/docs/APIv1/accessibilityMap.yml
@@ -77,6 +77,11 @@ accessibilityMapRequest:
       type: number
       description: Assumed walking speed, in meters per second
       example: 1.3888888888
+    calculatePois:
+      type: boolean
+      description: Whether to calculate the POIs located in the polygon and include the count in the result. Defaults to false.
+      example: true
+
 
 accessibilityMapResponseSuccess:
   type: object
@@ -224,6 +229,18 @@ accessibilityMapResultResponsePolygons:
                 type: number
                 description: The total area of the polygon, in square meters
                 example: 2309327.161000439
+              accessiblePlacesCountByCategory:
+                type: object
+                additionalProperties:
+                  type: integer
+                description: The number of POIs within the accessibility polygon (if any), separated by categories. The keys are the names of the categories defined in the PlaceCategory type, and the values are integers.
+                example: {'service': 10, 'restaurant': 5}
+              accessiblePlacesCountByDetailedCategory:
+                type: object
+                additionalProperties:
+                  type: integer
+                description: The number of POIs within the accessibility polygon (if any), separated by detailed categories. The keys are the names of the detailed categories defined in the PlaceDetailedCategory type, and the values are integers.
+                example: {'service_bank': 8, 'service_other': 2, 'restaurant_restaurant': 5}
 
 accessibilityMapResponseBadRequest:
   type: string

--- a/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
+++ b/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
@@ -9,6 +9,10 @@ import APIResponseBase from './APIResponseBase';
 import { AccessibilityMapCalculationResult } from '../../services/routingCalculation/RoutingCalculator';
 import { Feature, MultiPolygon, Point } from 'geojson';
 import * as TrRoutingApi from 'chaire-lib-common/lib/api/TrRouting';
+import {
+    PlaceCategory,
+    PlaceDetailedCategory
+} from 'chaire-lib-common/lib/config/osm/osmMappingDetailedCategoryToCategory';
 
 type AccessibilityMapAPIQueryResponse = {
     locationGeojson: {
@@ -27,6 +31,7 @@ type AccessibilityMapAPIQueryResponse = {
     maxAccessEgressTravelTimeSeconds: number;
     maxTransferTravelTimeSeconds: number;
     walkingSpeedMps: number;
+    calculatePois: boolean;
 };
 
 type AccessibilityMapAPIResultResponse = {
@@ -39,6 +44,8 @@ type AccessibilityMapAPIResultResponse = {
             properties: {
                 durationSeconds: number;
                 areaSqM: number;
+                accessiblePlacesCountByCategory?: { [key in PlaceCategory]: number };
+                accessiblePlacesCountByDetailedCategory?: { [key in PlaceDetailedCategory]: number };
             };
         }>;
     };
@@ -80,7 +87,8 @@ export default class AccessibilityMapAPIResponse extends APIResponseBase<
             minWaitingTimeSeconds: queryParams.minWaitingTimeSeconds!,
             maxAccessEgressTravelTimeSeconds: queryParams.maxAccessEgressTravelTimeSeconds!,
             maxTransferTravelTimeSeconds: queryParams.maxTransferTravelTimeSeconds!,
-            walkingSpeedMps: queryParams.walkingSpeedMps!
+            walkingSpeedMps: queryParams.walkingSpeedMps!,
+            calculatePois: queryParams.calculatePois!
         };
     }
 
@@ -96,7 +104,10 @@ export default class AccessibilityMapAPIResponse extends APIResponseBase<
                             geometry: feature.geometry,
                             properties: {
                                 durationSeconds: feature.properties!.durationSeconds,
-                                areaSqM: feature.properties!.areaSqM
+                                areaSqM: feature.properties!.areaSqM,
+                                accessiblePlacesCountByCategory: feature.properties!.accessiblePlacesCountByCategory,
+                                accessiblePlacesCountByDetailedCategory:
+                                      feature.properties!.accessiblePlacesCountByDetailedCategory
                             }
                         }))
                     }

--- a/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
+++ b/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
@@ -101,7 +101,7 @@ export const getAttributesOrDefault = (attributes: Partial<AccessibilityMapAttri
         locationColor: attributes.locationColor,
         color: attributes.color,
         placeName: attributes.placeName,
-        calculatePois: attributes.calculatePois
+        calculatePois: attributes.calculatePois || false
     };
 };
 


### PR DESCRIPTION
The accessibility map API call can now return the amount of contained POIs within the calculated polygon. Also updates the documentation.

Tested with a python script and works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "calculatePois" parameter added to accessibility map requests (defaults to false) to enable POI calculations for polygons.
  * Accessibility map results now include POI counts per polygon, broken down by category and by detailed category for richer insights.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->