### PR TITLE
Move memcached management outside of TrRoutingProcessManager

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/MemcachedProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/MemcachedProcessManager.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import ProcessManager from './ProcessManager';
+
+const DEFAULT_PORT = 11212; // 11211 is the default memcached port, we use +1 to not clash
+const TAG_NAME = 'memcached';
+
+const getServiceName = function (port: number) {
+    return `memcached${port}`;
+};
+
+/**
+ * Represents a running memcached instance.
+ * Use this object to get the server connection string and to stop the instance.
+ */
+export class MemcachedInstance {
+    constructor(private port: number) {
+        /* Nothing to do */
+    }
+
+    /**
+     * Get the server connection string for this memcached instance.
+     * @returns Server string in format 'localhost:port'
+     */
+    getServer(): string {
+        return `localhost:${this.port}`;
+    }
+
+    /**
+     * Check if the memcached instance is running.
+     * @returns 'running' if the process is running, 'not_running' otherwise
+     */
+    async status(): Promise<'running' | 'not_running'> {
+        const isRunning = await ProcessManager.isServiceRunning(getServiceName(this.port));
+        return isRunning ? 'running' : 'not_running';
+    }
+
+    /**
+     * Stop this memcached instance.
+     * @returns Status of the stop operation
+     */
+    async stop(): Promise<{ status: 'stopped' | 'not_running' | 'error'; error?: unknown }> {
+        return ProcessManager.stopProcess(getServiceName(this.port), TAG_NAME);
+    }
+}
+
+/**
+ * Start a memcached instance.
+ *
+ * @param options - Optional configuration
+ * @param options.port - Port to run memcached on (default: 11212)
+ * @returns A MemcachedInstance object if started successfully, null otherwise
+ */
+const start = async (options?: { port?: number }): Promise<MemcachedInstance | null> => {
+    const port = options?.port ?? DEFAULT_PORT;
+
+    const processStatus = await ProcessManager.startProcess({
+        serviceName: getServiceName(port),
+        tagName: TAG_NAME,
+        command: 'memcached',
+        commandArgs: [
+            `--port=${port}`,
+            '--user=nobody', // Memcached does not want to run as root, let's drop to nobody
+            '-vv' // Enable detailed output for logging
+        ],
+        waitString: '',
+        useShell: false,
+        attemptRestart: false
+    });
+
+    if (processStatus.status === 'started') {
+        return new MemcachedInstance(port);
+    }
+
+    if (processStatus.status === 'already_running') {
+        // We treat already_running as an error since we don't know where this memcached
+        // is managed and we have not idea of its lifecycle. It could disappear at any
+        // moment.
+        console.error('a memcached process already exist for port:', port);
+    } else if (processStatus.status === 'error' && processStatus.error?.code === 'ENOENT') {
+        console.error('memcached executable does not exist in path');
+    } else {
+        console.error('cannot start memcached:', processStatus);
+    }
+
+    return null;
+};
+
+export default { start };

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/MemcachedProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/MemcachedProcessManager.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import MemcachedProcessManager, { MemcachedInstance } from '../MemcachedProcessManager';
+import ProcessManager from '../ProcessManager';
+
+jest.mock('../ProcessManager', () => ({
+    startProcess: jest.fn(),
+    stopProcess: jest.fn(),
+    isServiceRunning: jest.fn()
+}));
+
+const startProcessMock = ProcessManager.startProcess as jest.MockedFunction<typeof ProcessManager.startProcess>;
+const stopProcessMock = ProcessManager.stopProcess as jest.MockedFunction<typeof ProcessManager.stopProcess>;
+const isServiceRunningMock = ProcessManager.isServiceRunning as jest.MockedFunction<typeof ProcessManager.isServiceRunning>;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('MemcachedProcessManager.start', () => {
+    test.each([
+        {
+            name: 'default port',
+            options: undefined,
+            mockReturn: { status: 'started', service: 'memcached', name: 'memcached' },
+            expectedServer: 'localhost:11212',
+            expectedServiceName: 'memcached11212',
+            expectedCommandArgs: ['--port=11212', '--user=nobody', '-vv']
+        },
+        {
+            name: 'custom port',
+            options: { port: 11300 },
+            mockReturn: { status: 'started', service: 'memcached', name: 'memcached' },
+            expectedServer: 'localhost:11300',
+            expectedServiceName: 'memcached11300',
+            expectedCommandArgs: ['--port=11300', '--user=nobody', '-vv']
+        }
+    ])('should start memcached with $name', async ({ options, mockReturn, expectedServer, expectedServiceName, expectedCommandArgs }) => {
+        startProcessMock.mockResolvedValue(mockReturn);
+
+        const instance = await MemcachedProcessManager.start(options);
+
+        expect(instance).not.toBeNull();
+        expect(instance?.getServer()).toBe(expectedServer);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                serviceName: expectedServiceName,
+                tagName: 'memcached',
+                command: 'memcached',
+                commandArgs: expectedCommandArgs,
+                waitString: '',
+                useShell: false,
+                attemptRestart: false
+            })
+        );
+    });
+
+    test.each([
+        {
+            name: 'memcached executable not found',
+            mockReturn: { status: 'error', service: 'memcached', name: 'memcached', error: { code: 'ENOENT' } },
+            expectedErrorMessage: 'memcached executable does not exist in path'
+        },
+        {
+            name: 'other error',
+            mockReturn: { status: 'error', service: 'memcached', name: 'memcached', error: { message: 'Some error' } },
+            expectedErrorMessage: 'cannot start memcached:'
+        },
+        {
+            name: 'memcached is already running',
+            mockReturn: { status: 'already_running', service: 'memcached', name: 'memcached', error: { message: 'already running' } },
+            expectedErrorMessage: 'a memcached process already exist for port:'
+        }
+    ])('should return null when $name', async ({ mockReturn, expectedErrorMessage }) => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+        startProcessMock.mockResolvedValue(mockReturn);
+
+        const instance = await MemcachedProcessManager.start();
+
+        expect(instance).toBeNull();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.stringContaining(expectedErrorMessage),
+            ...(expectedErrorMessage.includes(':') ? [expect.anything()] : [])
+        );
+        consoleErrorSpy.mockRestore();
+    });
+});
+
+describe('MemcachedInstance', () => {
+    let instance: MemcachedInstance;
+
+    beforeEach(async () => {
+        startProcessMock.mockResolvedValue({
+            status: 'started',
+            service: 'memcached',
+            name: 'memcached'
+        });
+        instance = (await MemcachedProcessManager.start())!;
+    });
+
+    test('getServer should return correct server string', () => {
+        expect(instance.getServer()).toBe('localhost:11212');
+    });
+
+    test.each([
+        { isRunning: true, expectedStatus: 'running' },
+        { isRunning: false, expectedStatus: 'not_running' }
+    ])('status should return $expectedStatus when process is $expectedStatus', async ({ isRunning, expectedStatus }) => {
+        isServiceRunningMock.mockResolvedValue(isRunning);
+
+        const status = await instance.status();
+
+        expect(status).toBe(expectedStatus);
+        expect(isServiceRunningMock).toHaveBeenCalledWith('memcached11212');
+    });
+
+    test.each([
+        { mockStatus: 'stopped', expectedStatus: 'stopped' },
+        { mockStatus: 'not_running', expectedStatus: 'not_running' },
+        { mockStatus: 'error', expectedStatus: 'error' }
+    ])('stop should handle $mockStatus status', async ({ mockStatus, expectedStatus }) => {
+        stopProcessMock.mockResolvedValue({
+            status: mockStatus,
+            service: 'memcached',
+            name: 'memcached'
+        });
+
+        const result = await instance.stop();
+
+        expect(result.status).toBe(expectedStatus);
+        expect(stopProcessMock).toHaveBeenCalledWith('memcached11212', 'memcached');
+    });
+});

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -505,22 +505,12 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-        expect(startProcessMock).toHaveBeenNthCalledWith(1,{
-            serviceName: 'memcached',
-            tagName: 'memcached',
-            command: 'memcached',
-            commandArgs: ['--port=11212', '--user=nobody', '-vv'],
-            waitString: '',
-            useShell: false,
-            cwd: undefined,
-            attemptRestart: false
-        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--useMemcached=localhost:11212'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -538,12 +528,12 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--useMemcached=localhost:11212'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -565,12 +555,12 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--useMemcached=localhost:11212'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -588,12 +578,12 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 12345
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--useMemcached=localhost:11212'],
+            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -614,12 +604,12 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: `trRouting${port}`,
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true', '--useMemcached=localhost:11212'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -635,13 +625,14 @@ describe('TrRouting Process Manager: startBatch', () => {
         const port = 12345;
         const debug = true;
         const cacheDirectoryPath = '/tmp/cache';
-        const status = await TrRoutingProcessManager.startBatch(4, { port, debug, cacheDirectoryPath });
+        const memcachedServer = 'localhost:11212';
+        const status = await TrRoutingProcessManager.startBatch(4, { port, debug, cacheDirectoryPath, memcachedServer });
         expect(status).toEqual({
             status: 'started',
             service: 'trRoutingBatch',
             port: 12345
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
@@ -657,6 +648,32 @@ describe('TrRouting Process Manager: startBatch', () => {
             }
         });
     });
+
+    test('start batch process with just memcached parameters set', async () => {
+        const memcachedServer = 'localhost:11212';
+        const status = await TrRoutingProcessManager.startBatch(4, { memcachedServer: memcachedServer });
+        expect(status).toEqual({
+            status: 'started',
+            service: 'trRoutingBatch',
+            port: 14000
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
+        expect(startProcessMock).toHaveBeenLastCalledWith({
+            serviceName: 'trRouting14000',
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: [`--port=14000`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--useMemcached=localhost:11212'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
+        });
+    });
+
     test('With debug and logFiles in the config', async () => {
         const logFiles = { maxFileSizeKB: 1500, nbFiles: 5 };
         setProjectConfiguration({ routing: { transit: { engines: { trRouting: { batch: { debug: true, logs: logFiles } } as any } } as any } });
@@ -666,12 +683,12 @@ describe('TrRouting Process Manager: startBatch', () => {
             service: 'trRoutingBatch',
             port: 14000
         });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
+        expect(startProcessMock).toHaveBeenCalledTimes(1);
         expect(startProcessMock).toHaveBeenLastCalledWith({
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--useMemcached=localhost:11212'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,

--- a/packages/transition-backend/src/services/transitRouting/BatchAccessibilityMapJob.ts
+++ b/packages/transition-backend/src/services/transitRouting/BatchAccessibilityMapJob.ts
@@ -7,6 +7,7 @@
 import { TransitDemandFromCsvAccessMapAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { TransitBatchCalculationResult } from 'transition-common/lib/services/batchCalculation/types';
 import { AccessibilityMapAttributes } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
+import { TrRoutingBatchJobParameters } from './TrRoutingBatchJobParameters';
 
 export type BatchAccessMapJobType = {
     name: 'batchAccessMap';
@@ -14,6 +15,7 @@ export type BatchAccessMapJobType = {
         parameters: {
             batchAccessMapAttributes: TransitDemandFromCsvAccessMapAttributes;
             accessMapAttributes: AccessibilityMapAttributes;
+            trRoutingJobParameters?: TrRoutingBatchJobParameters;
         };
         results?: Omit<TransitBatchCalculationResult, 'errors' | 'warnings'>;
     };

--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
@@ -55,8 +55,8 @@ export const batchAccessibilityMap = async (
         progressEmitter.emit('progressCount', { name: 'ParsingCsvWithLineNumber', progress: -1 });
 
         const { threadCount: trRoutingThreadsCount, port: trRoutingPort } = await batchManager.startBatch(
-            locationsCount
-            // TODO add options with cachePath
+            locationsCount,
+            job.attributes.data.parameters.trRoutingJobParameters
         );
 
         // Assert the job is not cancelled, otherwise reject

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatchJobParameters.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatchJobParameters.ts
@@ -19,4 +19,17 @@ export type TrRoutingBatchJobParameters = {
      * Example: '/path/to/custom/cache/directory'
      */
     cacheDirectoryPath?: string;
+
+    /**
+     * Memcached server URL (e.g., 'localhost:11212').
+     * If provided, TrRouting will use this existing memcached instance instead
+     * of starting a new one. This is useful for parent jobs that spawn multiple
+     * TrRouting batch jobs that can benefit from sharing the same cache.
+     *
+     * When not provided, a new memcached instance will be started and stopped
+     * with the batch job.
+     *
+     * Example: 'localhost:11212'
+     */
+    memcachedServer?: string;
 };

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatchManager.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatchManager.ts
@@ -6,6 +6,9 @@
  */
 import { EventEmitter } from 'events';
 import TrRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
+import MemcachedProcessManager, {
+    MemcachedInstance
+} from 'chaire-lib-backend/lib/utils/processManagers/MemcachedProcessManager';
 import { TrRoutingBatchJobParameters } from './TrRoutingBatchJobParameters';
 import serverConfig from 'chaire-lib-backend/lib/config/server.config';
 
@@ -28,11 +31,24 @@ export type TrRoutingBatchStartResult = {
  * Handles starting and stopping TrRouting instance with proper
  * progress reporting and configuration.
  *
+ * Memcached handling:
+ * - If a memcachedServer is provided (via startBatch options),
+ *   uses that external server and does not manage its lifecycle.
+ * - If no memcachedServer is provided, starts a new memcached instance and
+ *   stops it when stopBatch is called.
+ *
  * TODO: Class name is a bit confusing, we should find something better, but it works for now.
  *       We should return an instance which represent the TrRouting instance, like the OSRMMode for OSRM,
  *       Instead of just returning a port number
  */
 export class TrRoutingBatchManager {
+    private memcachedInstance?: MemcachedInstance;
+    private started: boolean = false; //Track if we are in the started or stopped state
+    /**
+     * Create a new TrRoutingBatchManager.
+     *
+     * @param progressEmitter - EventEmitter for progress reporting
+     */
     constructor(private progressEmitter: EventEmitter) {
         // Nothing else to do
     }
@@ -43,31 +59,66 @@ export class TrRoutingBatchManager {
      * Port, debug settings, and max parallel threads are determined by
      * TrRoutingProcessManager from server configuration.
      *
+     * Memcached is handled as follows:
+     * 1. If options.memcachedServer is provided, use it
+     * 2. Else start a new memcached instance (will be stopped in stopBatch)
+     *
      * @param workloadSize - Number of items to process (OD trips or locations)
-     * @param options - Optional TrRouting configuration (e.g., cache directory)
+     * @param options - Optional TrRouting configuration (e.g., cache directory, memcached server)
      * @returns Promise with thread count and port information
      * @throws Error if TrRouting instance fail to start
      */
     async startBatch(workloadSize: number, options?: TrRoutingBatchJobParameters): Promise<TrRoutingBatchStartResult> {
+        if (this.started) {
+            throw new Error('startBatch was already called');
+        }
+
         const threadCount = this.calculateThreadCount(workloadSize);
 
         try {
             this.progressEmitter.emit('progress', { name: 'StartingRoutingParallelServer', progress: 0.0 });
 
-            // Make sure processes are stopped before restarting
+            // Make sure TrRouting is stopped before restarting
             await TrRoutingProcessManager.stopBatch();
+
+            // Determine memcached server: options > start new one
+            let memcachedServer = options?.memcachedServer;
+
+            if (!memcachedServer) {
+                // Start our own memcached instance
+                const instance = await MemcachedProcessManager.start();
+                if (instance) {
+                    this.memcachedInstance = instance;
+                    memcachedServer = instance.getServer();
+                } else {
+                    // Only print an error message on failure. Calculation will still
+                    // be able to complete, but could be slower
+                    console.warn('Failed to start memcached, calculation could be slower');
+                }
+            }
 
             // Start the TrRouting instance
             // Port, debug, and thread count are determined by TrRoutingProcessManager from config
             const startStatus = await TrRoutingProcessManager.startBatch(threadCount, {
-                cacheDirectoryPath: options?.cacheDirectoryPath
+                cacheDirectoryPath: options?.cacheDirectoryPath,
+                memcachedServer
             });
 
             if (startStatus.status !== 'started') {
+                // We failed at starting TrRouting, stop memcached if we started it
+                if (this.memcachedInstance) {
+                    console.info('Stopping memcached since we failed to start TrRouting');
+                    // We on purpose do not do the await on this call, it will eventually finish
+                    // and get cleaned up.
+                    this.memcachedInstance.stop();
+                    this.memcachedInstance = undefined;
+                }
                 throw new Error(`Failed to start TrRouting instance: ${startStatus.status}`);
             }
 
             console.log('trRouting multiple startStatus', startStatus);
+
+            this.started = true;
 
             return {
                 threadCount,
@@ -80,13 +131,27 @@ export class TrRoutingBatchManager {
 
     /**
      * Stop TrRouting batch instance.
+     * Also stops the memcached instance if it was started by this manager.
      * Port is determined by TrRoutingProcessManager from server configuration.
      */
     async stopBatch(): Promise<void> {
         try {
             this.progressEmitter.emit('progress', { name: 'StoppingRoutingParallelServer', progress: 0.0 });
+
+            if (!this.started) {
+                console.warn('Batch Manager was not started, attempting to stop anyway');
+            }
+
             const stopStatus = await TrRoutingProcessManager.stopBatch();
             console.log('trRouting multiple stopStatus', stopStatus);
+
+            // Stop memcached if we started it
+            if (this.memcachedInstance) {
+                await this.memcachedInstance.stop();
+                this.memcachedInstance = undefined;
+            }
+
+            this.started = false;
         } finally {
             this.progressEmitter.emit('progress', { name: 'StoppingRoutingParallelServer', progress: 1.0 });
         }
@@ -103,7 +168,7 @@ export class TrRoutingBatchManager {
      */
     private calculateThreadCount(workloadSize: number): number {
         // TODO Investigate if it still make sense to divide by 3, since we manage thread and
-        // not processes nowaday.
+        // not processes nowadays.
         return Math.min(Math.max(1, Math.ceil(workloadSize / 3)), serverConfig.maxParallelCalculators);
     }
 }

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchManager.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatchManager.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+import { TrRoutingBatchManager } from '../TrRoutingBatchManager';
+import TrRoutingProcessManager from 'chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager';
+import MemcachedProcessManager, {
+    MemcachedInstance
+} from 'chaire-lib-backend/lib/utils/processManagers/MemcachedProcessManager';
+
+jest.mock('chaire-lib-backend/lib/utils/processManagers/TrRoutingProcessManager', () => ({
+    startBatch: jest.fn(),
+    stopBatch: jest.fn()
+}));
+
+jest.mock('chaire-lib-backend/lib/utils/processManagers/MemcachedProcessManager', () => ({
+    start: jest.fn()
+}));
+
+jest.mock('chaire-lib-backend/lib/config/server.config', () => ({
+    maxParallelCalculators: 4
+}));
+
+const mockTrRoutingStartBatch = TrRoutingProcessManager.startBatch as jest.MockedFunction<
+    typeof TrRoutingProcessManager.startBatch
+>;
+const mockTrRoutingStopBatch = TrRoutingProcessManager.stopBatch as jest.MockedFunction<
+    typeof TrRoutingProcessManager.stopBatch
+>;
+const mockMemcachedStart = MemcachedProcessManager.start as jest.MockedFunction<typeof MemcachedProcessManager.start>;
+
+describe('TrRoutingBatchManager', () => {
+    let progressEmitter: EventEmitter;
+    let mockMemcachedInstance: jest.Mocked<MemcachedInstance>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        progressEmitter = new EventEmitter();
+
+        // Create mock memcached instance
+        mockMemcachedInstance = {
+            getServer: jest.fn().mockReturnValue('localhost:11212'),
+            status: jest.fn().mockResolvedValue('running'),
+            stop: jest.fn().mockResolvedValue({ status: 'stopped' })
+        } as unknown as jest.Mocked<MemcachedInstance>;
+
+        // Default mock implementations
+        mockTrRoutingStartBatch.mockResolvedValue({
+            status: 'started',
+            service: 'trRoutingBatch',
+            port: 14000
+        });
+        mockTrRoutingStopBatch.mockResolvedValue({
+            status: 'stopped',
+            service: 'trRoutingBatch',
+            port: 14000
+        });
+        mockMemcachedStart.mockResolvedValue(mockMemcachedInstance);
+    });
+
+    describe('startBatch', () => {
+        test('should start memcached when no external server provided', async () => {
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            const result = await manager.startBatch(10);
+
+            expect(result).toEqual({ threadCount: 4, port: 14000 });
+            expect(mockMemcachedStart).toHaveBeenCalledTimes(1);
+            expect(mockTrRoutingStartBatch).toHaveBeenCalledWith(4, {
+                cacheDirectoryPath: undefined,
+                memcachedServer: 'localhost:11212'
+            });
+        });
+
+        test('should use memcached server from startBatch options', async () => {
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            const result = await manager.startBatch(10, {
+                memcachedServer: 'options:11212'
+            });
+
+            expect(mockMemcachedStart).not.toHaveBeenCalled();
+            expect(mockTrRoutingStartBatch).toHaveBeenCalledWith(4, {
+                cacheDirectoryPath: undefined,
+                memcachedServer: 'options:11212'
+            });
+        });
+
+        test('should pass cacheDirectoryPath to TrRoutingProcessManager', async () => {
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.startBatch(10, {
+                cacheDirectoryPath: '/custom/cache/path'
+            });
+
+            expect(mockTrRoutingStartBatch).toHaveBeenCalledWith(4, {
+                cacheDirectoryPath: '/custom/cache/path',
+                memcachedServer: 'localhost:11212'
+            });
+        });
+
+        test.each([
+            { workload: 'small', size: 3, expectedSize: 1}, // Small workload: ceil(3/3) = 1
+            { workload: 'medium', size: 9, expectedSize: 3}, // Medium workload: ceil(9/3) = 3
+            { workload: 'large', size: 100, expectedSize: 4} // Large workload: min(4, ceil(100/3)) = 4 (capped at maxParallelCalculators)
+        ])('should calculate thread count based on workload size ($workload)', async ({size, expectedSize}) => {
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.startBatch(size);
+            expect(mockTrRoutingStartBatch).toHaveBeenLastCalledWith(expectedSize, expect.anything());
+        });
+
+        test('should throw error when TrRouting fails to start', async () => {
+            mockTrRoutingStartBatch.mockResolvedValue({
+                status: 'error',
+                service: 'trRoutingBatch',
+                port: 14000
+            } as any);
+
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await expect(manager.startBatch(10)).rejects.toThrow('Failed to start TrRouting instance: error');
+        });
+
+        test('should emit progress events', async () => {
+            const progressEvents: any[] = [];
+            progressEmitter.on('progress', (data) => progressEvents.push(data));
+
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.startBatch(10);
+
+            expect(progressEvents).toEqual([
+                { name: 'StartingRoutingParallelServer', progress: 0.0 },
+                { name: 'StartingRoutingParallelServer', progress: 1.0 }
+            ]);
+        });
+
+        test('should handle memcached start failure gracefully', async () => {
+            mockMemcachedStart.mockResolvedValue(null);
+
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.startBatch(10);
+
+            // Should still start TrRouting, but without memcached
+            expect(mockTrRoutingStartBatch).toHaveBeenCalledWith(4, {
+                cacheDirectoryPath: undefined,
+                memcachedServer: undefined
+            });
+        });
+    });
+
+    describe('stopBatch', () => {
+        test('should stop memcached when it was started by the manager', async () => {
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.startBatch(10);
+            await manager.stopBatch();
+
+            expect(mockTrRoutingStopBatch).toHaveBeenCalledTimes(2); // Once in startBatch cleanup, once in stopBatch
+            expect(mockMemcachedInstance.stop).toHaveBeenCalledTimes(1);
+        });
+
+        test('should not stop memcached when external server was used', async () => {
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.startBatch(10, {
+                memcachedServer: 'external:11211'
+            });
+            await manager.stopBatch();
+
+            expect(mockTrRoutingStopBatch).toHaveBeenCalled();
+            expect(mockMemcachedInstance.stop).not.toHaveBeenCalled();
+        });
+
+        test('should emit progress events', async () => {
+            const progressEvents: Array<{ name: string; progress: number }> = [];
+            progressEmitter.on('progress', (data) => progressEvents.push(data));
+
+            const manager = new TrRoutingBatchManager(progressEmitter);
+
+            await manager.stopBatch();
+
+            expect(progressEvents).toContainEqual({ name: 'StoppingRoutingParallelServer', progress: 0.0 });
+            expect(progressEvents).toContainEqual({ name: 'StoppingRoutingParallelServer', progress: 1.0 });
+        });
+    });
+});


### PR DESCRIPTION
We create a new MemcachedProcessManager, that will return a MemcachedInstance object, when we start it. We can then get the status, serverUrl and stop it from this object.

TrRoutingBatchManager is now responsible to start and stop memcached, unless the jobs have received a memcachedServer string to use when starting trRouting.

This will allow to start a memcached and have several jobs use the same one. We are planning to use this in the Genetic algorithm simulations



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Memcached process manager and support for passing an optional Memcached server to batch routing jobs; the system will use a provided server or manage one automatically. Batch start APIs and managers accept routing options to control memcached usage.
* **Tests**
  * Added extensive unit tests covering Memcached integration, batch start/stop flows, lifecycle ownership, error handling, and routing-option propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->