### PR TITLE
Add continueOnMissingGeojson option to task

### DIFF
--- a/packages/chaire-lib-backend/src/tasks/dataImport/OsmDataPreparationResidential.ts
+++ b/packages/chaire-lib-backend/src/tasks/dataImport/OsmDataPreparationResidential.ts
@@ -37,9 +37,11 @@ const queryResidentialBuildingsFromOsm = [
 export default class OsmDataPreparationResidential {
     private _hasError = false;
     private _geojsonOutputter: GeojsonOutputter;
+    private _continueOnGeojsonError: boolean;
 
-    constructor(geojsonOutputter: GeojsonOutputter) {
+    constructor(geojsonOutputter: GeojsonOutputter, continueOnGeojsonError: boolean) {
         this._geojsonOutputter = geojsonOutputter;
+        this._continueOnGeojsonError = continueOnGeojsonError;
     }
 
     private parseNumberOfFlats(building: SingleGeoFeature) {
@@ -77,7 +79,7 @@ export default class OsmDataPreparationResidential {
         const residentialBuildings = osmGeojsonService.getGeojsonsFromRawData(
             osmGeojsonData,
             allOsmResidentialBuildings,
-            { generateNodesIfNotFound: false, continueOnMissingGeojson: true }
+            { generateNodesIfNotFound: false, continueOnGeojsonError: this._continueOnGeojsonError }
         );
 
         // For each building, get its entrances
@@ -156,7 +158,8 @@ export default class OsmDataPreparationResidential {
 
         // Do we have a home or main entrance
         const entrances = getEntrancesForBuilding(building, homeObject, osmRawData, {
-            entranceTypes: ['main', 'home']
+            entranceTypes: ['main', 'home'],
+            continueOnInsideNodesUndefinedError: this._continueOnGeojsonError
         });
         if (entrances.length) {
             let flatsAssigned = 0;

--- a/packages/chaire-lib-backend/src/tasks/dataImport/__tests__/OsmDataPreparationResidential.test.ts
+++ b/packages/chaire-lib-backend/src/tasks/dataImport/__tests__/OsmDataPreparationResidential.test.ts
@@ -45,7 +45,7 @@ each([
 ]).test('Test Residential Area: %s', async (testDir) => {
     const { osmRawData, osmGeojsonData } = getData(testDir);
 
-    const residentialDataPreparation = new OsmDataPreparationResidential(new GeojsonOutputter());
+    const residentialDataPreparation = new OsmDataPreparationResidential(new GeojsonOutputter(), true);
     const { residentialEntrances, zonesWithResidences } = await residentialDataPreparation.run(
         osmRawData,
         osmGeojsonData

--- a/packages/chaire-lib-backend/src/tasks/dataImport/__tests__/prepareOsmDataForImport.test.ts
+++ b/packages/chaire-lib-backend/src/tasks/dataImport/__tests__/prepareOsmDataForImport.test.ts
@@ -54,6 +54,7 @@ const fileManager = new TestFileManager();
 
 class prepareOsmDataStub extends prepareOsmData {
     promptOverwriteIfExists = (absoluteFilePath, message) => new Promise<boolean>((resolve) => {resolve(true)});
+    continueOnGeojsonErrorPrompt = () => new Promise<boolean>((resolve) => {resolve(true)});
 }
 
 const task = new prepareOsmDataStub(fileManager);

--- a/packages/chaire-lib-backend/src/tasks/dataImport/data/__tests__/osmGeojsonService.test.ts
+++ b/packages/chaire-lib-backend/src/tasks/dataImport/data/__tests__/osmGeojsonService.test.ts
@@ -83,7 +83,7 @@ describe('getGeojsonsFromRawData', () => {
             { type: 'node' as const, id: '1234', lon: -73, lat: 45 },
             { type: 'node' as const, id: '2345', lon: -73.1, lat: 45.1, tags: { test: ['foo'], abc: ['foo', 'bar'] } }
         ]
-        expect(osmGeojsonService.getGeojsonsFromRawData(geojsonData, rawData, { generateNodesIfNotFound: true, continueOnMissingGeojson: false })).toEqual([
+        expect(osmGeojsonService.getGeojsonsFromRawData(geojsonData, rawData, { generateNodesIfNotFound: true, continueOnGeojsonError: false })).toEqual([
             {
                 geojson:
                 {

--- a/packages/chaire-lib-backend/src/tasks/dataImport/data/osmGeojsonService.ts
+++ b/packages/chaire-lib-backend/src/tasks/dataImport/data/osmGeojsonService.ts
@@ -278,9 +278,9 @@ const unsplitTags = (tags: { [key: string]: string[] | undefined }): { [key: str
 const getGeojsonsFromRawData = (
     geojsonData: DataGeojson,
     features: OsmRawDataType[],
-    options: { generateNodesIfNotFound: boolean; continueOnMissingGeojson: boolean } = {
+    options: { generateNodesIfNotFound: boolean; continueOnGeojsonError: boolean } = {
         generateNodesIfNotFound: false,
-        continueOnMissingGeojson: false
+        continueOnGeojsonError: false
     }
 ): { geojson: SingleGeoFeature; raw: OsmRawDataType }[] => {
     const geojsonFeatures: { geojson: SingleGeoFeature; raw: OsmRawDataType }[] = [];
@@ -301,7 +301,7 @@ const getGeojsonsFromRawData = (
                     features[i].type,
                     features[i].id
                 );
-                if (options.continueOnMissingGeojson) {
+                if (options.continueOnGeojsonError) {
                     continue;
                 } else {
                     throw 'Missing OSM geojson';


### PR DESCRIPTION
Adds a prompt to the 2_importAndProcessOsmDataToFiles task that allows points of interrests with no geojson to be skipped instead of throwing an error. As the import area increases, it is almost guaranteed to get multiple of these, making this necessary when importing data.
We made a partial fix for this before, however we only skipped some of the problematic function calls so that the task would pass with one particular geojson input.
It makes more sense to have one param control all of them equally instead of picking and choosing, however.
Fix: https://github.com/chairemobilite/transition/issues/1645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a prompt during OSM import to let users choose whether to continue when GeoJSON data is missing or invalid.

* **Bug Fixes**
  * Import is more robust: certain failures when extracting interior nodes are caught and treated as empty results instead of crashing.
  * GeoJSON lookups and entrance/POI handling now honor the user's continue-on-GeoJSON choice.

* **Tests**
  * Updated tests to cover the continue-on-GeoJSON behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->