### PR TITLE
dateTimeUtils: improve the `toXXhrYYminZZsec` function

### DIFF
--- a/packages/chaire-lib-common/package.json
+++ b/packages/chaire-lib-common/package.json
@@ -26,6 +26,7 @@
     "geojson": "^0.5.0",
     "geojson-validation": "^1.0.2",
     "geokdbush": "^1.1.0",
+    "i18next": "^25.7.3",
     "kdbush": "^3.0.0",
     "lodash": "^4.17.23",
     "papaparse": "^5.5.3",

--- a/packages/chaire-lib-frontend/src/components/pageParts/DurationUnitFormatter.tsx
+++ b/packages/chaire-lib-frontend/src/components/pageParts/DurationUnitFormatter.tsx
@@ -5,14 +5,14 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React, { useState, useEffect } from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { toXXhrYYminZZsec } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
 
 const destinationUnitOptions = ['hrMinSec', 's', 'm', 'h'] as const;
 type destinationUnitOptionsType = (typeof destinationUnitOptions)[number];
 
-export type DurationUnitFormatterProps = WithTranslation & {
+export type DurationUnitFormatterProps = {
     value: number;
     sourceUnit: 's' | 'm' | 'h';
     destinationUnit?: destinationUnitOptionsType;
@@ -24,6 +24,7 @@ const DurationUnitFormatter: React.FunctionComponent<DurationUnitFormatterProps>
     const [destinationUnit, setDestinationUnit] = useState<destinationUnitOptionsType | undefined>(
         props.destinationUnit
     );
+    const { t } = useTranslation('main');
 
     const valueInSeconds =
         props.sourceUnit === 's'
@@ -43,11 +44,14 @@ const DurationUnitFormatter: React.FunctionComponent<DurationUnitFormatterProps>
 
     const unitFormatters: Record<destinationUnitOptionsType, (value: number) => string> = {
         hrMinSec: (value) =>
-            toXXhrYYminZZsec(value, props.t('main:hourAbbr'), props.t('main:minuteAbbr'), props.t('main:secondAbbr')) ||
-            `${value.toString()} ${props.t('main:secondAbbr')}`,
-        s: (value) => `${roundToDecimals(value, 2)} ${props.t('main:secondAbbr')}`,
-        m: (value) => `${roundToDecimals(value / 60, 2)} ${props.t('main:minuteAbbr')}`,
-        h: (value) => `${roundToDecimals(value / 3600, 2)} ${props.t('main:hourAbbr')}`
+            toXXhrYYminZZsec(value, t, {
+                hourUnit: 'main:hourAbbr',
+                minuteUnit: 'main:minuteAbbr',
+                secondsUnit: 'main:secondAbbr'
+            }),
+        s: (value) => `${roundToDecimals(value, 2)} ${t('main:secondAbbr')}`,
+        m: (value) => `${roundToDecimals(value / 60, 2)} ${t('main:minuteAbbr')}`,
+        h: (value) => `${roundToDecimals(value / 3600, 2)} ${t('main:hourAbbr')}`
     };
 
     const formattedValue = destinationUnit ? unitFormatters[destinationUnit](valueInSeconds) : '';
@@ -65,4 +69,4 @@ const DurationUnitFormatter: React.FunctionComponent<DurationUnitFormatterProps>
     return <span onClick={cycleThroughDestinationUnits}>{formattedValue}</span>;
 };
 
-export default withTranslation('main')(DurationUnitFormatter);
+export default DurationUnitFormatter;


### PR DESCRIPTION
fixes #1761

The function now receives a `t` function instead of only the translated units to allow to pluralize the units depending on the count of each value.

Pass the units and other options as a third object parameter, with named fields.

The `withSeconds` field allows to specify if we want to show the seconds in the display, or stop at the minutes.

A `zeroText` option is returned when all the values to be displayed are at 0.

Add unit tests for all the new use cases provided by this function.

Update the `DurationUnitFormatter` component to use the new function signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internationalization support for duration formatting across the application
  * Improved localization of time unit displays and zero-value handling in duration components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->