### PR TITLE
batch routing: decouple execution from file generation

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrAccessibilityMapBatch.ts
@@ -180,7 +180,6 @@ export const batchAccessibilityMap = async (
         Object.assign(files, resultProcessor.getFiles());
 
         return {
-            detailed: parameters.detailed,
             completed: true,
             errors: [],
             warnings: errors,
@@ -189,7 +188,6 @@ export const batchAccessibilityMap = async (
     } catch (error) {
         if (Array.isArray(error)) {
             return {
-                detailed: false,
                 completed: false,
                 errors: error,
                 warnings: [],

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -198,7 +198,6 @@ export class TrRoutingBatchExecutor {
 
             return {
                 completed: true,
-                detailed: false,
                 errors: [],
                 warnings: this.errors
             };
@@ -206,7 +205,6 @@ export class TrRoutingBatchExecutor {
             if (Array.isArray(error)) {
                 console.log('Multiple errors in batch route calculations for job %d', this.job.id);
                 return {
-                    detailed: false,
                     completed: false,
                     errors: error,
                     warnings: []

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
@@ -162,7 +162,6 @@ test('3 locations, all successful', async() => {
     mockedParseLocations.mockResolvedValue({ locations, errors: [] });
     const result = await batchAccessibilityMap(mockedJob, progressEmitter, isCancelledMock);
     expect(result).toEqual({
-        detailed: mockJobAttributes.data.parameters.batchAccessMapAttributes.detailed,
         completed: true,
         errors: [],
         warnings: [],
@@ -186,7 +185,6 @@ test('3 locations, error on first', async() => {
     mockedCalculateWithPolygon.mockRejectedValueOnce('Some error occurred');
     const result = await batchAccessibilityMap(mockedJob, progressEmitter, isCancelledMock);
     expect(result).toEqual(expect.objectContaining({
-        detailed: mockJobAttributes.data.parameters.batchAccessMapAttributes.detailed,
         completed: true,
         errors: []
     }));

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -199,7 +199,6 @@ describe('batchRoute function', () => {
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
         expect(mockCreateFileStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
-            detailed: false,
             completed: true,
             errors: [],
             warnings: [],
@@ -266,7 +265,6 @@ describe('batchRoute function', () => {
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
         expect(mockCreateFileStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
-            detailed: false,
             completed: true,
             errors: [],
             warnings: [],
@@ -282,7 +280,6 @@ describe('batchRoute function', () => {
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length);
         expect(mockCreateFileStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
-            detailed: false,
             completed: true,
             errors: [],
             warnings: errors,
@@ -315,7 +312,6 @@ describe('batchRoute function', () => {
         expect(routeOdTripMock).toHaveBeenCalledTimes(0);
         expect(mockCreateFileStream).toHaveBeenCalledTimes(0);
         expect(result).toEqual({
-            detailed: false,
             completed: false,
             errors,
             warnings: [],
@@ -369,7 +365,6 @@ describe('TrRoutingBatchExecutor', () => {
         // Make sure result is successful
         expect(result).toEqual({
             completed: true,
-            detailed: false,
             errors: [],
             warnings: []
         });
@@ -423,7 +418,6 @@ describe('Batch route from checkpoint', () => {
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length - currentCheckpoint);
         expect(mockCreateFileStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
-            detailed: false,
             completed: true,
             errors: [],
             warnings: [],
@@ -446,7 +440,6 @@ describe('Batch route from checkpoint', () => {
         expect(routeOdTripMock).toHaveBeenCalledTimes(odTrips.length - currentCheckpoint);
         expect(mockCreateFileStream).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
-            detailed: false,
             completed: true,
             errors: [],
             warnings: [],

--- a/packages/transition-common/src/services/batchCalculation/types.ts
+++ b/packages/transition-common/src/services/batchCalculation/types.ts
@@ -57,7 +57,7 @@ export type BatchCalculationParameters = {
 } & TransitRoutingQueryAttributes;
 
 export interface TransitBatchCalculationResult {
-    detailed: boolean;
+    /** Whether the task is successfully completed or not */
     completed: boolean;
     warnings: ErrorMessage[];
     errors: ErrorMessage[];


### PR DESCRIPTION
fixes #1724

Rename the `TrRoutingBatch` class to `TrRoutingBatchExecutor` and export
it. This class's responsibility is only to execute the calculation, with
the results saved to the database. It does not generate the files.

The result file generation is moved to the `batchRoute` function, which
is the one called by the worker when a job of type `batchRoute` is
requested.

Also drop the `detailed` property from batch route result type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced `detailed` flag with `completed` in batch calculation results to more clearly indicate success.
  * Removed stray `detailed` property from accessibility map batch responses.

* **Refactor**
  * Reworked batch routing execution and result handling for clearer, more consistent outcomes; partial runs now return minimal file references while completed runs include merged generated files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->