### PR TITLE
Replace ill-named ErrorMessage

### DIFF
--- a/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/RoutingResult.ts
@@ -7,7 +7,8 @@
 import Preferences from '../../config/Preferences';
 import { Route } from './RoutingService';
 import { RoutingOrTransitMode, RoutingMode } from '../../config/routingModes';
-import TrError, { ErrorMessage } from '../../utils/TrError';
+import TrError from '../../utils/TrError';
+import { TranslatableMessage } from '../../utils/TranslatableMessage';
 import { TrRoutingRoute } from '../transitRouting/types';
 
 export const pathIsRoute = (path: Route | TrRoutingRoute | undefined): path is Route => {
@@ -51,7 +52,7 @@ export interface UnimodalRoutingResultData {
     origin: GeoJSON.Feature<GeoJSON.Point>;
     destination: GeoJSON.Feature<GeoJSON.Point>;
     paths: Route[];
-    error?: { localizedMessage: ErrorMessage; error: string; errorCode: string };
+    error?: { localizedMessage: TranslatableMessage; error: string; errorCode: string };
 }
 
 /**

--- a/packages/chaire-lib-common/src/services/routing/TransitRoutingResult.ts
+++ b/packages/chaire-lib-common/src/services/routing/TransitRoutingResult.ts
@@ -11,7 +11,8 @@ import { TrRoutingV2 } from '../../api/TrRouting';
 import { TrRoutingRoute } from '../transitRouting/types';
 import { Route, RouteResults } from './RoutingService';
 import { getRouteByMode } from './RoutingUtils';
-import TrError, { ErrorMessage } from '../../utils/TrError';
+import TrError from '../../utils/TrError';
+import { TranslatableMessage } from '../../utils/TranslatableMessage';
 import { RoutingResult } from './RoutingResult';
 import { RoutingOrTransitMode } from '../../config/routingModes';
 
@@ -41,7 +42,7 @@ export interface TransitRoutingResultData {
     destination: GeoJSON.Feature<GeoJSON.Point>;
     paths: TrRoutingRoute[];
     walkOnlyPath?: Route;
-    error?: { localizedMessage: ErrorMessage; error: string; errorCode: string };
+    error?: { localizedMessage: TranslatableMessage; error: string; errorCode: string };
 }
 
 export type SegmentToGeoJSON = (

--- a/packages/chaire-lib-common/src/utils/TrError.ts
+++ b/packages/chaire-lib-common/src/utils/TrError.ts
@@ -4,24 +4,17 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-export interface ErrorMessageWithParams {
-    text: string;
-    params: {
-        [key: string]: string;
-    };
-}
-
-export type ErrorMessage = string | ErrorMessageWithParams;
+import { TranslatableMessage } from './TranslatableMessage';
 
 export default class TrError extends Error {
     private code: string;
-    private localizedMessage: ErrorMessage;
+    private localizedMessage: TranslatableMessage;
 
     static isTrError(error: any): error is TrError {
         return error.code && typeof error.getCode === 'function' && typeof error.export === 'function';
     }
 
-    constructor(message: string, code: string, localizedError: ErrorMessage = '') {
+    constructor(message: string, code: string, localizedError: TranslatableMessage = '') {
         super(message);
 
         // see https://medium.com/@xjamundx/custom-javascript-errors-in-es6-aa891b173f87

--- a/packages/chaire-lib-common/src/utils/TranslatableMessage.ts
+++ b/packages/chaire-lib-common/src/utils/TranslatableMessage.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+/**
+ * A message that can be translated using i18next, consisting of a translation
+ * key and parameters to interpolate into the translated string.
+ * @typedef {Object} TranslatableMessageWithParams
+ * @property {string} text - The i18next translation key.
+ * @property {Object.<string, string>} params - Vals to interpolate into the string.
+ */
+export type TranslatableMessageWithParams = {
+    text: string;
+    params: {
+        [key: string]: string;
+    };
+};
+
+/**
+ * A translatable message for use with i18next. Either a plain translation key
+ * or an object containing a key with interpolation parameters.
+ * @typedef {string | TranslatableMessageWithParams} TranslatableMessage
+ */
+export type TranslatableMessage = string | TranslatableMessageWithParams;

--- a/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/RegisterForm.tsx
+++ b/packages/chaire-lib-frontend/src/components/forms/auth/localLogin/RegisterForm.tsx
@@ -8,7 +8,7 @@ import { Action } from 'redux';
 import { startRegisterWithPassword } from '../../../../actions/Auth';
 import Button from '../../../input/Button';
 import FormErrors from '../../../pageParts/FormErrors';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import CaptchaComponent from '../../../captcha/CaptchaComponent';
 import { _isEmail } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { RootState } from '../../../../store/configureStore';
@@ -26,7 +26,7 @@ type FormState = {
     passwordConfirmation: string;
     captchaValid: boolean;
     captchaReloadKey: number;
-    error?: ErrorMessage;
+    error?: TranslatableMessage;
 };
 
 const RegisterForm: React.FC<RegisterFormProps> = ({
@@ -60,7 +60,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({
         }));
     };
 
-    const validateForm = (): ErrorMessage | undefined => {
+    const validateForm = (): TranslatableMessage | undefined => {
         if (!withEmailOnly && !formState.username) {
             return 'auth:missingUsername';
         }

--- a/packages/chaire-lib-frontend/src/components/pageParts/FormErrors.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/FormErrors.tsx
@@ -10,10 +10,10 @@ import { useTranslation } from 'react-i18next';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 export type FormErrorsProps = {
-    errors: ErrorMessage[];
+    errors: TranslatableMessage[];
     errorType?: 'Warning' | 'Error';
 };
 

--- a/packages/chaire-lib-frontend/src/components/pages/ForgotPasswordPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/ForgotPasswordPage.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 import { startForgotPasswordRequest } from '../../actions/Auth';
 import Button, { ButtonProps } from '../input/Button';
 import FormErrors from '../pageParts/FormErrors';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { RootState } from '../../store/configureStore';
 import { Action } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -32,10 +32,10 @@ const ForgotPasswordPage: React.FC<ForgotPasswordPageProps> = () => {
 
     const [formState, setFormState] = React.useState({
         email: '',
-        error: undefined as ErrorMessage | undefined
+        error: undefined as TranslatableMessage | undefined
     });
 
-    const validateEmail = (email: string): ErrorMessage | undefined => {
+    const validateEmail = (email: string): TranslatableMessage | undefined => {
         if (!email) {
             return 'auth:missingEmail';
         }

--- a/packages/chaire-lib-frontend/src/components/pages/ResetPasswordPage.tsx
+++ b/packages/chaire-lib-frontend/src/components/pages/ResetPasswordPage.tsx
@@ -6,7 +6,7 @@ import { Link, useParams } from 'react-router';
 import Button, { ButtonProps } from '../input/Button';
 import FormErrors from '../pageParts/FormErrors';
 import { startResetPassword } from '../../actions/Auth';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { RootState } from '../../store/configureStore';
 import { ThunkDispatch } from 'redux-thunk';
 import { Action } from 'redux';
@@ -43,7 +43,7 @@ const ResetPasswordPage: React.FC = () => {
     const [formState, setFormState] = React.useState({
         password: '',
         passwordConfirmation: '',
-        error: undefined as ErrorMessage | undefined
+        error: undefined as TranslatableMessage | undefined
     });
 
     React.useEffect(() => {
@@ -63,7 +63,7 @@ const ResetPasswordPage: React.FC = () => {
         return () => document.removeEventListener('keydown', handleKeyPress);
     }, []);
 
-    const validateForm = (): ErrorMessage | undefined => {
+    const validateForm = (): TranslatableMessage | undefined => {
         if (!formState.password) {
             return t('auth:missingPassword');
         }

--- a/packages/transition-backend/src/api/odPairs.socketRoutes.ts
+++ b/packages/transition-backend/src/api/odPairs.socketRoutes.ts
@@ -8,7 +8,8 @@ import { EventEmitter } from 'events';
 
 import odPairsQueries from '../models/db/odPairs.db.queries';
 import { BaseOdTripAttributes } from 'transition-common/lib/services/odTrip/BaseOdTrip';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 /**
  * Add routes specific to od pairs
@@ -24,7 +25,7 @@ export default function (socket: EventEmitter) {
             callback: (
                 response:
                     | { collection: BaseOdTripAttributes[] }
-                    | { error: string; errorCode?: string; localizedMessage?: ErrorMessage }
+                    | { error: string; errorCode?: string; localizedMessage?: TranslatableMessage }
             ) => void
         ) => {
             try {

--- a/packages/transition-backend/src/services/accessMapLocation/AccessMapLocationProvider.ts
+++ b/packages/transition-backend/src/services/accessMapLocation/AccessMapLocationProvider.ts
@@ -18,7 +18,8 @@ import {
     intTimeToSecondsSinceMidnight
 } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import constants from 'chaire-lib-common/lib/config/constants';
 
 export interface accessMapLocationOptions {
@@ -83,7 +84,7 @@ const extractLocation = (
 };
 
 const MAX_ERROR = 10;
-const addError = (errors: ErrorMessage[], error: unknown, nbErrors: number, rowNumber: number) => {
+const addError = (errors: TranslatableMessage[], error: unknown, nbErrors: number, rowNumber: number) => {
     if (nbErrors < MAX_ERROR) {
         if (TrError.isTrError(error)) {
             errors.push({
@@ -117,11 +118,11 @@ const parseLocationsFromCsvInternal = async (
     csvStream: NodeJS.ReadableStream,
     options: accessMapLocationOptions,
     progressEmitter?: EventEmitter
-): Promise<{ locations: AccessibilityMapLocation[]; errors: ErrorMessage[] }> => {
+): Promise<{ locations: AccessibilityMapLocation[]; errors: TranslatableMessage[] }> => {
     const locations: AccessibilityMapLocation[] = [];
     const projections = Preferences.get('proj4Projections');
     let nbErrors = 0;
-    const errors: ErrorMessage[] = [];
+    const errors: TranslatableMessage[] = [];
 
     const projection =
         projections[options.projection] !== undefined
@@ -183,7 +184,7 @@ export const parseLocationsFromCsv = async (
     csvFilePath: string,
     options: accessMapLocationOptions,
     progressEmitter?: EventEmitter
-): Promise<{ locations: AccessibilityMapLocation[]; errors: ErrorMessage[] }> => {
+): Promise<{ locations: AccessibilityMapLocation[]; errors: TranslatableMessage[] }> => {
     console.log(`parsing csv file ${csvFilePath}...`);
 
     // Check if file exists
@@ -216,6 +217,6 @@ export const parseLocationsFromCsvStream = async (
     csvFileStream: NodeJS.ReadableStream,
     options: accessMapLocationOptions,
     progressEmitter?: EventEmitter
-): Promise<{ locations: AccessibilityMapLocation[]; errors: ErrorMessage[] }> => {
+): Promise<{ locations: AccessibilityMapLocation[]; errors: TranslatableMessage[] }> => {
     return parseLocationsFromCsvInternal(csvFileStream, options, progressEmitter);
 };

--- a/packages/transition-backend/src/services/gtfsImport/GtfsImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/GtfsImporter.ts
@@ -12,7 +12,7 @@ import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection'
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
 import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollection';
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
 import AgencyImporter from './AgencyImporter';
 import ServiceImporter from './ServiceImporter';
@@ -44,8 +44,8 @@ const importGtfsData = async (
     parameters: GtfsImportData,
     progressEmitter?: EventEmitter
 ): Promise<
-    | { status: 'success'; warnings: ErrorMessage[]; errors: ErrorMessage[]; nodesDirty: boolean }
-    | { status: 'failed'; errors: ErrorMessage[]; nodesDirty: boolean }
+    | { status: 'success'; warnings: TranslatableMessage[]; errors: TranslatableMessage[]; nodesDirty: boolean }
+    | { status: 'failed'; errors: TranslatableMessage[]; nodesDirty: boolean }
 > => {
     // initialize collection and add them to collection manager, they will be loaded when required
     const lineCollection = new LineCollection([], {});

--- a/packages/transition-backend/src/services/gtfsImport/PathImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/PathImporter.ts
@@ -9,7 +9,7 @@ import type * as GtfsTypes from 'gtfs-types';
 import pQueue from 'p-queue';
 import _isEqual from 'lodash/isEqual';
 
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import Line from 'transition-common/lib/services/line/Line';
 import Path from 'transition-common/lib/services/path/Path';
 import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
@@ -41,10 +41,10 @@ const generateAndImportPaths = async (
     importData: GtfsInternalData,
     collectionManager: any
 ): Promise<
-    | { status: 'success'; pathIdsByTripId: { [key: string]: string }; warnings: ErrorMessage[] }
-    | { status: 'failed'; errors: ErrorMessage[] }
+    | { status: 'success'; pathIdsByTripId: { [key: string]: string }; warnings: TranslatableMessage[] }
+    | { status: 'failed'; errors: TranslatableMessage[] }
 > => {
-    let allWarnings: ErrorMessage[] = [];
+    let allWarnings: TranslatableMessage[] = [];
     const pathIdsByTripId = {};
 
     try {
@@ -106,8 +106,8 @@ const generatePathsForLine = (
     tripsForLine: { trip: GtfsTypes.Trip; stopTimes: StopTime[] }[],
     pathIdByTripId: { [key: string]: string },
     importData: GtfsInternalData
-): { paths: Path[]; warnings: ErrorMessage[]; pathByTripId: { [key: string]: string } } => {
-    let allWarnings: ErrorMessage[] = [];
+): { paths: Path[]; warnings: TranslatableMessage[]; pathByTripId: { [key: string]: string } } => {
+    let allWarnings: TranslatableMessage[] = [];
     const newPaths: Path[] = [];
     const pathByShapeId: { [key: string]: Path[] } = {};
     const pathsWithoutShape: Path[] = [];
@@ -176,7 +176,7 @@ const generatePathFromShape = (
     shapeGtfsId: string,
     nodeIds: string[],
     importData: GtfsInternalData
-): { newPath: Path; warnings: ErrorMessage[] } => {
+): { newPath: Path; warnings: TranslatableMessage[] } => {
     const gtfsDirectionId = trip.direction_id || 0;
     const pathName = trip.trip_headsign;
     const direction = gtfsDirectionId === 0 ? 'outbound' : 'inbound';
@@ -204,7 +204,7 @@ const generatePathWithoutShape = (
     stopTimes: StopTime[],
     nodeIds: string[],
     importData: GtfsInternalData
-): { newPath: Path; warnings: ErrorMessage[] } => {
+): { newPath: Path; warnings: TranslatableMessage[] } => {
     const gtfsDirectionId = trip.direction_id || 0;
     const pathName = trip.trip_headsign;
     const direction = gtfsDirectionId === 0 ? 'outbound' : 'inbound';

--- a/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
@@ -9,7 +9,7 @@ import type * as GtfsTypes from 'gtfs-types';
 import { v4 as uuidV4 } from 'uuid';
 import _cloneDeep from 'lodash/cloneDeep';
 import pQueue from 'p-queue';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { hoursToSeconds, secondsSinceMidnightToTimeStr } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
 import { GtfsInternalData, StopTime, Frequencies, Period } from './GtfsImportTypes';
@@ -109,8 +109,10 @@ const generateAndImportSchedules = async (
     importData: GtfsInternalData,
     collectionManager: CollectionManager,
     generateFrequencyBasedSchedules = false
-): Promise<{ status: 'success'; warnings: ErrorMessage[] } | { status: 'failed'; errors: ErrorMessage[] }> => {
-    const warnings: string[] = [];
+): Promise<
+    { status: 'success'; warnings: TranslatableMessage[] } | { status: 'failed'; errors: TranslatableMessage[] }
+> => {
+    const warnings: TranslatableMessage[] = [];
 
     const gtfsLineIds = Object.keys(tripByGtfsLineId);
     const promiseQueue = new pQueue({ concurrency: 1 });

--- a/packages/transition-backend/src/services/odTrip/odTripProvider.ts
+++ b/packages/transition-backend/src/services/odTrip/odTripProvider.ts
@@ -18,7 +18,8 @@ import {
     intTimeToSecondsSinceMidnight
 } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import constants from 'chaire-lib-common/lib/config/constants';
 import { TransitDemandFromCsvRoutingAttributes } from 'transition-common/lib/services/transitDemand/types';
 
@@ -113,7 +114,7 @@ const extractOdTrip = (
 };
 
 const MAX_ERROR = 10;
-const addError = (errors: ErrorMessage[], error: unknown, nbErrors: number, rowNumber: number) => {
+const addError = (errors: TranslatableMessage[], error: unknown, nbErrors: number, rowNumber: number) => {
     if (nbErrors < MAX_ERROR) {
         if (TrError.isTrError(error)) {
             errors.push({
@@ -146,11 +147,11 @@ const parseOdTripsFromCsvInternal = async (
     csvStream: NodeJS.ReadableStream,
     options: OdTripCsvMapping,
     progressEmitter?: EventEmitter
-): Promise<{ odTrips: BaseOdTrip[]; errors: ErrorMessage[] }> => {
+): Promise<{ odTrips: BaseOdTrip[]; errors: TranslatableMessage[] }> => {
     const odTrips: BaseOdTrip[] = [];
     const projections = Preferences.get('proj4Projections');
     let nbErrors = 0;
-    const errors: ErrorMessage[] = [];
+    const errors: TranslatableMessage[] = [];
 
     const projection =
         projections[options.projection] !== undefined
@@ -212,7 +213,7 @@ export const parseOdTripsFromCsv = async (
     csvFilePath: string,
     options: OdTripCsvMapping,
     progressEmitter?: EventEmitter
-): Promise<{ odTrips: BaseOdTrip[]; errors: ErrorMessage[] }> => {
+): Promise<{ odTrips: BaseOdTrip[]; errors: TranslatableMessage[] }> => {
     console.log(`parsing csv file ${csvFilePath}...`);
 
     // Check if file exists
@@ -245,6 +246,6 @@ export const parseOdTripsFromCsvStream = async (
     csvFileStream: NodeJS.ReadableStream,
     options: OdTripCsvMapping,
     progressEmitter?: EventEmitter
-): Promise<{ odTrips: BaseOdTrip[]; errors: ErrorMessage[] }> => {
+): Promise<{ odTrips: BaseOdTrip[]; errors: TranslatableMessage[] }> => {
     return parseOdTripsFromCsvInternal(csvFileStream, options, progressEmitter);
 };

--- a/packages/transition-backend/src/services/path/PathGtfsGeographyGenerator.ts
+++ b/packages/transition-backend/src/services/path/PathGtfsGeographyGenerator.ts
@@ -9,7 +9,7 @@ import type * as GtfsTypes from 'gtfs-types';
 import { Path, TimeAndDistance } from 'transition-common/lib/services/path/Path';
 import { StopTime } from '../gtfsImport/GtfsImportTypes';
 import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import {
     length as turfLength,
     cleanCoords as turfCleanCoords,
@@ -204,11 +204,11 @@ export const generateGeographyAndSegmentsFromGtfs = (
     stopCoordinatesByStopId: { [key: string]: [number, number] },
     defaultLayoverRatioOverTotalTravelTime = 0.1,
     defaultMinLayoverTimeSeconds = 180
-): ErrorMessage[] => {
+): TranslatableMessage[] => {
     path.attributes.nodes = nodeIds; // reset nodes, they will be regenerated from stop times
 
     // Return errors when generating the path
-    const errors: ErrorMessage[] = [];
+    const errors: TranslatableMessage[] = [];
     if (!shapeCoordinatesWithDistances || !shapeCoordinatesWithDistances[0]) {
         path.setData('gtfs', { shape_id: shapeGtfsId });
         path.set('geography', null);
@@ -501,11 +501,11 @@ export const generateGeographyAndSegmentsFromStopTimes = (
     stopCoordinatesByStopId: { [key: string]: [number, number] },
     defaultLayoverRatioOverTotalTravelTime = 0.1,
     defaultMinLayoverTimeSeconds = 180
-): ErrorMessage[] => {
+): TranslatableMessage[] => {
     path.attributes.nodes = nodeIds; // reset nodes, they will be regenerated from stop times
 
     // Return errors when generating the path
-    const errors: ErrorMessage[] = [];
+    const errors: TranslatableMessage[] = [];
 
     const coordinates = stopTimes
         .map((stopTime) => {

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -19,7 +19,7 @@ import { CheckpointTracker } from '../executableJob/JobCheckpointTracker';
 import { resultIsUnimodal } from 'chaire-lib-common/lib/services/routing/RoutingResultUtils';
 import { ExecutableJob } from '../executableJob/ExecutableJob';
 import { BatchRouteJobType, BatchRouteResultVisitor } from './BatchRoutingJob';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { BatchRouteFileResultVisitor } from './batchRouteCalculation/BatchRouteFileResultVisitor';
 
 const CHECKPOINT_INTERVAL = 250;
@@ -56,7 +56,7 @@ export const batchRoute = async (
 
 class TrRoutingBatch {
     private odTrips: BaseOdTrip[] = [];
-    private errors: ErrorMessage[] = [];
+    private errors: TranslatableMessage[] = [];
     private batchManager: TrRoutingBatchManager;
 
     constructor(
@@ -263,7 +263,7 @@ class TrRoutingBatch {
 
     private getOdTrips = async (): Promise<{
         odTrips: BaseOdTrip[];
-        errors: ErrorMessage[];
+        errors: TranslatableMessage[];
     }> => {
         console.log(`importing od trips from CSV file ${this.job.getInputFileName()}`);
         console.log('reading data from csv file...');

--- a/packages/transition-common/src/api/gtfs.ts
+++ b/packages/transition-common/src/api/gtfs.ts
@@ -6,7 +6,7 @@
  */
 // Unused vars, but linked to in the documentation
 import { GtfsImportData } from '../services/gtfs/GtfsImportTypes'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 export interface GtfsExportParameters {
     gtfsExporterId: string;
@@ -21,8 +21,8 @@ export interface GtfsExportParameters {
 }
 
 export type GtfsImportStatus =
-    | { status: 'success'; warnings: ErrorMessage[]; errors: ErrorMessage[] }
-    | { status: 'failed'; errors: ErrorMessage[] };
+    | { status: 'success'; warnings: TranslatableMessage[]; errors: TranslatableMessage[] }
+    | { status: 'failed'; errors: TranslatableMessage[] };
 
 /**
  * Upon success, the gtfsExporterId should match the gtfsExporterId of the export
@@ -31,7 +31,7 @@ export type GtfsImportStatus =
 
 export type GtfsExportStatus =
     | { status: 'success'; gtfsExporterId: string; zipFilePath: string }
-    | { status: 'failed'; gtfsExporterId: string; errors: ErrorMessage[] };
+    | { status: 'failed'; gtfsExporterId: string; errors: TranslatableMessage[] };
 
 export class GtfsConstants {
     /**

--- a/packages/transition-common/src/services/batchCalculation/types.ts
+++ b/packages/transition-common/src/services/batchCalculation/types.ts
@@ -4,7 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { validateTrQueryAttributes } from '../transitRouting/TransitRoutingQueryAttributes';
 import { TransitRoutingQueryAttributes } from 'chaire-lib-common/lib/services/routing/types';
 
@@ -59,6 +59,6 @@ export type BatchCalculationParameters = {
 export interface TransitBatchCalculationResult {
     detailed: boolean;
     completed: boolean;
-    warnings: ErrorMessage[];
-    errors: ErrorMessage[];
+    warnings: TranslatableMessage[];
+    errors: TranslatableMessage[];
 }

--- a/packages/transition-common/src/services/csv/CsvFieldMapper.ts
+++ b/packages/transition-common/src/services/csv/CsvFieldMapper.ts
@@ -8,7 +8,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 
 import { parseCsvFile } from 'chaire-lib-common/lib/utils/files/CsvFile';
 import { CsvFieldMappingDescriptor, CsvFileAndMapping, FileConfig } from './types';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 /**
  * A class to manage CSV field mapping from CSV fields to application fields
@@ -18,7 +18,7 @@ export class CsvFieldMapper<T extends Record<string, string> = Record<string, st
     protected _csvFields: string[] = [];
     protected _fieldMappings: Partial<T> = {};
     private _isValid: boolean | undefined = undefined;
-    private _errors: ErrorMessage[] = [];
+    private _errors: TranslatableMessage[] = [];
 
     constructor(
         protected mappingDescriptors: CsvFieldMappingDescriptor[],
@@ -39,7 +39,7 @@ export class CsvFieldMapper<T extends Record<string, string> = Record<string, st
             suffix?: string;
             isCsvField?: boolean;
         } = {}
-    ): true | ErrorMessage[] {
+    ): true | TranslatableMessage[] {
         const suffix = options.suffix ?? '';
         const fieldMappingKey = descriptor.key + suffix;
         const mappedField = this._fieldMappings[fieldMappingKey];
@@ -58,8 +58,10 @@ export class CsvFieldMapper<T extends Record<string, string> = Record<string, st
         return true;
     }
 
-    private _descriptorTypeSpecificValidation = (descriptor: CsvFieldMappingDescriptor): true | ErrorMessage[] => {
-        const errors: ErrorMessage[] = [];
+    private _descriptorTypeSpecificValidation = (
+        descriptor: CsvFieldMappingDescriptor
+    ): true | TranslatableMessage[] => {
+        const errors: TranslatableMessage[] = [];
         switch (descriptor.type) {
         case 'latLon': {
             const latOk = this._validateSingleDescriptor(descriptor, { suffix: 'Lat' });
@@ -98,9 +100,9 @@ export class CsvFieldMapper<T extends Record<string, string> = Record<string, st
         }
     };
 
-    protected _validate(): { isValid: boolean; errors: ErrorMessage[] } {
+    protected _validate(): { isValid: boolean; errors: TranslatableMessage[] } {
         let isValid = true;
-        const errors: ErrorMessage[] = [];
+        const errors: TranslatableMessage[] = [];
 
         if (this._csvFields.length === 0) {
             isValid = false;
@@ -229,10 +231,10 @@ export class CsvFieldMapper<T extends Record<string, string> = Record<string, st
 
     /**
      * Get the array of error messages if the object is not valid.
-     * @returns {ErrorMessage[]} An array of error messages. If the object is
+     * @returns {TranslatableMessage[]} An array of error messages. If the object is
      * valid, the array is empty.
      */
-    getErrors(): ErrorMessage[] {
+    getErrors(): TranslatableMessage[] {
         // Cache the validation result
         if (this._isValid === undefined) {
             const { isValid, errors } = this._validate();
@@ -272,9 +274,9 @@ export class CsvFileAndFieldMapper<
         }
     }
 
-    protected _validate(): { isValid: boolean; errors: ErrorMessage[] } {
+    protected _validate(): { isValid: boolean; errors: TranslatableMessage[] } {
         let isValid = true;
-        const errors: ErrorMessage[] = [];
+        const errors: TranslatableMessage[] = [];
 
         if (!this._csvFile) {
             isValid = false;

--- a/packages/transition-common/src/services/gtfs/GtfsExporter.ts
+++ b/packages/transition-common/src/services/gtfs/GtfsExporter.ts
@@ -9,13 +9,13 @@ import { ObjectWithHistory } from 'chaire-lib-common/lib/utils/objects/ObjectWit
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GtfsConstants } from '../../api/gtfs';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 export interface GtfsExporterAttributes extends GenericAttributes {
     selectedAgencies: string[];
     filename: string;
     isPrepared?: boolean;
-    exportErrors?: ErrorMessage[];
+    exportErrors?: TranslatableMessage[];
     data: {
         zipFilePath?: string;
     };

--- a/packages/transition-common/src/services/jobs/Job.ts
+++ b/packages/transition-common/src/services/jobs/Job.ts
@@ -1,4 +1,4 @@
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 /*
  * Copyright 2022, Polytechnique Montreal and contributors
@@ -70,7 +70,11 @@ export interface JobAttributes<TData extends JobDataType> {
     user_id: number;
     name: TData[JobNameKey];
     status: JobStatus;
-    statusMessages?: { errors?: ErrorMessage[]; warnings?: ErrorMessage[]; infos?: ErrorMessage[] };
+    statusMessages?: {
+        errors?: TranslatableMessage[];
+        warnings?: TranslatableMessage[];
+        infos?: TranslatableMessage[];
+    };
     /**
      * Data internal to the job management, that is not relevant to the users.
      * This data is persisted and can be used for job checkpointing, resuming

--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
@@ -27,7 +27,7 @@ import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper'
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import TransitAccessibilityMapRouting, {
     MAX_DELTA_MINUTES,
     MAX_DELTA_INTERVAL_MINUTES,
@@ -78,7 +78,7 @@ interface TransitRoutingFormState extends ChangeEventsState<TransitAccessibility
     alternateScenarioRouting: TransitAccessibilityMapRouting;
     scenarioCollection: any;
     loading: boolean;
-    routingErrors?: ErrorMessage[];
+    routingErrors?: TranslatableMessage[];
     geojsonDownloadUrl: string | null;
     jsonDownloadUrl: string | null;
     csvDownloadUrl: string | null;

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapBatchForm.tsx
@@ -29,7 +29,8 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
 import { _toInteger, _toBool, _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import BatchAttributesSelection from './widgets/BatchAttributesSelection';
 import { BatchAccessibilityMapCalculator } from '../../../services/accessibilityMap/BatchAccessibilityMapCalculator';
 import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobComponent';
@@ -49,8 +50,8 @@ interface BatchAccessibilityMapFormState extends ChangeEventsState<TransitBatchA
     jsonDownloadUrl: any;
     csvDownloadUrl: any;
     batchRoutingInProgress: boolean;
-    errors: ErrorMessage[];
-    warnings: ErrorMessage[];
+    errors: TranslatableMessage[];
+    warnings: TranslatableMessage[];
     csvFile?: File;
 }
 

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -25,7 +25,7 @@ import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper'
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import TransitAccessibilityMapRouting, {
     MAX_DELTA_MINUTES,
     MAX_DELTA_INTERVAL_MINUTES,
@@ -66,7 +66,7 @@ interface TransitRoutingFormState extends ChangeEventsState<TransitAccessibility
     currentResult?: TransitAccessibilityMapWithPolygonResult;
     scenarioCollection: any;
     loading: boolean;
-    routingErrors?: ErrorMessage[];
+    routingErrors?: TranslatableMessage[];
     geojsonDownloadUrl: string | null;
     jsonDownloadUrl: string | null;
     csvDownloadUrl: string | null;

--- a/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
+++ b/packages/transition-frontend/src/components/forms/batchCalculation/BatchCalculationList.tsx
@@ -14,7 +14,8 @@ import ExecutableJobComponent from '../../parts/executableJob/ExecutableJobCompo
 import TransitBatchRoutingCalculator from 'transition-common/lib/services/transitRouting/TransitBatchRoutingCalculator';
 import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
 import FormErrors from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
-import TrError, { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { BatchRoutingOdDemandFromCsvAttributes } from 'transition-common/lib/services/transitDemand/types';
 
 interface BatchCalculationListProps extends WithTranslation {
@@ -26,7 +27,7 @@ interface BatchCalculationListProps extends WithTranslation {
 }
 
 const BatchCalculationList: React.FunctionComponent<BatchCalculationListProps> = (props: BatchCalculationListProps) => {
-    const [errors, setErrors] = React.useState<ErrorMessage[]>([]);
+    const [errors, setErrors] = React.useState<TranslatableMessage[]>([]);
     const replayJob = async (jobId: number) => {
         try {
             const parameters = await TransitBatchRoutingCalculator.getCalculationParametersForJob(jobId);

--- a/packages/transition-frontend/src/components/forms/comparison/ScenarioComparisonPanel.tsx
+++ b/packages/transition-frontend/src/components/forms/comparison/ScenarioComparisonPanel.tsx
@@ -18,7 +18,7 @@ import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import TransitRouting, { TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
 
@@ -49,7 +49,7 @@ const ScenarioComparisonPanel: React.FC = () => {
     const [currentResult, setCurrentResult] = useState<RoutingResultsByMode[] | undefined>(undefined);
     const [scenarioCollection, setScenarioCollection] = useState(serviceLocator.collectionManager.get('scenarios'));
     const [loading, setLoading] = useState(false);
-    const [routingErrors, setRoutingErrors] = useState<ErrorMessage[] | undefined>(undefined);
+    const [routingErrors, setRoutingErrors] = useState<TranslatableMessage[] | undefined>(undefined);
     // FIXME using any to avoid typing the formValues, which would be tedious
     const [formValues, setFormValues] = useState<any>(() => ({
         routingName: routingObj.attributes.routingName || '',
@@ -159,7 +159,7 @@ const ScenarioComparisonPanel: React.FC = () => {
         const localNonce = (calculateRoutingNonceRef.current = new Object());
         const routing = routingObj;
         const alternate = alternateRoutingObj;
-        const newRoutingErrors: ErrorMessage[] = [];
+        const newRoutingErrors: TranslatableMessage[] = [];
         const isCancelled = () => localNonce !== calculateRoutingNonceRef.current;
         resetResults();
         setLoading(true);

--- a/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/TransitRoutingForm.tsx
@@ -19,7 +19,7 @@ import InputRadio from 'chaire-lib-frontend/lib/components/input/InputRadio';
 import InputMultiselect from 'chaire-lib-frontend/lib/components/input/InputMultiselect';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
-import { ErrorMessage } from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import TransitRouting, { TransitRoutingAttributes } from 'transition-common/lib/services/transitRouting/TransitRouting';
 
@@ -64,7 +64,7 @@ const TransitRoutingForm: React.FC<TransitRoutingFormProps> = (props) => {
     const [currentResult, setCurrentResult] = useState<RoutingResultsByMode | undefined>(undefined);
     const [scenarioCollection, setScenarioCollection] = useState(serviceLocator.collectionManager.get('scenarios'));
     const [loading, setLoading] = useState(false);
-    const [routingErrors, setRoutingErrors] = useState<ErrorMessage[] | undefined>(undefined);
+    const [routingErrors, setRoutingErrors] = useState<TranslatableMessage[] | undefined>(undefined);
     const [selectedMode, setSelectedMode] = useState<RoutingOrTransitMode | undefined>(undefined);
 
     const { t } = useTranslation(['transit', 'main', 'form']);
@@ -156,7 +156,7 @@ const TransitRoutingForm: React.FC<TransitRoutingFormProps> = (props) => {
         }
         const localNonce = (calculateRoutingNonceRef.current = new Object());
         const routing = transitRouting;
-        const newRoutingErrors: ErrorMessage[] = [];
+        const newRoutingErrors: TranslatableMessage[] = [];
         const isCancelled = () => localNonce !== calculateRoutingNonceRef.current;
         resetResultsData();
         setLoading(true);


### PR DESCRIPTION
Fixes #1400

Creates the new TranslatableMessage.ts file in chaire-lib-common/src/utils to replace the ErrorMessage type which was in TrError.ts which was used everywhere even when not for errors. It's just a copy paste of ErrorMessage and a rename to TrMessage. ErrorMessage has been deleted and replaced throughout the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error/warning message format to a translatable structure across the product.
  * UI forms, pages and import/export workflows now surface localized, translatable messages for errors, warnings and infos.
  * Batch jobs, routing, GTFS/path/schedule imports, CSV/OD/access-map parsing, and related flows return and display localized warnings/errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->