### PR TITLE
API: fix accessibility map response when no routing

### DIFF
--- a/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
+++ b/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
@@ -94,7 +94,8 @@ export default class AccessibilityMapAPIResponse extends APIResponseBase<
 
     private createResultResponse(resultParams: AccessibilityMapCalculationResult): AccessibilityMapAPIResultResponse {
         return {
-            nodes: resultParams.resultByNode!.nodes,
+            // FIXME The resultByNode should probably not be undefined, but contain an empty array in case where there is no routing. See https://github.com/chairemobilite/transition/issues/1681
+            nodes: resultParams.resultByNode?.nodes ?? [],
             polygons:
                 'polygons' in resultParams
                     ? {

--- a/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
+++ b/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
@@ -192,7 +192,7 @@ export class TransitAccessibilityMapCalculator {
             const routingResults = promiseResults
                 .map((promiseResult, index) => {
                     if (promiseResult.status === 'rejected') {
-                        // TODO Return something for no routing found?
+                        // TODO Return something for no routing found? See https://github.com/chairemobilite/transition/issues/1681
                         return undefined;
                     }
                     const routingResult = promiseResult.value;


### PR DESCRIPTION
If there was no routing the resultByNode would be `undefined` and cause an error 500 on those API calls. Since it is a legitimate response, we return an empty array in those cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test covering POST /api/v1/accessibility when a calculation yields no results, validating the empty-results response shape.

* **Bug Fixes**
  * API now gracefully returns an empty nodes array and the default query structure instead of throwing when result data is absent.

* **Documentation**
  * Added a clarifying comment about handling undefined calculation results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->