### PR TITLE
Add min and max to integer inputs

### DIFF
--- a/packages/chaire-lib-common/src/config/Preferences.ts
+++ b/packages/chaire-lib-common/src/config/Preferences.ts
@@ -19,6 +19,16 @@ import config from './shared/project.config';
 import { _isBlank } from '../utils/LodashExtensions';
 import { lineModesArray } from './lineModesDefaultValues';
 
+// Boundaries for the default values of various path parameters. Changing these does not affect the bounds of the parameters themselves, only those of the default param you can configure in the preferences.
+export const MIN_DEFAULT_WALKING_SPEED_KPH = 2.0;
+export const MAX_DEFAULT_WALKING_SPEED_KPH = 7.0;
+const MAX_DEFAULT_RUNNING_SPEED_KMH = 500;
+const MAX_DEFAULT_DWELL_TIME_SECONDS = 600;
+const MIN_DEFAULT_ACCELERATION = 0.3;
+const MAX_DEFAULT_ACCELERATION = 1.5;
+const MIN_DEFAULT_DECELERATION = 0.3;
+const MAX_DEFAULT_DECELERATION = 1.5;
+
 interface PreferencesModelWithIdAndData extends PreferencesModel {
     id: string;
     data: { [key: string]: any };
@@ -79,10 +89,10 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
     public validate() {
         this._isValid = true;
         this._errors = [];
-        if (this.attributes.defaultWalkingSpeedMetersPerSeconds < 2.0 / 3.6) {
+        if (this.attributes.defaultWalkingSpeedMetersPerSeconds < MIN_DEFAULT_WALKING_SPEED_KPH / 3.6) {
             this._isValid = false;
             this._errors.push('main:preferences:errors:DefaultWalkingSpeedMustBeAtLeast2kph');
-        } else if (this.attributes.defaultWalkingSpeedMetersPerSeconds > 7.0 / 3.6) {
+        } else if (this.attributes.defaultWalkingSpeedMetersPerSeconds > MAX_DEFAULT_WALKING_SPEED_KPH / 3.6) {
             this._isValid = false;
             this._errors.push('main:preferences:errors:DefaultWalkingSpeedMustBeAtMost7kph');
         }
@@ -95,11 +105,17 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
             const defaultDwellTimeSeconds =
                 this.attributes.transit.lines.lineModesDefaultValues[mode].defaultDwellTimeSeconds;
             const maxRunningSpeedKmH = this.attributes.transit.lines.lineModesDefaultValues[mode].maxRunningSpeedKmH;
-            if (_isNumber(defaultRunningSpeedKmH) && (defaultRunningSpeedKmH <= 0 || defaultRunningSpeedKmH > 500)) {
+            if (
+                _isNumber(defaultRunningSpeedKmH) &&
+                (defaultRunningSpeedKmH <= 0 || defaultRunningSpeedKmH > MAX_DEFAULT_RUNNING_SPEED_KMH)
+            ) {
                 this.errors.push('transit:transitPath:errors:DefaultRunningSpeedIsInvalid');
                 this._isValid = false;
             }
-            if (_isNumber(defaultDwellTimeSeconds) && (defaultDwellTimeSeconds <= 0 || defaultDwellTimeSeconds > 600)) {
+            if (
+                _isNumber(defaultDwellTimeSeconds) &&
+                (defaultDwellTimeSeconds <= 0 || defaultDwellTimeSeconds > MAX_DEFAULT_DWELL_TIME_SECONDS)
+            ) {
                 if (mode !== 'transferable' || (mode === 'transferable' && defaultDwellTimeSeconds < 0)) {
                     this.errors.push('transit:transitPath:errors:DefaultDwellTimeIsInvalid');
                     this._isValid = false;
@@ -112,10 +128,10 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
                 if (defaultAcceleration < 0) {
                     this.errors.push('transit:transitPath:errors:DefaultAccelerationIsInvalid');
                     this._isValid = false;
-                } else if (defaultAcceleration <= 0.3) {
+                } else if (defaultAcceleration <= MIN_DEFAULT_ACCELERATION) {
                     this.errors.push('transit:transitPath:errors:DefaultAccelerationIsTooLow');
                     this._isValid = false;
-                } else if (defaultAcceleration > 1.5 && mode !== 'transferable') {
+                } else if (defaultAcceleration > MAX_DEFAULT_ACCELERATION && mode !== 'transferable') {
                     this.errors.push('transit:transitPath:errors:DefaultAccelerationIsTooHigh');
                     this._isValid = false;
                 }
@@ -127,10 +143,10 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
                 if (defaultDeceleration < 0) {
                     this.errors.push('transit:transitPath:errors:DefaultDecelerationIsInvalid');
                     this._isValid = false;
-                } else if (defaultDeceleration <= 0.3) {
+                } else if (defaultDeceleration <= MIN_DEFAULT_DECELERATION) {
                     this.errors.push('transit:transitPath:errors:DefaultDecelerationIsTooLow');
                     this._isValid = false;
-                } else if (defaultDeceleration > 1.5 && mode !== 'transferable') {
+                } else if (defaultDeceleration > MAX_DEFAULT_DECELERATION && mode !== 'transferable') {
                     this.errors.push('transit:transitPath:errors:DefaultDecelerationIsTooHigh');
                     this._isValid = false;
                 }

--- a/packages/chaire-lib-frontend/src/components/input/InputString.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/InputString.tsx
@@ -33,6 +33,8 @@ export type InputStringProps = {
     autocompleteChoices?: ({ label: string; value: string } | string)[];
     type?: 'text' | 'email' | 'number';
     pattern?: string;
+    min?: number;
+    max?: number;
 };
 
 type defaultInputType = {
@@ -43,6 +45,8 @@ type defaultInputType = {
     onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
     disabled?: boolean;
     pattern?: string;
+    min?: number;
+    max?: number;
 };
 
 const InputString: React.FunctionComponent<InputStringProps> = ({
@@ -56,7 +60,9 @@ const InputString: React.FunctionComponent<InputStringProps> = ({
     disabled = false,
     autocompleteChoices = [],
     type = 'text',
-    pattern = undefined
+    pattern = undefined,
+    min = undefined,
+    max = undefined
 }: InputStringProps) => {
     const actualValue = value === undefined || value === null ? '' : value;
     const defaultAttributes: defaultInputType = {
@@ -77,6 +83,14 @@ const InputString: React.FunctionComponent<InputStringProps> = ({
 
     if (pattern) {
         defaultAttributes.pattern = pattern;
+    }
+
+    if (type === 'number' && min !== undefined) {
+        defaultAttributes.min = min;
+    }
+
+    if (type === 'number' && max !== undefined) {
+        defaultAttributes.max = max;
     }
 
     if (autocompleteChoices && autocompleteChoices.length > 0) {

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
@@ -16,6 +16,13 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { validateTrQueryAttributes } from '../transitRouting/TransitRoutingQueryAttributes';
 import { TransitQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
 
+export const MAX_DELTA_MINUTES = 30;
+export const MAX_DELTA_INTERVAL_MINUTES = 30;
+export const MIN_WALKING_SPEED_KPH = 2.0;
+export const MAX_WALKING_SPEED_KPH = 10.0;
+const MIN_MAX_ACCESS_EGRESS_TRAVEL_TIME_MINUTES = 1;
+const MAX_MAX_ACCESS_EGRESS_TRAVEL_TIME_MINUTES = 20;
+
 export interface AccessibilityMapCalculationAttributes extends GenericAttributes {
     departureTimeSecondsSinceMidnight?: number;
     arrivalTimeSecondsSinceMidnight?: number;
@@ -92,7 +99,7 @@ class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapA
         } else if (isNaN(deltaSeconds) || deltaSeconds < 0) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:DeltaIsInvalid');
-        } else if (deltaSeconds > 1800) {
+        } else if (deltaSeconds > MAX_DELTA_MINUTES * 60) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:DeltaIsTooLarge');
         }
@@ -104,7 +111,7 @@ class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapA
         } else if (isNaN(deltaIntervalSeconds) || deltaIntervalSeconds < 0) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:DeltaIntervalIsInvalid');
-        } else if (deltaIntervalSeconds > 1800) {
+        } else if (deltaIntervalSeconds > MAX_DELTA_INTERVAL_MINUTES * 60) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:DeltaIntervalIsTooLarge');
         }
@@ -121,10 +128,13 @@ class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapA
         if (!maxAccessEgressTravelTimeSeconds) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:MaxAccessEgressTravelTimeSecondsIsMissing');
-        } else if (isNaN(maxAccessEgressTravelTimeSeconds) || maxAccessEgressTravelTimeSeconds < 60) {
+        } else if (
+            isNaN(maxAccessEgressTravelTimeSeconds) ||
+            maxAccessEgressTravelTimeSeconds < MIN_MAX_ACCESS_EGRESS_TRAVEL_TIME_MINUTES * 60
+        ) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:MaxAccessEgressTravelTimeSecondsIsInvalid');
-        } else if (this._isValid && maxAccessEgressTravelTimeSeconds > 1200) {
+        } else if (this._isValid && maxAccessEgressTravelTimeSeconds > MAX_MAX_ACCESS_EGRESS_TRAVEL_TIME_MINUTES * 60) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:AccessEgressTravelTimeSecondsTooLarge');
         }
@@ -137,10 +147,10 @@ class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapA
         } else if (isNaN(walkingSpeedMps) || walkingSpeedMps < 0) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:WalkingSpeedMpsIsInvalid');
-        } else if (this._isValid && walkingSpeedMps > 10.0 / 3.6) {
+        } else if (this._isValid && walkingSpeedMps > MAX_WALKING_SPEED_KPH / 3.6) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:WalkingSpeedMpsIsTooLarge');
-        } else if (this._isValid && walkingSpeedMps < 2.0 / 3.6) {
+        } else if (this._isValid && walkingSpeedMps < MIN_WALKING_SPEED_KPH / 3.6) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:WalkingSpeedMpsIsTooLow');
         }

--- a/packages/transition-common/src/services/networkDesign/transit/TransitNetworkDesignParameters.ts
+++ b/packages/transition-common/src/services/networkDesign/transit/TransitNetworkDesignParameters.ts
@@ -27,8 +27,8 @@ export type TransitNetworkDesignParameters = {
     linesToKeep?: string[];
 };
 
-const MAX_TIME_BETWEEN_PASSAGES = 60;
-const MIN_TIME_BETWEEN_PASSAGES = 3;
+export const MIN_TIME_BETWEEN_PASSAGES = 3;
+export const MAX_TIME_BETWEEN_PASSAGES = 60;
 
 export const validateTransitNetworkDesignParameters = (
     parameters: TransitNetworkDesignParameters
@@ -67,7 +67,7 @@ export const validateTransitNetworkDesignParameters = (
             valid = false;
             errors.push('transit:simulation:errors:MaxTimeBetweenPassagesTooHigh');
         }
-        if (maxTimeBetweenPassages < 0) {
+        if (maxTimeBetweenPassages < MIN_TIME_BETWEEN_PASSAGES) {
             valid = false;
             errors.push('transit:simulation:errors:MaxTimeBetweenPassagesNoNegative');
         }

--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
@@ -28,7 +28,12 @@ import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import TransitAccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
+import TransitAccessibilityMapRouting, {
+    MAX_DELTA_MINUTES,
+    MAX_DELTA_INTERVAL_MINUTES,
+    MIN_WALKING_SPEED_KPH,
+    MAX_WALKING_SPEED_KPH
+} from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import { calculateAccessibilityMap, calculateAccessibilityMapComparison } from '../../../services/routing/RoutingUtils';
 import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
@@ -582,6 +587,7 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                                     stringToValue={_toInteger}
                                     valueToString={_toString}
                                     type="number"
+                                    min={1}
                                 />
                             </InputWrapper>
                             <InputWrapper
@@ -597,6 +603,8 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                                     stringToValue={minutesToSeconds}
                                     valueToString={(val) => _toString(secondsToMinutes(val))}
                                     type="number"
+                                    min={1}
+                                    max={MAX_DELTA_MINUTES}
                                 />
                             </InputWrapper>
                             <InputWrapper
@@ -613,6 +621,8 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                                     stringToValue={minutesToSeconds}
                                     valueToString={(val) => _toString(secondsToMinutes(val))}
                                     type="number"
+                                    min={1}
+                                    max={MAX_DELTA_INTERVAL_MINUTES}
                                 />
                             </InputWrapper>
                             {/* TODO: If we add a new mode, separate the changing sections into different subcomponents to be cleaner. */}
@@ -742,6 +752,8 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                                         _toString(!isNaN(parseFloat(value)) ? roundToDecimals(mpsToKph(value), 1) : '')
                                     }
                                     type="number"
+                                    min={MIN_WALKING_SPEED_KPH}
+                                    max={MAX_WALKING_SPEED_KPH}
                                 />
                             </InputWrapper>
                             <InputWrapper

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -289,6 +289,7 @@ class AccessibilityMapBatchForm extends ChangeEventsForm<
                                 stringToValue={_toInteger}
                                 valueToString={_toString}
                                 type={'number'}
+                                min={1}
                             />
                         </InputWrapper>
                     }

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -26,7 +26,12 @@ import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
-import TransitAccessibilityMapRouting from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
+import TransitAccessibilityMapRouting, {
+    MAX_DELTA_MINUTES,
+    MAX_DELTA_INTERVAL_MINUTES,
+    MIN_WALKING_SPEED_KPH,
+    MAX_WALKING_SPEED_KPH
+} from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
 import { calculateAccessibilityMap } from '../../../services/routing/RoutingUtils';
 import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
 import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
@@ -269,6 +274,7 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                                     stringToValue={_toInteger}
                                     valueToString={_toString}
                                     type="number"
+                                    min={1}
                                 />
                             </InputWrapper>
                             <InputWrapper
@@ -282,6 +288,8 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                                     stringToValue={minutesToSeconds}
                                     valueToString={(val) => _toString(secondsToMinutes(val))}
                                     type="number"
+                                    min={1}
+                                    max={MAX_DELTA_MINUTES}
                                 />
                             </InputWrapper>
                             <InputWrapper
@@ -296,6 +304,8 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                                     stringToValue={minutesToSeconds}
                                     valueToString={(val) => _toString(secondsToMinutes(val))}
                                     type="number"
+                                    min={1}
+                                    max={MAX_DELTA_INTERVAL_MINUTES}
                                 />
                             </InputWrapper>
                             <InputWrapper label={this.props.t('transit:transitRouting:Scenario')}>
@@ -339,6 +349,8 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                                         _toString(!isNaN(parseFloat(value)) ? roundToDecimals(mpsToKph(value), 1) : '')
                                     }
                                     type="number"
+                                    min={MIN_WALKING_SPEED_KPH}
+                                    max={MAX_WALKING_SPEED_KPH}
                                 />
                             </InputWrapper>
                             <InputWrapper

--- a/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/stepForms/ConfigureBatchCalculationForm.tsx
@@ -148,6 +148,8 @@ const ConfigureCalculationParametersForm: React.FunctionComponent<
                             stringToValue={_toInteger}
                             valueToString={_toString}
                             type={'number'}
+                            min={1}
+                            // We do not want a max bound for the CPU count as the max CPU count may change between infrastructures and we do not want an valid job to become invalid later.
                         />
                     </InputWrapper>
                 </React.Fragment>

--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -491,6 +491,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                             stringToValue={parseIntOrNull}
                                             valueToString={(val) => _toString(parseIntOrNull(val))}
                                             type="number"
+                                            min={0}
                                         />
                                     </InputWrapper>
                                 </div>
@@ -574,6 +575,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                         stringToValue={parseIntOrNull}
                                         valueToString={(val) => _toString(parseIntOrNull(val))}
                                         type="number"
+                                        min={0}
                                     />
                                 </div>
                             )}
@@ -662,6 +664,7 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                     stringToValue={parseIntOrNull}
                                     valueToString={(val) => _toString(parseIntOrNull(val))}
                                     type="number"
+                                    min={0}
                                 />
                             </InputWrapper>
                         </div>

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionGeneral.tsx
@@ -12,6 +12,7 @@ import _toString from 'lodash/toString';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
 import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
+import { MIN_DEFAULT_WALKING_SPEED_KPH, MAX_DEFAULT_WALKING_SPEED_KPH } from 'chaire-lib-common/lib/config/Preferences';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
@@ -94,6 +95,8 @@ const PreferencesSectionGeneral: React.FunctionComponent<PreferencesSectionProps
                             _toString(!isNaN(parseFloat(value)) ? roundToDecimals(mpsToKph(value), 1) : '')
                         }
                         type="number"
