### PR TITLE
feat(backend): add GeneralizedCostFunction class

### DIFF
--- a/packages/transition-backend/src/services/generalizedCostFunction/GeneralizedCostFunction.ts
+++ b/packages/transition-backend/src/services/generalizedCostFunction/GeneralizedCostFunction.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { GeneralizedCostFunctionValues, GeneralizedCostFunctionWeights } from './types';
+export class GeneralizedCostFunction {
+    private weights: GeneralizedCostFunctionWeights;
+
+    constructor(weights: GeneralizedCostFunctionWeights) {
+        this.weights = weights;
+    }
+
+    /**
+     * Validate that a time value is finite and non-negative.
+     * @param value The time value to validate
+     * @returns true if valid (finite and >= 0), false otherwise
+     */
+    private isValidTimeValue(value: number): boolean {
+        return Number.isFinite(value) && value >= 0;
+    }
+
+    /**
+     * Get the headway values for each leg
+     * @param values GeneralizedCostFunctionValues object
+     * @returns the headway values for each leg, undefined if any headway value is missing
+     * or invalid (undefined/NaN/not finite/negative)
+     */
+    private getHeadways(values: GeneralizedCostFunctionValues): number[] | undefined {
+        if (!values.byLeg || values.byLeg.length === 0) {
+            return undefined;
+        }
+        const headwayByLegIndex: number[] = [];
+        for (const legIndex in values.byLeg) {
+            const leg = values.byLeg[legIndex];
+            if (leg.headwaySeconds === undefined || !this.isValidTimeValue(leg.headwaySeconds)) {
+                return undefined;
+            }
+            headwayByLegIndex.push(leg.headwaySeconds);
+        }
+        return headwayByLegIndex;
+    }
+
+    /**
+     * Calculate the weighted travel time seconds
+     * @param values GeneralizedCostFunctionValues object
+     * @returns Status with the weighted travel time seconds, or error if validation fails
+     */
+    public calculateWeightedTravelTimeSeconds(values: GeneralizedCostFunctionValues): Status.Status<number> {
+        if (values.byLeg.length === 0) {
+            return Status.createError(
+                new TrError('At least one leg is required', 'GCO001', 'GeneralizedCostFunctionError')
+            );
+        }
+
+        // Validate access and egress travel times
+        if (!this.isValidTimeValue(values.accessTravelTimeSeconds)) {
+            return Status.createError(
+                new TrError(
+                    'Invalid accessTravelTimeSeconds: must be finite and >= 0',
+                    'GCO002',
+                    'GeneralizedCostFunctionError'
+                )
+            );
+        }
+        if (!this.isValidTimeValue(values.egressTravelTimeSeconds)) {
+            return Status.createError(
+                new TrError(
+                    'Invalid egressTravelTimeSeconds: must be finite and >= 0',
+                    'GCO003',
+                    'GeneralizedCostFunctionError'
+                )
+            );
+        }
+
+        // Validate first leg waiting time
+        if (!this.isValidTimeValue(values.byLeg[0].waitingTimeSeconds)) {
+            return Status.createError(
+                new TrError(
+                    'Invalid waitingTimeSeconds for leg 0: must be finite and >= 0',
+                    'GCO004',
+                    'GeneralizedCostFunctionError'
+                )
+            );
+        }
+
+        // Validate all leg time values upfront
+        for (let i = 0; i < values.byLeg.length; i++) {
+            const leg = values.byLeg[i];
+            if (!this.isValidTimeValue(leg.inVehicleTravelTimeSeconds)) {
+                return Status.createError(
+                    new TrError(
+                        `Invalid inVehicleTravelTimeSeconds for leg ${i}: must be finite and >= 0`,
+                        'GCO005',
+                        'GeneralizedCostFunctionError'
+                    )
+                );
+            }
+            if (i > 0) {
+                if (!this.isValidTimeValue(leg.waitingTimeSeconds)) {
+                    return Status.createError(
+                        new TrError(
+                            `Invalid waitingTimeSeconds for leg ${i}: must be finite and >= 0`,
+                            'GCO006',
+                            'GeneralizedCostFunctionError'
+                        )
+                    );
+                }
+                if (!this.isValidTimeValue(leg.transferTravelTimeSeconds)) {
+                    return Status.createError(
+                        new TrError(
+                            `Invalid transferTravelTimeSeconds for leg ${i}: must be finite and >= 0`,
+                            'GCO007',
+                            'GeneralizedCostFunctionError'
+                        )
+                    );
+                }
+            }
+        }
+
+        const headwaysSeconds = this.getHeadways(values); // undefined if no headway values are provided
+
+        // Initialize the weighted travel time seconds
+        let weightedTravelTimeSeconds = 0;
+
+        // Calculate the weighted access/egress travel time seconds
+        weightedTravelTimeSeconds +=
+            this.weights.accessTravelTimeWeightByMode[values.accessMode] * values.accessTravelTimeSeconds +
+            this.weights.egressTravelTimeWeightByMode[values.egressMode] * values.egressTravelTimeSeconds;
+
+        // Calculate the weighted waiting time seconds at the first boarding stop
+        weightedTravelTimeSeconds +=
+            this.weights.firstWaitingTimeWeightByWeatherProtection[values.byLeg[0].weatherProtectionAtBoardingStop] *
+            values.byLeg[0].waitingTimeSeconds;
+
+        // Calculate the weighted travel time seconds for each leg
+        for (let i = 0; i < values.byLeg.length; i++) {
+            const leg = values.byLeg[i];
+
+            /**
+             * Calculate the weighted in-vehicle travel time seconds.
+             * Weights for ROW, support, vertical alignment and load factor
+             * are multiplied before applying to inVehicleTravelTimeSeconds.
+             *
+             * Like other in-vehicle weights, the load factor weight can be:
+             * - < 1: model productive time (e.g., working on an empty train)
+             * - = 1: neutral
+             * - > 1: strong crowding aversion
+             *
+             * The formula weight * (loadFactor + 1) allows this flexibility.
+             */
+            weightedTravelTimeSeconds +=
+                leg.inVehicleTravelTimeSeconds *
+                (this.weights.inVehicleTravelTimeWeightByROW[leg.rightOfWayCategory] *
+                    this.weights.inVehicleTravelTimeWeightBySupport[leg.support] *
+                    this.weights.inVehicleTravelTimeWeightByVerticalAlignment[leg.verticalAlignment] *
+                    /**
+                     * Load factor: weight * (loadFactor + 1.0).
+                     * With weight = 1.0: empty (0) = no effect, crowded (1) = doubles time.
+                     * Weight < 1 can model productive travel time.
+                     * Ignored if undefined, not finite, or negative (defaults to 1.0).
+                     */
+                    (leg.loadFactor !== undefined && Number.isFinite(leg.loadFactor) && leg.loadFactor >= 0
+                        ? this.weights.inVehicleTravelTimeWeightForLoadFactor * (leg.loadFactor + 1.0)
+                        : 1.0));
+
+            // We already calculated weighted waiting time at first stop
+            if (i > 0) {
+                // Calculate the weighted transfer waiting time seconds
+                weightedTravelTimeSeconds +=
+                    leg.waitingTimeSeconds *
+                    this.weights.waitingTimeWeightByWeatherProtection[leg.weatherProtectionAtBoardingStop];
+
+                /**
+                 * Calculate the weighted transfer travel time seconds.
+                 * TODO: implement an increasing transfer travel time weight
+                 * by transfer index, if the modeling says we need to do so.
+                 */
+                weightedTravelTimeSeconds +=
+                    leg.transferTravelTimeSeconds * this.weights.transferTravelTimeWeightByMode[values.accessMode];
+
+                // Calculate the weighted transfer penalty seconds by index
+                const transferIndex = i - 1;
+                if (this.weights.transferPenaltySecondsByIndex[transferIndex] !== undefined) {
+                    weightedTravelTimeSeconds += this.weights.transferPenaltySecondsByIndex[transferIndex];
+                } else {
+                    weightedTravelTimeSeconds += this.weights.transferPenaltySecondsMax;
+                }
+            }
+
+            /**
+             * Calculate the penalty for headway.
+             * The penalty added is in seconds, like the rest, and is
+             * calculated like this: weight * headway in seconds = penalty in seconds.
+             */
+            if (headwaysSeconds !== undefined) {
+                const headwaySeconds = headwaysSeconds[i];
+                weightedTravelTimeSeconds +=
+                    headwaySeconds * this.weights.headwayPenaltyWeightByROW[leg.rightOfWayCategory];
+            }
+
+            /**
+             * Calculate the penalty for unreliability.
+             * Uses (1 - reliabilityRatio) so higher reliability = lower penalty.
+             * 100% reliable (1.0) → 0 penalty, 0% reliable (0.0) → full penalty.
+             * Only applies if reliabilityRatio is in valid range [0, 1].
+             */
+            if (
+                leg.reliabilityRatio !== undefined &&
+                Number.isFinite(leg.reliabilityRatio) &&
+                leg.reliabilityRatio >= 0 &&
+                leg.reliabilityRatio <= 1
+            ) {
+                weightedTravelTimeSeconds += this.weights.reliabilityRatioPenaltyWeight * (1 - leg.reliabilityRatio);
+            }
+        }
+
+        return Status.createOk(weightedTravelTimeSeconds);
+    }
+}

