### PR TITLE
networkDesign: fix bounds to be inclusive for service preparation

### DIFF
--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/preparation/ServicePreparation.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/preparation/ServicePreparation.ts
@@ -122,8 +122,8 @@ const prepareServicesForLines = async (
 
         if (
             timeBetweenPassages !== lastTimeBetweenPassages &&
-            timeBetweenPassages > minTime &&
-            timeBetweenPassages < maxTime
+            timeBetweenPassages >= minTime &&
+            timeBetweenPassages <= maxTime
         ) {
             // Keep this schedule and service if the time between passages is within range
             lineServices.push({


### PR DESCRIPTION
With schedules using non-second based schedules, the entire minutes
corresponding to the `minTimeBetweenPassages` and
`maxTimeBetweenPassages` boundaries had no valid service. Now we include
the bounds in the interval check.

Also refactor unit tests to be parameterized so it is easier to add new tests later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule selection now includes boundary values when evaluating time intervals between passages, improving service generation accuracy.

* **Tests**
  * Refactored unit tests into data-driven scenarios with shared helpers and type-safe trip fixtures; mocks and assertions adjusted to match per-case expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->