### PR TITLE
New types for line (LineMode and LineCategory)

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -284,22 +284,20 @@
             "ShortnameOrLongnameIsRequired": "Either line number or name must be specified, potentially both.",
             "ModeIsRequired": "Line mode is required."
         },
-        "Category": "Right-of-way category (ROW)",
-        "categories": {
+        "ROWCategory": "Right-of-way category (ROW)",
+        "ROWcategories": {
             "A": "ROW A",
             "B": "ROW B",
-            "C+": "ROW C enhanced",
-            "C": "ROW C",
-            "B_C": "ROW B and C",
-            "non_applicable": "N/A"
+            "B-": "ROW B-",
+            "C+": "ROW C+",
+            "C": "ROW C"
         },
-        "categoriesDescription": {
+        "ROWcategoriesDescription": {
             "A": "Fully controlled separated track/lanes used exclusively by transit vehicles, priority at all time",
-            "B": "Separated track/lanes with physical barrier (fence, wall, median or step), priority at every shared intersection",
-            "C+": "On-street with mixed traffic, without physical barrier, with reserved lanes and/or priority at intersections",
-            "C": "On-street with mixed traffic, without reserved lanes and with limited or no priority at intersections",
-            "B_C": "Mix of ROW B and C",
-            "non_applicable": "Non applicable"
+            "B": "Separated track/lanes with physical barrier 100% of the distance (fence, wall, median or step), priority at every shared intersection",
+            "B-": "Separated track/lanes with physical barrier at least 50% of the distance, no non-transit turning lanes in transit ROW, some priority at shared intersections",
+            "C+": "On-street with mixed traffic, without physical barrier (or less than 50% of the distance), with reserved lanes and/or priority at intersections",
+            "C": "On-street with mixed traffic, without physical barrier (or less than 50% of the distance), without reserved lanes and with limited or no priority at intersections"
         },
         "nPath": "{{n}} path",
         "nPaths": "{{n}} paths",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -276,7 +276,6 @@
         "true": "Oui",
         "false": "Non",
         "DuplicateLine": "Dupliquer la ligne",
-        "Category": "Priorité de passage",
         "IsAutonomous": "Véhicules autonomes (sans chauffeur)",
         "AllowSameLineTransfers": "Permettre les transferts sur la même ligne",
         "errors": {
@@ -285,21 +284,20 @@
             "ShortnameOrLongnameIsRequired": "Le numéro ou le nom de la ligne doit être spécifié, ou potentiellement les deux.",
             "ModeIsRequired": "Le mode de la ligne est requis."
         },
-        "categories": {
+        "ROWCategory": "Priorité de passage",
+        "ROWcategories": {
             "A": "Catégorie A",
             "B": "Catégorie B",
-            "C+": "Catégorie C améliorée",
-            "C": "Catégorie C",
-            "B_C": "Catégorie mixte (B et C)",
-            "non_applicable": "N/A"
+            "B-": "Catégorie B-",
+            "C+": "Catégorie C+",
+            "C": "Catégorie C"
         },
-        "categoriesDescription": {
+        "ROWcategoriesDescription": {
             "A": "En site propre entièrement contrôlé et exclusif, priorité en tout temps",
             "B": "En site propre avec séparation physique (barrière, mur, terre-plein ou dénivelé) et priorité à toutes les intersections partagées",
-            "C+": "Sur rue, sans séparation physique, avec voies réservées et/ou priorités aux intersections",
-            "C": "Sur rue, sans voies réservées et avec priorité limitée ou aucune priorité aux intersections",
-            "B_C": "Catégorie mixte B et C",
-            "non_applicable": "Non applicable"
+            "B-": "En site propre avec séparation physique au moins 50% de la distance, pas de voies de virages pour les véhicules non transport collectif, priorité partielle aux intersections partagées",
+            "C+": "Sur rue, sans séparation physique (ou moins de 50% de la distance), avec voies réservées et/ou priorités aux intersections",
+            "C": "Sur rue, sans voies réservées et avec priorité limitée ou aucune priorité aux intersections"
         },
         "nPath": "{{n}} parcours",
         "nPaths": "{{n}} parcours",

--- a/packages/transition-backend/src/services/gtfsImport/LineImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/LineImporter.ts
@@ -10,10 +10,10 @@ import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import Line, { LineAttributes } from 'transition-common/lib/services/line/Line';
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
-import lineModes, { LineMode } from 'transition-common/lib/config/lineModes';
+import lineModes from 'transition-common/lib/config/lineModes';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { LineImportData, GtfsImportData, GtfsRoute } from 'transition-common/lib/services/gtfs/GtfsImportTypes';
-import { LineCategory } from 'transition-common/lib/config/lineCategories';
+import type { RightOfWayCategory, TransitMode } from 'transition-common/lib/services/line/types';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 
 import AgencyImporter from './AgencyImporter';
@@ -95,17 +95,17 @@ export class LineImporter implements GtfsObjectImporter<LineImportData, Line> {
         gtfsObject: GtfsRoute,
         options: { agencyId: string; agencyColor?: string }
     ): Partial<LineAttributes> {
-        let mode: LineMode | undefined = undefined;
+        let mode: TransitMode | undefined = undefined;
         const categoryRouteType = Math.floor(gtfsObject.route_type / 100) * 100;
         for (let i = 0, count = lineModes.length; i < count; i++) {
             const modeGtfsId = lineModes[i].gtfsId;
             const modeExtendedGtfsId = lineModes[i].extendedGtfsId;
             if (gtfsObject.route_type === modeGtfsId || gtfsObject.route_type === modeExtendedGtfsId) {
-                mode = lineModes[i].value as LineMode;
+                mode = lineModes[i].value as TransitMode;
                 break;
             } else if (categoryRouteType === modeExtendedGtfsId) {
                 // Check if the route type without units correspond to the current mode (which would be a category), but don't stop the loop. See https://developers.google.com/transit/gtfs/reference/extended-route-types for route types
-                mode = lineModes[i].value as LineMode;
+                mode = lineModes[i].value as TransitMode;
             }
         }
         if (!mode) {
@@ -126,7 +126,7 @@ export class LineImporter implements GtfsObjectImporter<LineImportData, Line> {
             lineAttributes.internal_id = gtfsObject.tr_route_internal_id;
         }
         if (gtfsObject.tr_route_row_category) {
-            lineAttributes.category = gtfsObject.tr_route_row_category as LineCategory;
+            lineAttributes.category = gtfsObject.tr_route_row_category as RightOfWayCategory;
         }
         if (gtfsObject.tr_allow_same_route_transfers) {
             lineAttributes.allow_same_line_transfers =

--- a/packages/transition-backend/src/services/importers/LinesImporter.ts
+++ b/packages/transition-backend/src/services/importers/LinesImporter.ts
@@ -9,14 +9,13 @@ import * as z from 'zod';
 import CollectionImporter, { genericAttributesSchema } from './CollectionImporter';
 import Line, { LineAttributes } from 'transition-common/lib/services/line/Line';
 import dbQueries from '../../models/db/transitLines.db.queries';
-import { lineModesArray } from 'transition-common/lib/config/lineModes';
-import { lineCategoriesArray } from 'transition-common/lib/config/lineCategories';
+import { rightOfWayCategories, transitModes } from 'transition-common/lib/services/line/types';
 import { objectsToCache } from '../../models/capnpCache/transitLines.cache.queries';
 
 const schema = genericAttributesSchema.extend({
     agency_id: z.string(),
-    mode: z.enum(lineModesArray),
-    category: z.union([z.enum(lineCategoriesArray), z.null()]).optional(),
+    mode: z.enum(transitModes),
+    category: z.union([z.enum(rightOfWayCategories), z.null()]).optional(),
     allow_same_line_transfers: z.union([z.boolean(), z.null()]).optional(),
     is_autonomous: z.union([z.boolean(), z.null()]).optional(),
     longname: z.union([z.string(), z.null()]).optional(),

--- a/packages/transition-common/src/config/lineCategories.ts
+++ b/packages/transition-common/src/config/lineCategories.ts
@@ -1,8 +1,0 @@
-/*
- * Copyright 2022, Polytechnique Montreal and contributors
- *
- * This file is licensed under the MIT License.
- * License text available at https://opensource.org/licenses/MIT
- */
-export const lineCategoriesArray = ['C', 'C+', 'B', 'A', 'B_C', 'non_applicable'] as const;
-export type LineCategory = (typeof lineCategoriesArray)[number];

--- a/packages/transition-common/src/config/lineModes.ts
+++ b/packages/transition-common/src/config/lineModes.ts
@@ -6,31 +6,11 @@
  */
 // See https://developers.google.com/transit/gtfs/reference/extended-route-types
 
-export const lineModesArray = [
-    'bus',
-    'trolleybus',
-    'rail',
-    'highSpeedRail',
-    'metro',
-    'monorail',
-    'tram',
-    'tramTrain',
-    'water',
-    'gondola',
-    'funicular',
-    'taxi',
-    'cableCar',
-    'horse',
-    'other',
-    'transferable'
-] as const;
-
-/** An enumeration of line modes */
-export type LineMode = (typeof lineModesArray)[number];
+import type { TransitMode } from '../services/line/types';
 
 export default [
     {
-        value: 'bus',
+        value: 'bus' as TransitMode,
         extendedGtfsId: 700,
         gtfsId: 3,
         defaultValues: {
@@ -49,7 +29,7 @@ export default [
         compatibleRoutingModes: ['driving', 'driving_congestion', 'bus_suburb', 'bus_urban', 'bus_congestion']
     },
     {
-        value: 'trolleybus',
+        value: 'trolleybus' as TransitMode,
         extendedGtfsId: 800,
         gtfsId: 11,
         defaultValues: {
@@ -67,7 +47,7 @@ export default [
         compatibleRoutingModes: ['driving', 'driving_congestion', 'bus_suburb', 'bus_urban', 'bus_congestion']
     },
     {
-        value: 'rail',
+        value: 'rail' as TransitMode,
         extendedGtfsId: 100,
         gtfsId: 2,
         defaultValues: {
@@ -85,7 +65,7 @@ export default [
         compatibleRoutingModes: ['rail']
     },
     {
-        value: 'highSpeedRail',
+        value: 'highSpeedRail' as TransitMode,
         extendedGtfsId: 101,
         gtfsId: 2,
         defaultValues: {
@@ -103,7 +83,7 @@ export default [
         compatibleRoutingModes: ['rail', 'high_speed_rail']
     },
     {
-        value: 'metro',
+        value: 'metro' as TransitMode,
         extendedGtfsId: 400,
         gtfsId: 1,
         defaultValues: {
@@ -121,7 +101,7 @@ export default [
         compatibleRoutingModes: ['rail', 'metro']
     },
     {
-        value: 'monorail',
+        value: 'monorail' as TransitMode,
         extendedGtfsId: 405,
         gtfsId: 12,
         defaultValues: {
@@ -139,7 +119,7 @@ export default [
         compatibleRoutingModes: ['monorail']
     },
     {
-        value: 'tram',
+        value: 'tram' as TransitMode,
         extendedGtfsId: 900,
         gtfsId: 0,
         defaultValues: {
@@ -157,7 +137,7 @@ export default [
         compatibleRoutingModes: ['tram', 'tram_train', 'rail']
     },
     {
-        value: 'tramTrain',
+        value: 'tramTrain' as TransitMode,
         extendedGtfsId: 900,
         gtfsId: 0,
         defaultValues: {
@@ -175,7 +155,7 @@ export default [
         compatibleRoutingModes: ['tram', 'tram_train', 'rail']
     },
     {
-        value: 'water',
+        value: 'water' as TransitMode,
         extendedGtfsId: 1000,
         gtfsId: 4,
         defaultValues: {
@@ -193,7 +173,7 @@ export default [
         compatibleRoutingModes: []
     },
     {
-        value: 'gondola',
+        value: 'gondola' as TransitMode,
         extendedGtfsId: 1300,
         gtfsId: 6,
         defaultValues: {
@@ -212,7 +192,7 @@ export default [
         compatibleRoutingModes: []
     },
     {
-        value: 'funicular',
+        value: 'funicular' as TransitMode,
         extendedGtfsId: 1400,
         gtfsId: 7,
         defaultValues: {
@@ -231,7 +211,7 @@ export default [
         compatibleRoutingModes: []
     },
     {
-        value: 'taxi',
+        value: 'taxi' as TransitMode,
         extendedGtfsId: 1500,
         gtfsId: 3,
         defaultValues: {
@@ -249,7 +229,7 @@ export default [
         compatibleRoutingModes: ['driving', 'driving_congestion']
     },
     {
-        value: 'cableCar',
+        value: 'cableCar' as TransitMode,
         extendedGtfsId: 1701,
         gtfsId: 5,
         defaultValues: {
@@ -267,7 +247,7 @@ export default [
         compatibleRoutingModes: ['cable_car']
     },
     {
-        value: 'horse',
+        value: 'horse' as TransitMode,
         extendedGtfsId: 1702,
         gtfsId: 3,
         defaultValues: {
@@ -285,7 +265,7 @@ export default [
         compatibleRoutingModes: ['horse', 'walking']
     },
     {
-        value: 'other',
+        value: 'other' as TransitMode,
         extendedGtfsId: 1700,
         gtfsId: 3,
         defaultValues: {
@@ -303,7 +283,7 @@ export default [
         compatibleRoutingModes: ['walking', 'cycling', 'driving', 'driving_congestion']
     },
     {
-        value: 'transferable',
+        value: 'transferable' as TransitMode,
         defaultValues: {
             data: {
                 routingMode: null,

--- a/packages/transition-common/src/services/line/Line.ts
+++ b/packages/transition-common/src/services/line/Line.ts
@@ -16,8 +16,8 @@ import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import lineModes, { LineMode } from '../../config/lineModes';
-import { LineCategory } from '../../config/lineCategories';
+import lineModes from '../../config/lineModes';
+import type { RightOfWayCategory, TransitMode } from './types';
 import { GenericAttributes } from 'chaire-lib-common/lib/utils/objects/GenericObject';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import routingServiceManager from 'chaire-lib-common/lib/services/routing/RoutingServiceManager';
@@ -34,13 +34,13 @@ for (let i = 0, countI = lineModes.length; i < countI; i++) {
 
 export interface LineAttributes extends GenericAttributes {
     agency_id: string;
-    mode: LineMode;
+    mode: TransitMode;
     path_ids: string[];
     /** Array of service IDs for which there are lines in the database. This
      * should be present in lines coming from a collection query, but the
      * schedulesByServiceId should be used for line objects */
     service_ids?: string[];
-    category: LineCategory;
+    category: RightOfWayCategory; // TODO: allow distinct paths and segments to have a different ROW category
     allow_same_line_transfers: boolean;
     is_autonomous: boolean;
     longname: string;

--- a/packages/transition-common/src/services/line/types.ts
+++ b/packages/transition-common/src/services/line/types.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+/**
+ * Right-of-way categories:
+ * ROW A: Fully controlled separated track/lanes used exclusively by transit vehicles, priority at all time
+ * ROW B: Separated track/lanes with physical barrier 100% of the distance (fence, wall, median or step), priority at every shared intersection
+ * ROW B-: Separated track/lanes with physical barrier at least 50% of the distance, no non-transit turning lanes in transit ROW, some priority at shared intersections
+ * ROW C+: On-street with mixed traffic, without physical barrier (or less than 50% of the distance), with reserved lanes and/or priority at intersections
+ * ROW C: On-street with mixed traffic, without physical barrier (or less than 50% of the distance), without reserved lanes and with limited or no priority at intersections
+ */
+export const rightOfWayCategories = ['A', 'B', 'B-', 'C+', 'C'] as const;
+export type RightOfWayCategory = (typeof rightOfWayCategories)[number];
+
+// Transit modes:
+export const transitModes = [
+    'bus',
+    'trolleybus',
+    'rail',
+    'highSpeedRail',
+    'metro',
+    'monorail',
+    'tram',
+    'tramTrain',
+    'water',
+    'gondola',
+    'funicular',
+    'taxi',
+    'cableCar',
+    'horse',
+    'other',
+    'transferable'
+] as const;
+
+/** An enumeration of transit modes */
+export type TransitMode = (typeof transitModes)[number];

--- a/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/line/TransitLineEdit.tsx
@@ -18,7 +18,7 @@ import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/I
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { getAutocompleteListFromObjectCollection } from 'chaire-lib-frontend/lib/services/autoCompleteNextService';
 import lineModes from 'transition-common/lib/config/lineModes';
-import { lineCategoriesArray } from 'transition-common/lib/config/lineCategories';
+import { rightOfWayCategories } from 'transition-common/lib/services/line/types';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Path from 'transition-common/lib/services/path/Path';
 import Line from 'transition-common/lib/services/line/Line';
@@ -47,7 +47,7 @@ interface LineFormState extends SaveableObjectState<Line> {
     lineNumberAutocompleteChoices: string[];
 }
 
-const lineCategories = lineCategoriesArray.map((cat) => ({ value: cat }));
+const lineCategories = rightOfWayCategories.map((cat) => ({ value: cat }));
 
 class TransitLineEdit extends SaveableObjectForm<Line, LineFormProps, LineFormState> {
     constructor(props: LineFormProps) {
@@ -288,13 +288,13 @@ class TransitLineEdit extends SaveableObjectForm<Line, LineFormProps, LineFormSt
                             />
                         </div>
                         <div className="apptr__form-input-container _two-columns">
-                            <label>{this.props.t('transit:transitLine:Category')}</label>
+                            <label>{this.props.t('transit:transitLine:ROWCategory')}</label>
                             <InputSelect
                                 id={`formFieldTransitLineEditCategory${lineId}`}
                                 disabled={isFrozen}
                                 value={line.attributes.category || ''}
                                 choices={lineCategories}
-                                localePrefix="transit:transitLine:categories"
+                                localePrefix="transit:transitLine:ROWcategories"
                                 t={this.props.t}
                                 onValueChange={(e) => this.onValueChange('category', { value: e.target.value })}
                             />

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLines.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitLines.tsx
@@ -11,7 +11,8 @@ import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton'
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputColor from 'chaire-lib-frontend/lib/components/input/InputColor';
 import PreferencesSectionProps from '../PreferencesSectionProps';
-import lineModesConfig, { lineModesArray } from 'transition-common/lib/config/lineModes';
+import lineModesConfig from 'transition-common/lib/config/lineModes';
+import { transitModes } from 'transition-common/lib/services/line/types';
 import PreferencesSectionTransitLineMode from './PreferencesSectionTransitLineMode';
 
 const lineModesConfigByMode = {};
@@ -25,7 +26,7 @@ const PreferencesSectionTransitLines: React.FunctionComponent<PreferencesSection
 ) => {
     const prefs = props.preferences.attributes;
 
-    const lineModesDefaultValuesPrefs = lineModesArray.map((mode) => {
+    const lineModesDefaultValuesPrefs = transitModes.map((mode) => {
         return (
             <PreferencesSectionTransitLineMode
                 key={mode}


### PR DESCRIPTION
Rename LineMode to TransitMode, which is more precise and more generic. Move LineMode to packages/transition-common/src/services/line/types.ts and update the imports.

Rename LineCategory to RightOfWayCategory, which is the correct name. Move LineCategory to packages/transition-common/src/services/line/types.ts and update the imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a B- transit line category describing intermediate right-of-way barrier coverage.

* **Updates**
  * Renamed category labels to ROWCategory / ROWcategories / ROWcategoriesDescription in UI/locales.
  * Revised and clarified right-of-way descriptions for A, B, B-, C+, and C with explicit separation/priority wording.
  * Removed legacy categories B_C and non_applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->