--- a/packages/transition-backend/src/services/generalizedCostFunction/README.md
+++ b/packages/transition-backend/src/services/generalizedCostFunction/README.md
@@ -1,0 +1,204 @@
+# Generalized Cost Function
+
+This module implements a generalized cost function for evaluating transit trip quality. The function converts various trip components into a single weighted travel time value (in seconds), allowing comparison between different transit options.
+
+## Current Scope
+
+This implementation calculates **weighted travel time with penalties** expressed in seconds. It does **not** convert the result to a real monetary cost using value of time ($c_{tu}$, user hourly cost). The output is a dimensionless weighted time that can be used for comparing transit options, but is not expressed in currency units.
+
+**This serves as a first template** that will be verified, validated, and updated through modeling using OD data from travel surveys or transit smart card transactions. The penalty factors and formula structure may evolve based on calibration results.
+
+Future enhancements may include:
+- Calibration and validation using real-world OD data
+- Conversion to monetary cost using value of time
+- Fare integration for complete cost calculations
+- Crowding penalties (requires demand data)
+
+## Mathematical Formulation
+
+The generalized cost $C$ is calculated as:
+
+$$C = C_ {\text{access}} + C_ {\text{egress}} + C_ {\text{first wait}} + \sum_ {k=0}^{n_ {tr}} C_ {\text{leg}}^{(k)}$$
+
+Where $n_ {tr}$ is the number of transfers (number of legs = $n_ {tr} + 1$).
+
+### Access and Egress Components
+
+$$C_ {\text{access}} = \mu_ {eO}^{(m_a)} \cdot t_ {eO}$$
+
+$$C_ {\text{egress}} = \mu_ {eD}^{(m_e)} \cdot t_ {eD}$$
+
+Where:
+- $t_ {eO}$: access travel time to first boarding stop (seconds)
+- $t_ {eD}$: egress travel time from last alighting stop (seconds)
+- $m_a, m_e$: access and egress modes (walking, cycling, driving)
+- $\mu_ {eO}^{(m)}, \mu_ {eD}^{(m)}$: mode-specific penalty factors
+
+### First Boarding Wait Time
+
+$$C_ {\text{first wait}} = \mu_ {wO}^{(\text{weatherProtection}_0)} \cdot t_ {wO}$$
+
+Where:
+- $t_ {wO}$: waiting time at first boarding stop (seconds)
+- $\text{weatherProtection}_0$: weather protection at first boarding stop (none, covered, indoor)
+- $\mu_ {wO}^{(\text{weatherProtection})}$: weather protection-specific penalty factor for first wait
+
+### Per-Leg Components
+
+For each leg $k$ (0-indexed, $k \in [0, n_ {tr}]$):
+
+$$C_ {\text{leg}}^{(k)} = C_ {\text{in-vehicle}}^{(k)} + C_ {\text{transfer}}^{(k)} + C_ {\text{headway}}^{(k)} + C_ {\text{reliability}}^{(k)}$$
+
+#### In-Vehicle Travel Time
+
+The in-vehicle penalty is calculated by **multiplying** the penalty factors for ROW, support, vertical alignment, and load factor:
+
+$$C_ {\text{in-vehicle}}^{(k)} = t_ {veh}^{(k)} \times \mu_ {\text{ROW}}^{(r_k)} \times \mu_ {\text{support}}^{(s_k)} \times \mu_ {\text{verticalAlignment}}^{(v_k)} \times \mu_ {\alpha_c}^{(k)}$$
+
+Where:
+- $t_ {veh}^{(k)}$: in-vehicle travel time for leg $k$ (seconds)
+- $r_k$: right-of-way category (A, B, B-, C+, C, unknown)
+- $s_k$: support type (rail, tires, water, suspended, magnetic, air, hover, hydrostatic, unknown)
+- $v_k$: vertical alignment (underground, surface, aerial, unknown)
+
+**Load factor multiplier** (optional):
+
+$$\mu_ {\alpha_c}^{(k)} = \begin{cases} \mu_ {\alpha_c} \times (\alpha_ {c,k} + 1.0) & \text{if } \alpha_ {c,k} \text{ is defined, finite, and } \geq 0 \\ 1.0 & \text{otherwise} \end{cases}$$
+
+Where $\alpha_ {c,k}$ is the load factor for leg $k$ (value $\geq 0$).
+
+Like other in-vehicle weights (ROW, support), the load factor weight allows flexibility:
+- **$\mu_ {\alpha_c} = 1.0$**: Empty vehicle ($\alpha_c = 0$) → multiplier = 1.0 (no effect); crowded ($\alpha_c = 1$) → multiplier = 2.0 (doubles perceived time)
+- **$\mu_ {\alpha_c} < 1.0$**: Models productive travel time (e.g., working on an empty train reduces perceived time)
+- **$\mu_ {\alpha_c} > 1.0$**: Models strong crowding aversion
+
+#### Transfer Components (for $k > 0$)
+
+$$C_ {\text{transfer}}^{(k)} = \mu_ {wtr}^{(\text{weatherProtection}_k)} \cdot t_ {wtr}^{(k)} + \mu_ {tr}^{(m_a)} \cdot t_ {tr}^{(k)} + c_ {t}^{(k-1)}$$
+
+Where:
+- $t_ {wtr}^{(k)}$: waiting time at transfer boarding stop (seconds)
+- $t_ {tr}^{(k)}$: non-transit travel time between transfer stops (seconds)
+- $\text{weatherProtection}_k$: weather protection at boarding stop for leg $k$
+- $c_ {t}^{(j)}$: transfer penalty for transfer index $j$
+
+Transfer penalty:
+
+$$c_ {t}^{(j)} = \begin{cases} c_ {t,j} & \text{if } j < |c_t| \\ c_ {t,\text{max}} & \text{otherwise} \end{cases}$$
+
+Where $|c_t|$ is the number of defined transfer penalties.
+
+#### Headway Penalty (optional, only if headway data provided for all legs)
+
+$$C_ {\text{headway}}^{(k)} = h_k \times \mu_ {h}^{(\text{ROW}_k)}$$
+
+Where:
+- $h_k$: headway of the service for leg $k$ (seconds)
+- $\mu_ {h}^{(\text{ROW}_k)}$: headway penalty factor by ROW category
+
+#### Unreliability Penalty (optional)
+
+$$C_ {\text{reliability}}^{(k)} = \begin{cases} \mu_ {R} \times (1 - R_k) & \text{if } R_k \in [0, 1] \\ 0 & \text{otherwise} \end{cases}$$
+
+Where:
+- $R_k$: reliability ratio for leg $k$ (ratio of on-time arrivals/departures, value between 0.0 and 1.0)
+- $\mu_ {R}$: unreliability penalty weight (max penalty in seconds for completely unreliable service)
+- $(1 - R_k)$: unreliability factor (100% reliable → 0 penalty, 0% reliable → full penalty)
+
+## Complete Formula (Expanded)
+
+$$\begin{aligned}
+C = & \; \mu_ {eO}^{(m_a)} \cdot t_ {eO} + \mu_ {eD}^{(m_e)} \cdot t_ {eD} \\
+& + \mu_ {wO}^{(\text{weatherProtection}_0)} \cdot t_ {wO} \\
+& + \sum_ {k=0}^{n_ {tr}} \left[ t_ {veh}^{(k)} \times \mu_ {\text{ROW}}^{(r_k)} \times \mu_ {\text{support}}^{(s_k)} \times \mu_ {\text{verticalAlignment}}^{(v_k)} \times \mu_ {\alpha_c}^{(k)} \right] \\
+& + \sum_ {k=1}^{n_ {tr}} \left[ \mu_ {wtr}^{(\text{weatherProtection}_k)} \cdot t_ {wtr}^{(k)} + \mu_ {tr}^{(m_a)} \cdot t_ {tr}^{(k)} + c_ {t}^{(k-1)} \right] \\
+& + \sum_ {k=0}^{n_ {tr}} \left[ h_k \times \mu_ {h}^{(\text{ROW}_k)} \right] \quad \text{(if headway data available for all legs)} \\
+& + \sum_ {k=0}^{n_ {tr}} \left[ \mu_ {R} \times (1 - R_k) \right] \quad \text{(if reliability data available)}
+\end{aligned}$$
+
+*** All input time and headways must be in seconds ***
+
+## Symbol Summary
+
+| Symbol | Description | Unit |
+|--------|-------------|------|
+| $t_ {eO}$ | Access travel time | s |
+| $t_ {eD}$ | Egress travel time | s |
+| $t_ {wO}$ | Origin waiting time | s |
+| $t_ {wtr}^{(k)}$ | Transfer waiting time at leg $k$ | s |
+| $t_ {tr}^{(k)}$ | Transfer travel time to leg $k$ | s |
+| $t_ {veh}^{(k)}$ | In-vehicle travel time for leg $k$ | s |
+| $h_k$ | Headway for leg $k$ | s |
+| $R_k$ | Reliability ratio for leg $k$ | - |
+| $\alpha_ {c,k}$ | Load factor for leg $k$ | - |
+| $n_ {tr}$ | Number of transfers | - |
+| $c_ {t}^{(j)}$ | Transfer penalty for transfer $j$ | s |
+| $\mu$ | Penalty factor (weight) | - |
+
+## Notes
+
+### Constraints
+
+**All weights ($\mu$) must be $\geq 0$**. This ensures penalties can never be negative:
+- Weights in range $(0, 1)$: reduce perceived time (e.g., productive travel on comfortable train)
+- Weight $= 1$: neutral (no adjustment)
+- Weight $> 1$: increase perceived time (penalty)
+
+**All input time values must be $\geq 0$** (accessTravelTimeSeconds, inVehicleTravelTimeSeconds, etc.).
+
+**Penalties for transfers and headway must be $\geq 0$** ($c_ {t}^{(j)}$ and $c_ {t,\text{max}}$).
+
+### Behavior Notes
+
+- **Multiplicative in-vehicle factors**: ROW, support, vertical alignment, and load factor penalties are **multiplied** together (not added)
+- **All-or-nothing headway**: If headway data is missing for any leg, headway costs are excluded for the entire trip
+- **Transfer penalty fallback**: When the transfer index exceeds defined penalties, $c_ {t,\text{max}}$ is used
+- **Weather protection**: Affects waiting time penalties at boarding stops
+- **Load factor**: The load factor value $\alpha_ {c,k}$ must be $\geq 0$ (0.0 = empty, 0.5 = good comfort, 1.0 = low comfort, > 1.0 = crowded). The effective multiplier is $\mu_ {\alpha_c} \times (\alpha_ {c,k} + 1.0)$. With weight in $(0, 1)$, this can reduce perceived time (e.g., productive work time on empty train); with weight $\geq 1$, it increases perceived time (crowding penalty)
+- **Reliability ratio**: On-time performance ratio, must be in range [0.0, 1.0]. Higher values indicate better reliability. The penalty uses $(1 - R_k)$ so that 100% reliable service adds no penalty
+- **Optional components**: Load factor is ignored when undefined, not finite, or negative. Reliability ratio is ignored when undefined, not finite, or outside [0, 1] range
+
+## Simplified Configuration
+
+If you don't need differentiated penalty factors for ROW, support, vertical alignment, weather protection, or load factor, you can simplify the configuration:
+
+1. Set all values in `inVehicleTravelTimeWeightByROW`, `inVehicleTravelTimeWeightBySupport`, and `inVehicleTravelTimeWeightByVerticalAlignment` to `1.0`
+2. Set `inVehicleTravelTimeWeightForLoadFactor` to `1.0` (or ensure load factor values are undefined)
+3. Change only the `unknown` value to your desired single in-vehicle time penalty factor
+
+For example, to use a single in-vehicle time penalty of `0.9`:
+
+```typescript
+inVehicleTravelTimeWeightByROW: {
+    A: 1.0, B: 1.0, 'B-': 1.0, 'C+': 1.0, C: 1.0, unknown: 0.9
+},
+inVehicleTravelTimeWeightBySupport: {
+    rail: 1.0, tires: 1.0, water: 1.0, suspended: 1.0,
+    magnetic: 1.0, air: 1.0, hover: 1.0, hydrostatic: 1.0, unknown: 1.0
+},
+inVehicleTravelTimeWeightByVerticalAlignment: {
+    surface: 1.0, aerial: 1.0, underground: 1.0, unknown: 1.0
+}
+```
+
+Then set all your leg data to use `rightOfWayCategory: 'unknown'`, `support: 'unknown'`, and `verticalAlignment: 'unknown'`. The result will be: $C_ {\text{in-vehicle}}^{(k)} = t_ {veh}^{(k)} \times 0.9 \times 1.0 \times 1.0 = 0.9 \cdot t_ {veh}^{(k)}$
+
+The same approach works for weather protection: set all values to `1.0` except `unknown`, and use `weatherProtection: 'unknown'` in your data.
+
+## Penalty Factor Types Summary
+
+| Component | Penalty Factor | Notes |
+|-----------|----------------|-------|
+| Access time | $\mu_ {eO}^{(m)}$ by mode | Additive |
+| Egress time | $\mu_ {eD}^{(m)}$ by mode | Additive |
+| First waiting time | $\mu_ {wO}^{(\text{weatherProtection})}$ | Additive |
+| Transfer waiting time | $\mu_ {wtr}^{(\text{weatherProtection})}$ | Additive |
+| Transfer travel time | $\mu_ {tr}^{(m)}$ by access mode | Additive |
+| Transfer penalty | $c_ {t}^{(j)}$ by index | Additive |
+| In-vehicle time | $\mu_ {\text{ROW}} \times \mu_ {\text{support}} \times \mu_ {\text{verticalAlignment}} \times \mu_ {\alpha_c}$ | **Multiplicative** |
+| Headway penalty | $\mu_ {h}^{(\text{ROW})}$ | Additive |
+| Unreliability penalty | $\mu_ {R} \times (1 - R_k)$ | Additive |
+
+## References
+
+For detailed symbol definitions and theoretical background, see the [Overleaf documentation](https://www.overleaf.com/read/dtxfhttxgjrx).

--- a/packages/transition-backend/src/services/generalizedCostFunction/__tests__/GeneralizedCostFunction.test.ts
+++ b/packages/transition-backend/src/services/generalizedCostFunction/__tests__/GeneralizedCostFunction.test.ts
@@ -1,0 +1,743 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { GeneralizedCostFunction } from '../GeneralizedCostFunction';
+import { GeneralizedCostFunctionValues, GeneralizedCostFunctionWeights } from '../types';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import type { RightOfWayCategory } from 'transition-common/lib/services/line/types';
+import type { WeatherProtection } from 'transition-common/lib/services/nodes/types';
+
+// Helper function to create default weights for testing
+const createDefaultWeights = (): GeneralizedCostFunctionWeights => ({
+    accessTravelTimeWeightByMode: {
+        walking: 2.0,
+        cycling: 1.5,
+        driving: 1.0
+    },
+    egressTravelTimeWeightByMode: {
+        walking: 2.0,
+        cycling: 1.5,
+        driving: 1.0
+    },
+    transferTravelTimeWeightByMode: {
+        walking: 2.5,
+        cycling: 2.0,
+        driving: 1.5
+    },
+    inVehicleTravelTimeWeightByROW: {
+        A: 0.8,
+        B: 0.9,
+        'B-': 1.0,
+        'C+': 1.1,
+        C: 1.2,
+        unknown: 1.0
+    },
+    inVehicleTravelTimeWeightBySupport: {
+        rail: 0.85,
+        tires: 1.0,
+        water: 1.1,
+        suspended: 0.9,
+        magnetic: 0.85,
+        air: 0.7,
+        hover: 0.95,
+        hydrostatic: 1.0,
+        unknown: 1.0
+    },
+    inVehicleTravelTimeWeightByVerticalAlignment: {
+        surface: 1.0,
+        aerial: 0.95,
+        underground: 1.05,
+        unknown: 1.0
+    },
+    inVehicleTravelTimeWeightForLoadFactor: 0.1,
+    firstWaitingTimeWeightByWeatherProtection: {
+        none: 2.5,
+        covered: 2.0,
+        indoor: 1.5,
+        unknown: 2.0
+    },
+    waitingTimeWeightByWeatherProtection: {
+        none: 3.0,
+        covered: 2.5,
+        indoor: 2.0,
+        unknown: 2.5
+    },
+    transferPenaltySecondsByIndex: [300, 400, 500],
+    transferPenaltySecondsMax: 600,
+    headwayPenaltyWeightByROW: {
+        A: 0.08,
+        B: 0.09,
+        'B-': 0.1,
+        'C+': 0.11,
+        C: 0.12,
+        unknown: 0.1
+    },
+    reliabilityRatioPenaltyWeight: 100
+});
+
+// Helper function to create default values for testing
+const createDefaultValues = (): GeneralizedCostFunctionValues => ({
+    accessMode: 'walking',
+    egressMode: 'walking',
+    accessTravelTimeSeconds: 300,
+    egressTravelTimeSeconds: 240,
+    byLeg: [
+        {
+            weatherProtectionAtBoardingStop: 'covered',
+            inVehicleTravelTimeSeconds: 900,
+            transferTravelTimeSeconds: 0,
+            waitingTimeSeconds: 300,
+            headwaySeconds: 480,
+            rightOfWayCategory: 'B',
+            verticalAlignment: 'surface',
+            support: 'tires',
+            loadFactor: undefined,
+            reliabilityRatio: undefined
+        },
+        {
+            weatherProtectionAtBoardingStop: 'indoor',
+            inVehicleTravelTimeSeconds: 900,
+            transferTravelTimeSeconds: 180,
+            waitingTimeSeconds: 240,
+            headwaySeconds: 600,
+            rightOfWayCategory: 'C',
+            verticalAlignment: 'underground',
+            support: 'rail',
+            loadFactor: undefined,
+            reliabilityRatio: undefined
+        }
+    ]
+});
+
+describe('GeneralizedCostFunction', () => {
+
+    describe('calculateWeightedTravelTimeSeconds', () => {
+        test('should return error when byLeg is empty', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+            values.byLeg = [];
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            expect(Status.isStatusError(result)).toBe(true);
+            if (Status.isStatusError(result)) {
+                expect((result.error as Error).message).toBe('At least one leg is required');
+            }
+        });
+
+        // Time value validation tests
+        test.each([
+            { field: 'accessTravelTimeSeconds', value: NaN, errorCode: 'GCO002' },
+            { field: 'accessTravelTimeSeconds', value: -100, errorCode: 'GCO002' },
+            { field: 'accessTravelTimeSeconds', value: Infinity, errorCode: 'GCO002' },
+            { field: 'egressTravelTimeSeconds', value: NaN, errorCode: 'GCO003' },
+            { field: 'egressTravelTimeSeconds', value: -100, errorCode: 'GCO003' },
+            { field: 'egressTravelTimeSeconds', value: Infinity, errorCode: 'GCO003' }
+        ])(
+            'should return error when $field is $value',
+            ({ field, value, errorCode }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                (values as any)[field] = value;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                expect(Status.isStatusError(result)).toBe(true);
+                if (Status.isStatusError(result)) {
+                    expect((result.error as TrError).getCode()).toBe(errorCode);
+                }
+            }
+        );
+
+        test.each([
+            { legIndex: 0, field: 'waitingTimeSeconds', value: NaN, errorCode: 'GCO004' },
+            { legIndex: 0, field: 'waitingTimeSeconds', value: -100, errorCode: 'GCO004' },
+            { legIndex: 0, field: 'inVehicleTravelTimeSeconds', value: NaN, errorCode: 'GCO005' },
+            { legIndex: 0, field: 'inVehicleTravelTimeSeconds', value: -100, errorCode: 'GCO005' },
+            { legIndex: 1, field: 'inVehicleTravelTimeSeconds', value: Infinity, errorCode: 'GCO005' },
+            { legIndex: 1, field: 'waitingTimeSeconds', value: NaN, errorCode: 'GCO006' },
+            { legIndex: 1, field: 'waitingTimeSeconds', value: -100, errorCode: 'GCO006' },
+            { legIndex: 1, field: 'transferTravelTimeSeconds', value: NaN, errorCode: 'GCO007' },
+            { legIndex: 1, field: 'transferTravelTimeSeconds', value: -100, errorCode: 'GCO007' }
+        ])(
+            'should return error when leg $legIndex $field is $value',
+            ({ legIndex, field, value, errorCode }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                (values.byLeg[legIndex] as any)[field] = value;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                expect(Status.isStatusError(result)).toBe(true);
+                if (Status.isStatusError(result)) {
+                    expect((result.error as TrError).getCode()).toBe(errorCode);
+                }
+            }
+        );
+
+        test('should calculate weighted travel time with two legs and headway', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation with MULTIPLICATIVE in-vehicle weights:
+            // Access: 2.0 * 300 = 600
+            // Egress: 2.0 * 240 = 480
+            // First waiting (leg 0, covered weather protection): 2.0 * 300 = 600
+            // Leg 0:
+            //   In-vehicle: 900 * (0.9 * 1.0 * 1.0) = 900 * 0.9 = 810
+            //   No transfer penalties (first leg)
+            //   Headway: 480 * 0.09 = 43.2
+            // Leg 1:
+            //   In-vehicle: 900 * (1.2 * 0.85 * 1.05) = 900 * 1.071 = 963.9
+            //   Transfer waiting (indoor weather protection): 240 * 2.0 = 480
+            //   Transfer travel (walking): 180 * 2.5 = 450
+            //   Transfer penalty by index (transfer 0): 300
+            //   Headway: 600 * 0.12 = 72
+            // Total: 600 + 480 + 600 + 810 + 43.2 + 963.9 + 480 + 450 + 300 + 72 = 4799.1
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(4799.1, 1);
+            }
+        });
+
+        test('should calculate weighted travel time without headway', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+            delete values.byLeg[0].headwaySeconds;
+            delete values.byLeg[1].headwaySeconds;
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation (same as above but without headway parts):
+            // Access: 600
+            // Egress: 480
+            // First waiting: 600
+            // Leg 0:
+            //   In-vehicle: 900 * 0.9 = 810
+            //   No transfer penalties
+            // Leg 1:
+            //   In-vehicle: 900 * 1.071 = 963.9
+            //   Transfer waiting: 480
+            //   Transfer travel: 450
+            //   Transfer penalty by index: 300
+            // Total: 600 + 480 + 600 + 810 + 963.9 + 480 + 450 + 300 = 4683.9
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(4683.9, 1);
+            }
+        });
+
+        test('should skip all headway costs if any leg is missing headway (all-or-nothing behavior)', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+
+            // Case 1: Both legs have headway
+            const valuesWithBothHeadways = createDefaultValues();
+            valuesWithBothHeadways.byLeg[0].headwaySeconds = 480;
+            valuesWithBothHeadways.byLeg[1].headwaySeconds = 600;
+            const resultWithBothHeadways = gcf.calculateWeightedTravelTimeSeconds(valuesWithBothHeadways);
+
+            // Case 2: Only first leg has headway (second is missing)
+            const valuesWithFirstHeadwayOnly = createDefaultValues();
+            valuesWithFirstHeadwayOnly.byLeg[0].headwaySeconds = 480;
+            delete valuesWithFirstHeadwayOnly.byLeg[1].headwaySeconds;
+            const resultWithFirstHeadwayOnly = gcf.calculateWeightedTravelTimeSeconds(valuesWithFirstHeadwayOnly);
+
+            // Case 3: Only second leg has headway (first is missing)
+            const valuesWithSecondHeadwayOnly = createDefaultValues();
+            delete valuesWithSecondHeadwayOnly.byLeg[0].headwaySeconds;
+            valuesWithSecondHeadwayOnly.byLeg[1].headwaySeconds = 600;
+            const resultWithSecondHeadwayOnly = gcf.calculateWeightedTravelTimeSeconds(valuesWithSecondHeadwayOnly);
+
+            // Case 4: Neither leg has headway
+            const valuesWithNoHeadway = createDefaultValues();
+            delete valuesWithNoHeadway.byLeg[0].headwaySeconds;
+            delete valuesWithNoHeadway.byLeg[1].headwaySeconds;
+            const resultWithNoHeadway = gcf.calculateWeightedTravelTimeSeconds(valuesWithNoHeadway);
+
+            // Verify all results are successful
+            expect(Status.isStatusOk(resultWithBothHeadways)).toBe(true);
+            expect(Status.isStatusOk(resultWithFirstHeadwayOnly)).toBe(true);
+            expect(Status.isStatusOk(resultWithSecondHeadwayOnly)).toBe(true);
+            expect(Status.isStatusOk(resultWithNoHeadway)).toBe(true);
+
+            if (
+                Status.isStatusOk(resultWithBothHeadways) &&
+                Status.isStatusOk(resultWithFirstHeadwayOnly) &&
+                Status.isStatusOk(resultWithSecondHeadwayOnly) &&
+                Status.isStatusOk(resultWithNoHeadway)
+            ) {
+                // When ANY leg is missing headway, the result should be the same as when NO leg has headway
+                // This verifies the all-or-nothing behavior of getHeadways
+                expect(resultWithFirstHeadwayOnly.result).toBeCloseTo(resultWithNoHeadway.result, 1);
+                expect(resultWithSecondHeadwayOnly.result).toBeCloseTo(resultWithNoHeadway.result, 1);
+
+                // Verify the base calculation without headway is ~4683.9 (from previous test)
+                expect(resultWithNoHeadway.result).toBeCloseTo(4683.9, 1);
+
+                // Verify the calculation with headway adds the expected costs:
+                // Headway costs for leg 0: 480 * 0.09 = 43.2
+                // Headway costs for leg 1: 600 * 0.12 = 72
+                // Total headway costs: 43.2 + 72 = 115.2
+                // Expected total: 4683.9 + 115.2 = 4799.1
+                expect(resultWithBothHeadways.result).toBeCloseTo(4799.1, 1);
+            }
+        });
+
+        // Invalid headway values (NaN, Infinity, -Infinity) should be treated like missing headway
+        // and skip all headway costs (all-or-nothing behavior)
+        test.each([
+            { scenario: 'NaN headway on one leg', leg0Headway: NaN, leg1Headway: 600 },
+            { scenario: 'NaN headway on both legs', leg0Headway: NaN, leg1Headway: NaN },
+            { scenario: 'undefined headway on one leg', leg0Headway: undefined, leg1Headway: 600 },
+            { scenario: 'undefined headway on both legs', leg0Headway: undefined, leg1Headway: undefined },
+            { scenario: 'Infinity headway on one leg', leg0Headway: Infinity, leg1Headway: 600 },
+            { scenario: 'Negative number headway on one leg', leg0Headway: 480, leg1Headway: -233 },
+            { scenario: 'Negative number headway on both legs', leg0Headway: -1, leg1Headway: -1 }
+        ])(
+            'should skip headway costs when $scenario',
+            ({ leg0Headway, leg1Headway }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                values.byLeg[0].headwaySeconds = leg0Headway;
+                values.byLeg[1].headwaySeconds = leg1Headway;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                // Should succeed and return the base calculation without headway costs
+                expect(Status.isStatusOk(result)).toBe(true);
+                if (Status.isStatusOk(result)) {
+                    // Base calculation without headway is ~4683.9
+                    expect(result.result).toBeCloseTo(4683.9, 1);
+                    // Verify result is not NaN
+                    expect(Number.isFinite(result.result)).toBe(true);
+                }
+            }
+        );
+
+        test('should handle single leg trip (no transfers)', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values: GeneralizedCostFunctionValues = {
+                accessMode: 'walking',
+                egressMode: 'walking',
+                accessTravelTimeSeconds: 300,
+                egressTravelTimeSeconds: 240,
+                byLeg: [
+                    {
+                        weatherProtectionAtBoardingStop: 'none',
+                        inVehicleTravelTimeSeconds: 900,
+                        transferTravelTimeSeconds: 0,
+                        waitingTimeSeconds: 300,
+                        headwaySeconds: 480,
+                        rightOfWayCategory: 'A',
+                        verticalAlignment: 'surface',
+                        support: 'rail',
+                        loadFactor: undefined,
+                        reliabilityRatio: undefined
+                    }
+                ]
+            };
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation:
+            // Access: 2.0 * 300 = 600
+            // Egress: 2.0 * 240 = 480
+            // First waiting (none weather protection): 2.5 * 300 = 750
+            // Leg 0:
+            //   In-vehicle: 900 * (0.8 * 0.85 * 1.0) = 900 * 0.68 = 612
+            //   No transfer penalties (single leg, no transfers)
+            //   Headway: 480 * 0.08 = 38.4
+            // Total: 600 + 480 + 750 + 612 + 38.4 = 2480.4
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(2480.4, 1);
+            }
+        });
+
+        test('should use transferPenaltySecondsMax when transfer index exceeds provided penalties', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+
+            // Add more legs to exceed transferPenaltySecondsByIndex length
+            values.byLeg.push(
+                {
+                    weatherProtectionAtBoardingStop: 'covered',
+                    inVehicleTravelTimeSeconds: 600,
+                    transferTravelTimeSeconds: 120,
+                    waitingTimeSeconds: 180,
+                    headwaySeconds: 720,
+                    rightOfWayCategory: 'B-',
+                    verticalAlignment: 'aerial',
+                    support: 'tires',
+                    loadFactor: undefined,
+                    reliabilityRatio: undefined
+                },
+                {
+                    weatherProtectionAtBoardingStop: 'indoor',
+                    inVehicleTravelTimeSeconds: 500,
+                    transferTravelTimeSeconds: 100,
+                    waitingTimeSeconds: 150,
+                    headwaySeconds: 800,
+                    rightOfWayCategory: 'C+',
+                    verticalAlignment: 'surface',
+                    support: 'rail',
+                    loadFactor: undefined,
+                    reliabilityRatio: undefined
+                }
+            );
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation for 4 legs with 3 transfers (MULTIPLICATIVE weights):
+            // Access: 2.0 * 300 = 600
+            // Egress: 2.0 * 240 = 480
+            // First waiting (leg 0, covered): 2.0 * 300 = 600
+            //
+            // Leg 0 (i=0, no transfer):
+            //   In-vehicle: 900 * (0.9 * 1.0 * 1.0) = 810
+            //   Headway: 480 * 0.09 = 43.2
+            //
+            // Leg 1 (i=1, transfer index 0):
+            //   In-vehicle: 900 * (1.2 * 0.85 * 1.05) = 963.9
+            //   Transfer waiting (indoor): 240 * 2.0 = 480
+            //   Transfer travel: 180 * 2.5 = 450
+            //   Transfer penalty[0]: 300
+            //   Headway: 600 * 0.12 = 72
+            //
+            // Leg 2 (i=2, transfer index 1):
+            //   In-vehicle: 600 * (1.0 * 1.0 * 0.95) = 570
+            //   Transfer waiting (covered): 180 * 2.5 = 450
+            //   Transfer travel: 120 * 2.5 = 300
+            //   Transfer penalty[1]: 400
+            //   Headway: 720 * 0.1 = 72
+            //
+            // Leg 3 (i=3, transfer index 2):
+            //   In-vehicle: 500 * (1.1 * 0.85 * 1.0) = 467.5
+            //   Transfer waiting (indoor): 150 * 2.0 = 300
+            //   Transfer travel: 100 * 2.5 = 250
+            //   Transfer penalty[2]: 500
+            //   Headway: 800 * 0.11 = 88
+            //
+            // Total: 600 + 480 + 600 + 810 + 43.2 + 963.9 + 480 + 450 + 300 + 72
+            //      + 570 + 450 + 300 + 400 + 72 + 467.5 + 300 + 250 + 500 + 88 = 8196.6
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(8196.6, 1);
+            }
+        });
+
+        // Tests transferPenaltySecondsMax when transfer index exceeds defined penalties.
+        // Custom weights: transferPenaltySecondsByIndex = [300], transferPenaltySecondsMax = 999
+        // - 2 legs (1 transfer): uses transferPenaltySecondsByIndex[0] = 300
+        // - 3 legs (2 transfers): uses transferPenaltySecondsByIndex[0] = 300, then transferPenaltySecondsMax = 999
+        test.each([
+            {
+                scenario: '2 legs using transferPenaltySecondsByIndex[0]',
+                addThirdLeg: false,
+                expected: 4683.9 // Base without headway
+            },
+            {
+                scenario: '3 legs using transferPenaltySecondsMax for second transfer',
+                addThirdLeg: true,
+                // Base + leg 2 in-vehicle (800 * 0.9 * 1.0 * 1.0 = 720) + transfer waiting (200 * 2.5 = 500)
+                // + transfer travel (150 * 2.5 = 375) + transferPenaltySecondsMax (999) = 4683.9 + 720 + 500 + 375 + 999 = 7277.9
+                expected: 7277.9
+            }
+        ])(
+            'should apply correct transfer penalty for $scenario',
+            ({ addThirdLeg, expected }) => {
+                const customWeights = createDefaultWeights();
+                customWeights.transferPenaltySecondsByIndex = [300]; // Only 1 penalty defined
+                customWeights.transferPenaltySecondsMax = 999;
+
+                const gcf = new GeneralizedCostFunction(customWeights);
+                const values = createDefaultValues();
+                delete values.byLeg[0].headwaySeconds;
+                delete values.byLeg[1].headwaySeconds;
+
+                if (addThirdLeg) {
+                    values.byLeg.push({
+                        weatherProtectionAtBoardingStop: 'covered' as WeatherProtection,
+                        inVehicleTravelTimeSeconds: 800,
+                        transferTravelTimeSeconds: 150,
+                        waitingTimeSeconds: 200,
+                        rightOfWayCategory: 'B' as RightOfWayCategory,
+                        verticalAlignment: 'surface',
+                        support: 'tires',
+                        loadFactor: undefined,
+                        reliabilityRatio: undefined
+                    });
+                }
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                expect(Status.isStatusOk(result)).toBe(true);
+                if (Status.isStatusOk(result)) {
+                    expect(result.result).toBeCloseTo(expected, 1);
+                }
+            }
+        );
+
+        // Access mode affects both access time weight and transfer travel time weight:
+        // - walking: access weight = 2.0, transfer weight = 2.5
+        // - cycling: access weight = 1.5, transfer weight = 2.0
+        // - driving: access weight = 1.0, transfer weight = 1.5
+        // Base (no headway): Egress: 480, First waiting: 600, Leg 0 in-vehicle: 810,
+        // Leg 1 in-vehicle: 963.9, Transfer waiting: 480, Transfer penalty: 300
+        // Variable: Access (300s) * access weight + Transfer travel (180s) * transfer weight
+        test.each([
+            // walking: 300 * 2.0 + 180 * 2.5 = 600 + 450 = 1050, Total = 4683.9
+            { accessMode: 'walking' as const, expected: 4683.9 },
+            // cycling: 300 * 1.5 + 180 * 2.0 = 450 + 360 = 810, Total = 4443.9
+            { accessMode: 'cycling' as const, expected: 4443.9 },
+            // driving: 300 * 1.0 + 180 * 1.5 = 300 + 270 = 570, Total = 4203.9
+            { accessMode: 'driving' as const, expected: 4203.9 }
+        ])('should apply correct weights for $accessMode access mode', ({ accessMode, expected }) => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+            values.accessMode = accessMode;
+            delete values.byLeg[0].headwaySeconds;
+            delete values.byLeg[1].headwaySeconds;
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(expected, 1);
+            }
+        });
+
+        // Egress mode weights (egress time = 240s):
+        // - walking: weight = 2.0 → 480
+        // - cycling: weight = 1.5 → 360
+        // - driving: weight = 1.0 → 240
+        // Base (no headway, egress excluded): Access: 600, First waiting: 600, Leg 0 in-vehicle: 810,
+        // Leg 1 in-vehicle: 963.9, Transfer waiting: 480, Transfer travel: 450, Transfer penalty: 300 = 4203.9
+        // Total = 4203.9 + egress
+        test.each([
+            { egressMode: 'walking' as const, expected: 4683.9 },
+            { egressMode: 'cycling' as const, expected: 4563.9 },
+            { egressMode: 'driving' as const, expected: 4443.9 }
+        ])('should apply correct weight for $egressMode egress mode', ({ egressMode, expected }) => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+            values.egressMode = egressMode;
+            delete values.byLeg[0].headwaySeconds;
+            delete values.byLeg[1].headwaySeconds;
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(expected, 1);
+            }
+        });
+
+        // Weather protection weights for first waiting time (waiting time = 300s):
+        // - none: weight = 2.5 → 750
+        // - covered: weight = 2.0 → 600
+        // - indoor: weight = 1.5 → 450
+        // Base calculation (no headway, first waiting excluded): Access: 600, Egress: 480,
+        // Leg 0 in-vehicle: 810, Leg 1 in-vehicle: 963.9, Transfer waiting: 480,
+        // Transfer travel: 450, Transfer penalty: 300 = 4083.9
+        // Total = 4083.9 + first waiting
+        test.each([
+            { weatherProtection: 'none' as WeatherProtection, expected: 4833.9 },
+            { weatherProtection: 'covered' as WeatherProtection, expected: 4683.9 },
+            { weatherProtection: 'indoor' as WeatherProtection, expected: 4533.9 }
+        ])(
+            'should apply $weatherProtection weather protection weight correctly',
+            ({ weatherProtection, expected }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                values.byLeg[0].weatherProtectionAtBoardingStop = weatherProtection;
+                delete values.byLeg[0].headwaySeconds;
+                delete values.byLeg[1].headwaySeconds;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                expect(Status.isStatusOk(result)).toBe(true);
+                if (Status.isStatusOk(result)) {
+                    expect(result.result).toBeCloseTo(expected, 1);
+                }
+            }
+        );
+
+        test('should multiply ROW, support, and vertical alignment weights for in-vehicle time', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+            delete values.byLeg[0].headwaySeconds;
+            delete values.byLeg[1].headwaySeconds;
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation with MULTIPLICATIVE weights:
+            // Access: 600
+            // Egress: 480
+            // First waiting: 600
+            // Leg 0: In-vehicle: 900 * (ROW B: 0.9 * support tires: 1.0 * vertical surface: 1.0) = 900 * 0.9 = 810
+            // Leg 1: In-vehicle: 900 * (ROW C: 1.2 * support rail: 0.85 * vertical underground: 1.05) = 900 * 1.071 = 963.9
+            //        Transfer waiting: 480, Transfer travel: 450, Transfer penalty: 300
+            // Total: 600 + 480 + 600 + 810 + 963.9 + 480 + 450 + 300 = 4683.9
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(4683.9, 1);
+            }
+        });
+
+        test('should apply load factor weight when provided', () => {
+            // Use weight = 1.0 for clearer semantics: empty = no effect, crowded = penalty
+            const customWeights = createDefaultWeights();
+            customWeights.inVehicleTravelTimeWeightForLoadFactor = 1.0;
+
+            const gcf = new GeneralizedCostFunction(customWeights);
+            const values = createDefaultValues();
+            delete values.byLeg[0].headwaySeconds;
+            delete values.byLeg[1].headwaySeconds;
+
+            // Set load factor for leg 0 (factor of 0.5 with weight 1.0 means 1.0 * (0.5 + 1.0) = 1.5 multiplier)
+            // This represents moderate crowding increasing perceived travel time by 50%
+            values.byLeg[0].loadFactor = 0.5;
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation:
+            // Leg 0 with load factor: 900 * (0.9 * 1.0 * 1.0 * 1.5) = 900 * 1.35 = 1215
+            // Leg 1 without load factor: 963.9 (unchanged)
+            // Base without headway is 4683.9, with leg 0 in-vehicle = 810
+            // Difference from load factor: 1215 - 810 = 405
+            // Total: 4683.9 + 405 = 5088.9
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(5088.9, 1);
+            }
+        });
+
+        // Invalid load factor values should be ignored (treated as 1.0 multiplier)
+        test.each([
+            { scenario: 'undefined', loadFactor: undefined },
+            { scenario: 'NaN', loadFactor: NaN },
+            { scenario: 'Infinity', loadFactor: Infinity },
+            { scenario: '-Infinity', loadFactor: -Infinity },
+            { scenario: 'negative number', loadFactor: -0.5 }
+        ])(
+            'should ignore load factor when $scenario',
+            ({ loadFactor }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                delete values.byLeg[0].headwaySeconds;
+                delete values.byLeg[1].headwaySeconds;
+                values.byLeg[0].loadFactor = loadFactor;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                // Should give the same result as the base calculation (4683.9)
+                expect(Status.isStatusOk(result)).toBe(true);
+                if (Status.isStatusOk(result)) {
+                    expect(result.result).toBeCloseTo(4683.9, 1);
+                    // Verify result is not NaN
+                    expect(Number.isFinite(result.result)).toBe(true);
+                }
+            }
+        );
+
+        test('should apply reliability ratio penalty when provided', () => {
+            const gcf = new GeneralizedCostFunction(createDefaultWeights());
+            const values = createDefaultValues();
+            delete values.byLeg[0].headwaySeconds;
+            delete values.byLeg[1].headwaySeconds;
+
+            // Set reliability ratio for both legs
+            values.byLeg[0].reliabilityRatio = 0.9; // 90% on-time
+            values.byLeg[1].reliabilityRatio = 0.85; // 85% on-time
+
+            const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+            // Manual calculation using (1 - reliabilityRatio):
+            // Base without reliability: 4683.9
+            // Unreliability penalty leg 0: 100 * (1 - 0.9) = 100 * 0.1 = 10
+            // Unreliability penalty leg 1: 100 * (1 - 0.85) = 100 * 0.15 = 15
+            // Total: 4683.9 + 10 + 15 = 4708.9
+
+            expect(Status.isStatusOk(result)).toBe(true);
+            if (Status.isStatusOk(result)) {
+                expect(result.result).toBeCloseTo(4708.9, 1);
+            }
+        });
+
+        test.each([
+            { scenario: 'undefined', reliabilityRatio: undefined },
+            { scenario: 'NaN', reliabilityRatio: NaN },
+            { scenario: 'Infinity', reliabilityRatio: Infinity },
+            { scenario: '-Infinity', reliabilityRatio: -Infinity },
+            { scenario: 'negative number', reliabilityRatio: -0.5 },
+            { scenario: 'greater than 1', reliabilityRatio: 1.5 }
+        ])(
+            'should ignore reliability ratio when $scenario',
+            ({ reliabilityRatio }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                delete values.byLeg[0].headwaySeconds;
+                delete values.byLeg[1].headwaySeconds;
+                values.byLeg[0].reliabilityRatio = reliabilityRatio;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                // Should give the same result as the base calculation (4683.9)
+                expect(Status.isStatusOk(result)).toBe(true);
+                if (Status.isStatusOk(result)) {
+                    expect(result.result).toBeCloseTo(4683.9, 1);
+                    // Verify result is not NaN
+                    expect(Number.isFinite(result.result)).toBe(true);
+                }
+            }
+        );
+
+        // Headway penalty is now simply headway * headwayPenaltyWeightByROW
+        test.each([
+            {
+                scenario: 'short headway',
+                leg0Headway: 300,
+                leg1Headway: 450,
+                // Leg 0: 300 * 0.09 = 27, Leg 1: 450 * 0.12 = 54, Total headway = 81
+                expected: 4764.9 // 4683.9 + 81
+            },
+            {
+                scenario: 'long headway',
+                leg0Headway: 900,
+                leg1Headway: 1200,
+                // Leg 0: 900 * 0.09 = 81, Leg 1: 1200 * 0.12 = 144, Total headway = 225
+                expected: 4908.9 // 4683.9 + 225
+            }
+        ])(
+            'should apply headway penalty for $scenario',
+            ({ leg0Headway, leg1Headway, expected }) => {
+                const gcf = new GeneralizedCostFunction(createDefaultWeights());
+                const values = createDefaultValues();
+                values.byLeg[0].headwaySeconds = leg0Headway;
+                values.byLeg[1].headwaySeconds = leg1Headway;
+
+                const result = gcf.calculateWeightedTravelTimeSeconds(values);
+
+                expect(Status.isStatusOk(result)).toBe(true);
+                if (Status.isStatusOk(result)) {
+                    expect(result.result).toBeCloseTo(expected, 1);
+                }
+            }
+        );
+
+    });
+});

