### PR TITLE
Change memory allocator for json2capnp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@
 FROM debian:trixie-slim AS json2capnpbuild
 WORKDIR /app/services/json2capnp
 COPY services/json2capnp ./
-RUN apt-get update && apt-get -y --no-install-recommends install cargo ca-certificates
+# Adding build-essential for jemalloc allocator
+RUN apt-get update && apt-get -y --no-install-recommends install build-essential cargo ca-certificates
 RUN cargo build
 
 

--- a/services/json2capnp/Cargo.lock
+++ b/services/json2capnp/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "pretty_assertions",
  "rouille",
  "serde_json",
+ "tikv-jemallocator",
  "transition_capnp_data",
 ]
 
@@ -1158,6 +1159,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/services/json2capnp/Cargo.toml
+++ b/services/json2capnp/Cargo.toml
@@ -11,5 +11,8 @@ rouille = "3.0"
 serde_json = "1.0"
 transition_capnp_data = { path = "transition_capnp_data" }
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/services/json2capnp/src/main.rs
+++ b/services/json2capnp/src/main.rs
@@ -13,6 +13,12 @@ use std::io;
 use std::path::Path;
 use std::env;
 
+// Switch memory allocator to jemalloc on Linux x86_64
+// The default allocator was keeping too much memory around between requests.
+#[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[macro_use]
 extern crate rouille;
 


### PR DESCRIPTION
The default memory allocator was keeping lot of memory around between requests. Since the requests are not frequent, that could lead to a lot of wasted memory.

Jemalloc is more efficient with its memory usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Enabled a jemalloc-based global allocator on Linux x86_64 to improve memory usage and runtime efficiency.
* **Chores**
  * Added the allocator dependency and ensured required build tools are included in the build environment.
  * Preserved existing development/test tooling without functional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->