### PR TITLE
dep: remove `react-select-event` dependency

### DIFF
--- a/packages/chaire-lib-frontend/package.json
+++ b/packages/chaire-lib-frontend/package.json
@@ -57,6 +57,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -81,7 +82,6 @@
     "jest-environment-jsdom": "^30.2.0",
     "mockdate": "^3.0.5",
     "prettier-eslint-cli": "^8.0.1",
-    "react-select-event": "^5.5.1",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.4.6",
     "typescript": "^5.8.3"

--- a/packages/chaire-lib-frontend/src/components/input/__tests__/InputMultiselect.test.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/__tests__/InputMultiselect.test.tsx
@@ -6,9 +6,7 @@
  */
 
 // TODO: This does not seem to work, We should find a way to add the testing-library's custom matchers in the file to test the rest.
-test('Default', () => {
-    expect(true).toBeTruthy();
-});
+test.todo('InputMultiselect tests to be fixed and re-enabled');
 /*
 import { create } from 'react-test-renderer';
 import InputMultiselect from '../InputMultiselect';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,18 +1706,18 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
-"@testing-library/dom@>=7":
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
-  integrity sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==
+"@testing-library/dom@^10.4.1":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^5.0.1"
     aria-query "5.3.0"
-    chalk "^4.1.0"
     dom-accessibility-api "^0.5.9"
     lz-string "^1.5.0"
+    picocolors "1.1.1"
     pretty-format "^27.0.2"
 
 "@testing-library/jest-dom@^6.6.3":
@@ -10032,7 +10032,7 @@ pgpass@1.x:
   dependencies:
     split2 "^4.1.0"
 
-picocolors@^1.0.1, picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.0.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -10590,13 +10590,6 @@ react-router@^7.5.2:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"
     turbo-stream "2.4.0"
-
-react-select-event@^5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/react-select-event/-/react-select-event-5.5.1.tgz#d67e04a6a51428b1534b15ecb1b82afbe5edddcb"
-  integrity sha512-goAx28y0+iYrbqZA2FeRTreHHs/ZtSuKxtA+J5jpKT5RHPCbVZJ4MqACfPnWyFXsEec+3dP5bCrNTxIX8oYe9A==
-  dependencies:
-    "@testing-library/dom" ">=7"
 
 react-select@*, react-select@^5.8.3:
   version "5.8.3"


### PR DESCRIPTION
This packages was previously used in the the `InputMultiselect` test, but this test was deactivated, so until we fix it and see if we still need this, it is removed from the dependency list.

Also put the InputMultiselect test as `todo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a development dependency from the frontend package and updated test tooling.

* **Tests**
  * Marked a multiselect input test as pending to be fixed and re-enabled later.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->