--- a/packages/transition-backend/src/services/generalizedCostFunction/types.ts
+++ b/packages/transition-backend/src/services/generalizedCostFunction/types.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import type {
+    RightOfWayCategory,
+    Support,
+    VerticalAlignment,
+    LoadFactor,
+    ReliabilityRatio
+} from 'transition-common/lib/services/line/types';
+import type { AccessEgressTransferMode } from 'chaire-lib-common/lib/config/routingModes';
+import type { WeatherProtection } from 'transition-common/lib/services/nodes/types';
+
+/** Variables used in the generalized cost function
+ * Symbols and definitions are available at https://www.overleaf.com/read/dtxfhttxgjrx
+ * Reliability weights are implemented via `ReliabilityRatio` (per-leg value)
+ * and `reliabilityRatioPenaltyWeight` (weight).
+ * TODO: implement a real cost (money) function with values of time and fares
+ */
+export type GeneralizedCostFunctionValues = {
+    accessMode: AccessEgressTransferMode;
+    egressMode: AccessEgressTransferMode;
+    /** t_e_O: non-transit travel time to access the first boarding stop */
+    accessTravelTimeSeconds: number;
+    /** t_e_D: non-transit travel time to egress from the last alighting stop */
+    egressTravelTimeSeconds: number;
+
+    /**
+     * Array of transit legs in the route.
+     * Index starts at 0 for first transit leg.
+     */
+    byLeg: {
+        /**
+         * Weather protection at the boarding stop.
+         * TODO: implement Stop so we can get the weather protection data.
+         * A node may include many stops and thus could not have unique protection.
+         */
+        weatherProtectionAtBoardingStop: WeatherProtection;
+        /** t_veh: travel time in transit vehicle/unit, in seconds */
+        inVehicleTravelTimeSeconds: number;
+        /** t_tr: non-transit travel time between transfer stops, in seconds */
+        transferTravelTimeSeconds: number;
+        /** t_w_tr: waiting time at transfer boarding stop, in seconds */
+        waitingTimeSeconds: number;
+        /** h: headway of the line path, in seconds */
+        headwaySeconds?: number;
+        /** ROW: Right-of-way category of the line */
+        rightOfWayCategory: RightOfWayCategory;
+        /**
+         * Vertical alignment of the line.
+         * TODO: implement by path/segment
+         */
+        verticalAlignment: VerticalAlignment;
+        /** Support of the line (rail, tires, water, etc.) */
+        support: Support;
+        /** Comfort coefficient of the line (number >= 0.0) */
+        loadFactor: LoadFactor;
+        /**
+         * Reliability ratio of the line/path.
+         * Ratio of on-time arrivals/departures vs planned schedules.
+         * On-time = between 0 and 3 minutes late.
+         * Value must be between 0.0 and 1.0 (100%).
+         * Values outside this range are ignored.
+         */
+        reliabilityRatio: ReliabilityRatio;
+    }[];
+};
+
+/**
+ * Weights used in the generalized cost function.
+ *
+ * **All weights must be >= 0**:
+ * - Weight in (0, 1): reduces perceived time (e.g., productive travel)
+ * - Weight = 1: neutral (no adjustment)
+ * - Weight > 1: increases perceived time (penalty)
+ *
+ * Penalties (for transfers and headway) must also be >= 0.
+ */
+export type GeneralizedCostFunctionWeights = {
+    /** w_t_e_O: weight for the accessTravelTimeSeconds by mode */
+    accessTravelTimeWeightByMode: {
+        [mode in AccessEgressTransferMode]: number;
+    };
+    /** w_t_e_D: weight for the egressTravelTimeSeconds by mode */
+    egressTravelTimeWeightByMode: {
+        [mode in AccessEgressTransferMode]: number;
+    };
+    /** Weight for the transferTravelTimeSeconds by mode */
+    transferTravelTimeWeightByMode: {
+        [mode in AccessEgressTransferMode]: number;
+    };
+
+    /**
+     * In-vehicle travel time weights (w_t_veh).
+     * For ROW, support, vertical alignment and weather protection,
+     * the weight for the 'unknown' value must always be set (usually 1.0).
+     * If more than one of these are used together, multiply each weight
+     * before applying them to inVehicleTravelTimeSeconds.
+     */
+    /** Weight for inVehicleTravelTimeSeconds by ROW category */
+    inVehicleTravelTimeWeightByROW: Record<RightOfWayCategory, number>;
+    /**
+     * Weight for inVehicleTravelTimeSeconds by support type
+     * (rail, tires, water, suspended, magnetic, air, hover, hydrostatic)
+     */
+    inVehicleTravelTimeWeightBySupport: Record<Support, number>;
+    /** Weight for inVehicleTravelTimeSeconds by vertical alignment */
+    inVehicleTravelTimeWeightByVerticalAlignment: Record<VerticalAlignment, number>;
+    /**
+     * Weight for load factor: multiplier = weight * (loadFactor + 1).
+     * With weight = 1.0: empty vehicle has no effect, crowded doubles time.
+     * Weight < 1 can model productive travel (e.g., working on train).
+     */
+    inVehicleTravelTimeWeightForLoadFactor: number;
+
+    /**
+     * Waiting time weights (w_t_w).
+     * If you don't want/can't account for weather protection at boarding stop,
+     * set all weights to 1.0 except use the 'unknown' value as the single weight.
+     */
+    /**
+     * w_t_w_O: weight for firstWaitingTimeSeconds (leg index 0)
+     * by weather protection at boarding stop
+     */
+    firstWaitingTimeWeightByWeatherProtection: Record<WeatherProtection, number>;
+    /**
+     * Weight for waitingTimeSeconds (leg index > 0)
+     * by weather protection at boarding stop
+     */
+    waitingTimeWeightByWeatherProtection: Record<WeatherProtection, number>;
+
+    /**
+     * Penalty for each transfer (index starts at 0), in seconds.
+     * E.g., transferPenaltyByIndex[0] = penalty for first transfer.
+     * Penalty is in seconds
+     * Summed as is, no multiplier/weight applied
+     * Must be >= 0.
+     */
+    transferPenaltySecondsByIndex: number[];
+    /**
+     * Maximum penalty for transfer index > provided array length.
+     * E.g., if penalties given for index 0, 1, 2 only,
+     * transferPenaltyMax applies to transfer index 3+.
+     * Penalty is in seconds
+     * Summed as is, no multiplier/weight applied
+     * Must be >= 0.
+     */
+    transferPenaltySecondsMax: number;
+
+    /**
+     * Headway penalty weight by ROW category.
+     * Multiplied by headway in seconds.
+     * Must be >= 0.
+     */
+    headwayPenaltyWeightByROW: Record<RightOfWayCategory, number>;
+
+    /**
+     * Penalty weight for unreliability: weight * (1 - reliabilityRatio).
+     * 100% reliable (1.0) → 0 penalty, 0% reliable (0.0) → full penalty.
+     * The weight represents max penalty (in seconds) for completely unreliable service.
+     */
+    reliabilityRatioPenaltyWeight: number;
+};