+                        min={MIN_DEFAULT_WALKING_SPEED_KPH}
+                        max={MAX_DEFAULT_WALKING_SPEED_KPH}
                     />
                     <PreferencesResetToDefaultButton
                         resetPrefToDefault={props.resetPrefToDefault}

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLineMode.tsx
@@ -182,6 +182,7 @@ const PreferencesSectionTransitLineMode: React.FunctionComponent<PreferencesSect
                         stringToValue={parseFloatOrNull}
                         valueToString={(val) => _toString(parseFloatOrNull(val))}
                         type="number"
+                        min={0}
                     />
                     <PreferencesResetToDefaultButton
                         resetPrefToDefault={props.resetPrefToDefault}

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitNodes.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitNodes.tsx
@@ -51,6 +51,7 @@ const PreferencesSectionTransitNodes: React.FunctionComponent<PreferencesSection
                         stringToValue={parseFloatOrNull}
                         valueToString={(val) => _toString(parseFloatOrNull(val))}
                         type="number"
+                        min={0}
                     />
                     <PreferencesResetToDefaultButton
                         resetPrefToDefault={props.resetPrefToDefault}

--- a/packages/transition-frontend/src/components/forms/simulation/widgets/TransitNetworkDesignParametersComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/simulation/widgets/TransitNetworkDesignParametersComponent.tsx
@@ -10,7 +10,11 @@ import _toString from 'lodash/toString';
 
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
-import { TransitNetworkDesignParameters } from 'transition-common/lib/services/networkDesign/transit/TransitNetworkDesignParameters';
+import {
+    TransitNetworkDesignParameters,
+    MAX_TIME_BETWEEN_PASSAGES,
+    MIN_TIME_BETWEEN_PASSAGES
+} from 'transition-common/lib/services/networkDesign/transit/TransitNetworkDesignParameters';
 import { _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Service from 'transition-common/lib/services/service/Service';
@@ -59,6 +63,7 @@ const TransitNetworkDesignParametersComponent: React.FunctionComponent<TransitNe
                     stringToValue={_toInteger}
                     valueToString={_toString}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper smallInput={true} label={props.t('transit:simulation:NumberOfLinesMax')}>
@@ -70,6 +75,7 @@ const TransitNetworkDesignParametersComponent: React.FunctionComponent<TransitNe
                     stringToValue={_toInteger}
                     valueToString={_toString}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper smallInput={true} label={props.t('transit:simulation:MaxIntervalMinutes')}>
@@ -81,6 +87,8 @@ const TransitNetworkDesignParametersComponent: React.FunctionComponent<TransitNe
                     stringToValue={_toInteger}
                     valueToString={_toString}
                     type={'number'}
+                    min={MIN_TIME_BETWEEN_PASSAGES}
+                    max={MAX_TIME_BETWEEN_PASSAGES}
                 />
             </InputWrapper>
             <InputWrapper smallInput={true} label={props.t('transit:simulation:MinIntervalMinutes')}>
@@ -92,6 +100,8 @@ const TransitNetworkDesignParametersComponent: React.FunctionComponent<TransitNe
                     stringToValue={_toInteger}
                     valueToString={_toString}
                     type={'number'}
+                    min={MIN_TIME_BETWEEN_PASSAGES}
+                    max={MAX_TIME_BETWEEN_PASSAGES}
                 />
             </InputWrapper>
             <InputWrapper smallInput={true} label={props.t('transit:simulation:VehiclesCount')}>
@@ -103,6 +113,7 @@ const TransitNetworkDesignParametersComponent: React.FunctionComponent<TransitNe
                     stringToValue={_toInteger}
                     valueToString={_toString}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper twoColumns={false} label={props.t('transit:simulation:LineSetAgencies')}>

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/TransitRoutingBaseComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/TransitRoutingBaseComponent.tsx
@@ -34,6 +34,7 @@ const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseCom
                     stringToValue={minutesToSeconds}
                     valueToString={(val) => _toString(secondsToMinutes(val))}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper
@@ -49,6 +50,7 @@ const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseCom
                     stringToValue={minutesToSeconds}
                     valueToString={(val) => _toString(secondsToMinutes(val))}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper
@@ -64,6 +66,7 @@ const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseCom
                     stringToValue={minutesToSeconds}
                     valueToString={(val) => _toString(secondsToMinutes(val))}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper
@@ -79,6 +82,7 @@ const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseCom
                     stringToValue={minutesToSeconds}
                     valueToString={(val) => _toString(secondsToMinutes(val))}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
             <InputWrapper
@@ -94,6 +98,7 @@ const TransitRoutingBaseComponent: React.FunctionComponent<TransitRoutingBaseCom
                     stringToValue={minutesToSeconds}
                     valueToString={(val) => _toString(secondsToMinutes(val))}
                     type={'number'}
+                    min={0}
                 />
             </InputWrapper>
         </React.Fragment>


### PR DESCRIPTION
Adds a min and max parameter to InputString components of type number, preventing the arrows on the side from incrementing or decrementing the number beyond those bounds. 
Adds a min bound of zero to most inputs to prevent a negative number from being entered, but also add custom min and max bounds to other inputs that already raise errors when the number is outside the bounds, adding an extra layer of security to those inputs. 
Fix: #1664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced numeric bounds on many form fields (walking speed, dwell time, delta intervals, polygon/count, CPU count, vehicle/timing parameters) to prevent invalid values.

* **Refactor**
  * Centralized and exported common validation thresholds as shared constants to ensure consistent input limits across the app.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->