### PR TITLE
Feat/display on map the paths used by a service

### DIFF
--- a/packages/transition-frontend/src/config/layers.config.ts
+++ b/packages/transition-frontend/src/config/layers.config.ts
@@ -40,6 +40,7 @@ export const sectionLayers = {
         'transitNodesSelected'
     ],
     scenarios: ['transitPathsForServices'],
+    services: ['transitPathsForServices'],
     routing: [
         'aggregatedOD' /*'transitPaths', 'transitNodes', 'transitStations', */,
         'routingPathsStrokes',


### PR DESCRIPTION
 In the services section, the map now updates  to display the available lines when editing a service ✏️

Fixes #1399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transit path visualization in the transit service editor so route paths appear on the map for easier route management.
  * Automatic map-layer lifecycle: service paths load when the editor opens and are cleared when it closes to keep the map state consistent.
  * Services map layer exposed to support these transit path displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->