--- a/packages/transition-common/src/services/line/types.ts
+++ b/packages/transition-common/src/services/line/types.ts
@@ -48,6 +48,22 @@ export type TransitMode = (typeof transitModes)[number];
 export const verticalAlignments = ['underground', 'surface', 'aerial', 'unknown'] as const;
 export type VerticalAlignment = (typeof verticalAlignments)[number];
 
+/** LoadFactor / Comfort coefficients:
+ * 0.0: empty (all seats available, no users)
+ * 0.5: good comfort (most users should be seated)
+ * 1.0: low comfort (all seats occupied, all standees areas occupied)
+ * > 1.0: very low comfort (all seats and standees areas occupied with too many people, hard to move, board or alight)
+ * undefined: used if the value is not set/unknown for the line/path/segment.
+ */
+export type LoadFactor = number | undefined;
+
+/** Reliability ratio:
+ * Ratio of on-time arrivals/departures compared to planned schedules. On-time = between 0 and 3 minutes late.
+ * Value is between 0.0 and 1.0 (100%).
+ * undefined: used if the value is not set/unknown for the line/path.
+ */
+export type ReliabilityRatio = number | undefined;
+
 /** Support
  * rail: steel on steel
  * tires: rubber tires on pavement (car, bus, etc.)


### PR DESCRIPTION
Add a new GeneralizedCostFunction class that calculates weighted travel time based on configurable weights for different transit trip components:

- Access/egress travel time with separate origin/destination weights
- In-vehicle travel time with ROW (right-of-way) category weights
- Transfer penalties based on headway frequency thresholds (high/low)
- Headway weights with optional ROW-specific values
- Context-aware frequency thresholds (urban/regional/intercity)

Includes ROWCategory type for type-safe right-of-way classification (A, B, B-, C+, C) and comprehensive value/weight type definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generalized cost calculation for transit routing that computes weighted travel times incorporating penalties for headway, reliability, transfers, and weather conditions, enabling more sophisticated transit analysis and routing optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->