### PR TITLE
Add data source selection to population calculation

### DIFF
--- a/docs/APIv1/accessibilityMap.yml
+++ b/docs/APIv1/accessibilityMap.yml
@@ -85,6 +85,10 @@ accessibilityMapRequest:
       type: boolean
       description: Whether to calculate the population of the polygon and include the count in the result. Defaults to false.
       example: true
+    populationDataSourceName: 
+      type: string
+      description: The name or shortname of the data source that contains the population data we want to use. Does nothing if calculatePopulation is set to false. Defaults to undefined. If left undefined or an empty string, the population will not be calculated.
+      example: Dissemination block boundaries 2021
 
 
 accessibilityMapResponseSuccess:
@@ -245,11 +249,22 @@ accessibilityMapResultResponsePolygons:
                   type: integer
                 description: The number of POIs within the accessibility polygon (if any), separated by detailed categories. The keys are the names of the detailed categories defined in the PlaceDetailedCategory type, and the values are integers.
                 example: {'service_bank': 8, 'service_other': 2, 'restaurant_restaurant': 5}
-              population:
-                type: number
-                nullable: true
-                description: The population inside the result polygon. Is null if calculatePopulation was set to false or the polygon does not cover any of the zones in the census db table.
-                example: 102457
+              populationData:
+                type: object
+                description: Object that contains the population in the polygon and how much of it is covered by the data source. Undefined if calculatePopulation is set to false.
+                required:
+                  - population
+                  - dataSourceAreaRatio
+                properties:
+                  population:
+                    type: number
+                    nullable: true
+                    description: The population inside the result polygon. Is null if calculatePopulation was set to false or the polygon does not cover any of the zones in the census db table (distinct from 0, which is for a population that's actually calculated to be 0 based on the data available).
+                    example: 102457
+                  dataSourceAreaRatio:
+                    type: number
+                    description: The portion, from 0 to 1, of how much of the polygon is covered by the zones included in the population data source (for example, it might be less than 1 when the source contains only data for Canada and the polygon is on the US-Canada border).
+                    example: 0.67327
 
 accessibilityMapResponseBadRequest:
   type: string

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -546,6 +546,9 @@
         "SeeDetailedCategories": "See detailed categories",
         "ShowEmptyDetailedCategories": "Show empty detailed categories",
         "AccessiblePOIsPopup": "The data used to determine accessible Points of interest was downloaded from OpenStreetMap and imported into the database. The results may be inaccurate if the accessibility polygon is not contained entirely within the imported area.",
+        "DataSourceWarningPopup": "Warning: The population data from this data source covers only {{percentage}}% of the accessibility polygon. This may be due to it intersecting a body of water or the border of the region imported by this source.",
+        "DataSourceNullWarningPopup": "Warning: The population data from this data source does not cover any of the accessibility polygon. This may be due to it being contained in a body of water or outside the region imported by this source.",
+        "DataSourceNullWarningComparisonPopup": "Warning: The population data from this data source does not cover any of the accessibility polygon for at least one of the scenarios. This may be due to it being contained in a body of water or outside the region imported by this source.",
         "Scenario": "Scenario",
         "DataSource": "Data source",
         "CompareWithScenario": "Compare with scenario",
@@ -581,6 +584,7 @@
         "WithAlternatives": "Calculate with alternatives",
         "CalculatePois": "Calculate with points of interest",
         "CalculatePopulation": "Calculate with the population",
+        "PopulationDataSourceSelect": "Select a data source to use to calculate the population",
         "Detailed": "Detailed results with steps",
         "WithGeometries": "Include route geometries (geojson)",
         "ReverseOD": "Reverse",
@@ -688,7 +692,8 @@
             "InvalidOdTripsDataSource": "Invalid OD calculations data source.",
             "ErrorCalculatingLocation": "Error calculating location {{id}}",
             "UserDiskQuotaReached": "Maximum allowed disk space has been reached. Please delete old tasks to delete their files.",
-            "RoutingParametersInvalidForBatch": "Routing parameters are invalid. Make sure the scenario is set and times have a valid value."
+            "RoutingParametersInvalidForBatch": "Routing parameters are invalid. Make sure the scenario is set and times have a valid value.",
+            "DataSourceIsMissing": "The data source is required."
         },
         "actions": {
             "walking": "Walk",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -546,6 +546,9 @@
         "SeeDetailedCategories": "Voir les catégories détaillées",
         "ShowEmptyDetailedCategories": "Montrer les catégories détaillées vides",
         "AccessiblePOIsPopup": "Les données utilisées pour calculer les lieux d'activité accessibles ont été téléchargées de OpenStreetMap et importées dans la base de données. Les résultats peuvent être inexacts si le polygone d'accessibilité n'est pas contenu entièrement dans la surface importée.",
+        "DataSourceWarningPopup": "Attention: Les données de population de cette source de données ne couvrent que {{percentage}}% du polygone d'accessibilité. Cela peut être parce qu'il chevauche une étendue d'eau ou la frontière de la région importée par cette source.",
+        "DataSourceNullWarningPopup": "Attention: Les données de population de cette source de données ne couvrent aucune partie du polygone d'accessibilité. Cela peut être parce qu'il est contenu dans une étendue d'eau ou en dehors de la région importée par cette source.",
+        "DataSourceNullWarningComparisonPopup": "Attention: Les données de population de cette source de données ne couvrent aucune partie du polygone d'accessibilité pour au moins un des scénarios. Cela peut être parce qu'il est contenu dans une étendue d'eau ou en dehors de la région importée par cette source.",
         "Scenario": "Scénario",
         "DataSource": "Source de données",
         "CompareWithScenario": "Comparer avec scénario",
@@ -581,6 +584,7 @@
         "WithAlternatives": "Calcul avec alternatives",
         "CalculatePois": "Calcul avec lieux d'activité",
         "CalculatePopulation": "Calcul avec la population",
+        "PopulationDataSourceSelect": "Sélectionnez une source de données pour calculer la population",
         "Detailed": "Résultats détaillés avec étapes",
         "WithGeometries": "Inclure les géométries des parcours (geojson)",
         "ReverseOD": "Inverser",
@@ -688,7 +692,8 @@
             "InvalidOdTripsDataSource": "Source de données de calculs OD invalide.",
             "ErrorCalculatingLocation": "Erreur de calcul pour le lieu {{id}}",
             "UserDiskQuotaReached": "L'espace disque maximal permis a été atteint. Veuillez supprimer des tâches passées pour en supprimer les fichiers",
-            "RoutingParametersInvalidForBatch": "Les paramètres pour le calcul de chemin sont invalides. Assurez-vous que le scénario est bien configuré et que les temps sont valides."
+            "RoutingParametersInvalidForBatch": "Les paramètres pour le calcul de chemin sont invalides. Assurez-vous que le scénario est bien configuré et que les temps sont valides.",
+            "DataSourceIsMissing": "La source de données est requise."
         },
         "actions": {
             "walking": "Marche",

--- a/packages/transition-backend/src/api/__tests__/public.routes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/public.routes.test.ts
@@ -700,7 +700,7 @@ describe('Testing API endpoints', () => {
                             otherProperty: 'foo',
                             accessiblePlacesCountByCategory: calculatePoisAndPopulation ? { 'service': 10 } : undefined,
                             accessiblePlacesCountByDetailedCategory: calculatePoisAndPopulation ? { 'service_other': 4, 'service_bank': 6 } : undefined,
-                            population: calculatePoisAndPopulation ? 500 : null
+                            populationData: calculatePoisAndPopulation ? { population: 500, dataSourceAreaRatio: 1 } : undefined
                         }
                     }]
                 },
@@ -729,11 +729,10 @@ describe('Testing API endpoints', () => {
                                 areaSqM: 1000,
                                 accessiblePlacesCountByCategory: { 'service': 10 },
                                 accessiblePlacesCountByDetailedCategory: { 'service_other': 4, 'service_bank': 6 },
-                                population: 500
+                                populationData: { population: 500, dataSourceAreaRatio: 1 }
                             } : {
                                 durationSeconds: 900,
-                                areaSqM: 1000,
-                                population: null
+                                areaSqM: 1000
                             }
                         }]
                     }

--- a/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
+++ b/packages/transition-backend/src/api/public/AccessibilityMapAPIResponse.ts
@@ -33,6 +33,7 @@ type AccessibilityMapAPIQueryResponse = {
     walkingSpeedMps: number;
     calculatePois: boolean;
     calculatePopulation: boolean;
+    populationDataSourceName?: string;
 };
 
 type AccessibilityMapAPIResultResponse = {
@@ -47,6 +48,7 @@ type AccessibilityMapAPIResultResponse = {
                 areaSqM: number;
                 accessiblePlacesCountByCategory?: { [key in PlaceCategory]: number };
                 accessiblePlacesCountByDetailedCategory?: { [key in PlaceDetailedCategory]: number };
+                populationData?: { population: number | null; dataSourceAreaRatio: number };
             };
         }>;
     };
@@ -90,7 +92,8 @@ export default class AccessibilityMapAPIResponse extends APIResponseBase<
             maxTransferTravelTimeSeconds: queryParams.maxTransferTravelTimeSeconds!,
             walkingSpeedMps: queryParams.walkingSpeedMps!,
             calculatePois: queryParams.calculatePois!,
-            calculatePopulation: queryParams.calculatePopulation!
+            calculatePopulation: queryParams.calculatePopulation!,
+            populationDataSourceName: queryParams.populationDataSourceName || undefined
         };
     }
 
@@ -111,7 +114,7 @@ export default class AccessibilityMapAPIResponse extends APIResponseBase<
                                 accessiblePlacesCountByCategory: feature.properties!.accessiblePlacesCountByCategory,
                                 accessiblePlacesCountByDetailedCategory:
                                       feature.properties!.accessiblePlacesCountByDetailedCategory,
-                                population: feature.properties!.population
+                                populationData: feature.properties!.populationData
                             }
                         }))
                     }

--- a/packages/transition-backend/src/models/db/census.db.queries.ts
+++ b/packages/transition-backend/src/models/db/census.db.queries.ts
@@ -8,6 +8,7 @@ import knex from 'chaire-lib-backend/lib/config/shared/db.config';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 
 import { truncate } from 'chaire-lib-backend/lib/models/db/default.db.queries';
+import dsQueries from 'chaire-lib-backend/lib/models/db/dataSources.db.queries';
 
 interface CensusAttributes {
     id: number;
@@ -63,28 +64,46 @@ const addPopulationBatch = async (inputArray: { internalId: string; population: 
 };
 
 const getPopulationInPolygon = async (
-    accessibilityPolygon: GeoJSON.MultiPolygon | GeoJSON.Polygon
-): Promise<number | null> => {
+    accessibilityPolygon: GeoJSON.MultiPolygon | GeoJSON.Polygon,
+    populationDataSourceName: string
+): Promise<{ population: number | null; dataSourceAreaRatio: number }> => {
     try {
-        // Find all the zones that intersect the input polygon, and fetch their population, area, and the area of the intersection.
+        const dataSourceId = (await dsQueries.findByName(populationDataSourceName))?.id;
+        if (dataSourceId === undefined) {
+            return { population: null, dataSourceAreaRatio: 0 };
+        }
+        // Find all the zones that intersect the input polygon from a particular data source, and fetch their population, area, and the area of the intersection.
         // We multiply the population of each zone by the ratio between the area  of its intersection with the input polygon and its total area, to estimate the true population of zones that aren't entirely contained within the input polygon.
-        // TO avoid division by zero in the edge case of a degenerate zone with no area, we use the NULLIF function.
+        // To avoid division by zero in the edge case of a degenerate zone with no area, we use the NULLIF function.
+        // We also get the ratio of the area of the zones in the polygon that have data to the area of the polygon.
+        // When we get a polygon for which we have complete data, we expect that number to be 1 or very close to it, however it will be lower if data is missing from that area (for example, if we input a polygon that's over the Canada-US border while using a data source that only has data for Canada).
         const populationResponse = await knex.raw(
             `
                 SELECT COUNT(*) as row_count,
                 ROUND(SUM(
-                    population * 
-                    ST_AREA(ST_INTERSECTION(ST_GeomFromGeoJSON(:polygon), geography::geometry)) / 
+                    population *
+                    ST_AREA(ST_INTERSECTION(ST_GeomFromGeoJSON(:polygon), geography::geometry)) /
                     NULLIF(ST_AREA(geography::geometry), 0)
-                )) as weighted_population
+                )) as weighted_population,
+                (
+                    ST_AREA(ST_INTERSECTION(ST_UNION(geography::geometry), ST_GeomFromGeoJSON(:polygon))) /
+                    NULLIF(ST_AREA(ST_GeomFromGeoJSON(:polygon)), 0)
+                ) as data_source_area_ratio
                 FROM ${tableName} c JOIN ${parentTable} z ON c.zone_id = z.id
-                WHERE ST_INTERSECTS(geography::geometry, ST_GeomFromGeoJSON(:polygon));
+                WHERE z.data_source_id = :dataSourceId
+                AND ST_INTERSECTS(geography::geometry, ST_GeomFromGeoJSON(:polygon));
             `,
-            { polygon: JSON.stringify(accessibilityPolygon) }
+            { polygon: JSON.stringify(accessibilityPolygon), dataSourceId }
         );
 
         const result = populationResponse.rows[0];
-        return Number(result.row_count) === 0 ? null : Number(result.weighted_population);
+
+        // If there is no population data, we set 'population' to null, and 'dataSourceAreaRatio' is irrelevant.
+        // This is distinct from a population of 0, where we calculate that there is no one living in the zone according to the data, and so 'dataSourceAreaRatio' is something we are interested in in this case.
+        return {
+            population: Number(result.row_count) === 0 ? null : Number(result.weighted_population),
+            dataSourceAreaRatio: result.data_source_area_ratio === null ? 0 : Number(result.data_source_area_ratio)
+        };
     } catch (error) {
         throw new TrError(`Problem getting population (knex error: ${error})`, 'CSDB0003', 'ProblemGettingPopulation');
     }

--- a/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
+++ b/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
@@ -103,7 +103,8 @@ export const getAttributesOrDefault = (attributes: Partial<AccessibilityMapAttri
         color: attributes.color,
         placeName: attributes.placeName,
         calculatePois: attributes.calculatePois || false,
-        calculatePopulation: attributes.calculatePopulation || false
+        calculatePopulation: attributes.calculatePopulation || false,
+        populationDataSourceName: attributes.populationDataSourceName || undefined
     };
 };
 
@@ -401,6 +402,7 @@ export class TransitAccessibilityMapCalculator {
             color?: string;
             calculatePois?: boolean;
             calculatePopulation?: boolean;
+            populationDataSourceName?: string;
             [key: string]: any;
         },
         result: TransitAccessibilityMapResultByNode,
@@ -510,9 +512,13 @@ export class TransitAccessibilityMapCalculator {
                     await placesDbQueries.getPOIsCategoriesCountInPolygon(polygon.geometry));
             }
 
-            let population: number | null = null;
-            if (attributes.calculatePopulation) {
-                population = await censusDbQueries.getPopulationInPolygon(polygon.geometry);
+            let populationData: { population: number | null; dataSourceAreaRatio: number } | undefined = undefined;
+
+            if (attributes.calculatePopulation && attributes.populationDataSourceName) {
+                populationData = await censusDbQueries.getPopulationInPolygon(
+                    polygon.geometry,
+                    attributes.populationDataSourceName
+                );
             }
 
             polygon.properties = {
@@ -524,7 +530,7 @@ export class TransitAccessibilityMapCalculator {
                 color: attributes.color,
                 accessiblePlacesCountByCategory,
                 accessiblePlacesCountByDetailedCategory,
-                population,
+                populationData,
                 ...attributes,
                 ...(options.additionalProperties || {})
             };

--- a/packages/transition-backend/src/services/accessibilityMap/__tests__/TransitAccessibilityMapCalculator.test.ts
+++ b/packages/transition-backend/src/services/accessibilityMap/__tests__/TransitAccessibilityMapCalculator.test.ts
@@ -215,7 +215,7 @@ describe('Test accessibility map with results using PostGIS', () => {
             accessiblePlacesCountByDetailedCategory
         });
 
-        mockedCensusPopulationCount.mockResolvedValue(500);
+        mockedCensusPopulationCount.mockResolvedValue({ population: 500, dataSourceAreaRatio: 1 });
     });
 
     test('Test one polygon, 2 nodes, with additional properties, POIs, and population', async() => {
@@ -227,7 +227,8 @@ describe('Test accessibility map with results using PostGIS', () => {
             maxTransferTravelTimeSeconds: 120,
             walkingSpeedMps: 1,
             calculatePois: true,
-            calculatePopulation: true
+            calculatePopulation: true,
+            populationDataSourceName: 'DS Name'
         }
 
         mockedAccessibilityMap.mockResolvedValueOnce({
@@ -277,14 +278,14 @@ describe('Test accessibility map with results using PostGIS', () => {
 
         // Verify the population was calculated
         expect(mockedCensusPopulationCount).toHaveBeenCalled();
-        expect(mockedCensusPopulationCount).toHaveBeenCalledWith(features[0].geometry);
+        expect(mockedCensusPopulationCount).toHaveBeenCalledWith(features[0].geometry, 'DS Name');
 
         // Verify the result structure
         expect(features).toHaveLength(1);
         expect(features[0].geometry.coordinates).toEqual(mockPolygonCoordinates);
         expect(features[0].properties?.accessiblePlacesCountByCategory).toEqual(accessiblePlacesCountByCategory);
         expect(features[0].properties?.accessiblePlacesCountByDetailedCategory).toEqual(accessiblePlacesCountByDetailedCategory);
-        expect(features[0].properties?.population).toEqual(500);
+        expect(features[0].properties?.populationData).toEqual({ population: 500, dataSourceAreaRatio: 1 });
     });
 
     test('Test multiple polygons with different durations using PostGIS', async() => {
@@ -366,7 +367,7 @@ describe('Test accessibility map with results using PostGIS', () => {
 
         // Test that we get a null population when calculatePopulation is explicitly set to false in the attributes
         expect(mockedCensusPopulationCount).toHaveBeenCalledTimes(0);
-        expect(polygonProperties.population).toBeNull();
+        expect(polygonProperties.populationData).toBeUndefined();
     });
 
     test('Test polygon generation with delta using PostGIS', async() => {

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapRouting.ts
@@ -34,6 +34,7 @@ export interface AccessibilityMapCalculationAttributes extends GenericAttributes
     placeName?: string;
     calculatePois?: boolean;
     calculatePopulation?: boolean;
+    populationDataSourceName?: string;
 }
 
 export type AccessibilityMapAttributes = AccessibilityMapCalculationAttributes & TransitQueryAttributes;
@@ -150,6 +151,11 @@ class TransitAccessibilityMapRouting extends ObjectWithHistory<AccessibilityMapA
         } else if (this._isValid && walkingSpeedMps < MIN_WALKING_SPEED_KPH / 3.6) {
             this._isValid = false;
             this.errors.push('transit:transitRouting:errors:WalkingSpeedMpsIsTooLow');
+        }
+
+        if (_isBlank(attributes.populationDataSourceName) && attributes.calculatePopulation) {
+            this._isValid = false;
+            this.errors.push('transit:transitRouting:errors:DataSourceIsMissing');
         }
 
         const { valid: queryAttrValid, errors: queryAttrErrors } = validateTrQueryAttributes(this.attributes);

--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
@@ -74,13 +74,14 @@ type TransitAccessibilityMapWithPolygonAndTimeResult = TransitAccessibilityMapWi
     travelTime?: number;
 };
 
-interface TransitRoutingFormState extends ChangeEventsState<TransitAccessibilityMapRouting> {
+interface AccessibilityComparisonFormState extends ChangeEventsState<TransitAccessibilityMapRouting> {
     currentPolygons?: {
         result1: FeatureCollection;
         result2: FeatureCollection;
     };
     alternateScenarioRouting: TransitAccessibilityMapRouting;
     scenarioCollection: any;
+    dataSourceCollection: any;
     loading: boolean;
     routingErrors?: TranslatableMessage[];
     geojsonDownloadUrl: string | null;
@@ -102,7 +103,10 @@ interface TransitRoutingFormState extends ChangeEventsState<TransitAccessibility
     comparisonPolygon2Color: string;
 }
 
-class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparisonFormProps, TransitRoutingFormState> {
+class AccessibilityComparisonForm extends ChangeEventsForm<
+    AccessibilityComparisonFormProps,
+    AccessibilityComparisonFormState
+> {
     calculateRoutingNonce = new Object();
 
     constructor(props) {
@@ -119,6 +123,7 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
             object: routingEngine,
             alternateScenarioRouting: routingEngine2,
             scenarioCollection: serviceLocator.collectionManager.get('scenarios'),
+            dataSourceCollection: serviceLocator.collectionManager.get('dataSources'),
             loading: false,
             geojsonDownloadUrl: null,
             jsonDownloadUrl: null,
@@ -153,6 +158,7 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
         this.displayMap = this.displayMap.bind(this);
         this.calculateRouting = this.calculateRouting.bind(this);
         this.onScenarioCollectionUpdate = this.onScenarioCollectionUpdate.bind(this);
+        this.onDataSourceCollectionUpdate = this.onDataSourceCollectionUpdate.bind(this);
 
         routingEngine.updatePointColor(this.state.intersectionLocationColor);
         if (routingEngine.hasLocation()) {
@@ -165,6 +171,39 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
 
     onScenarioCollectionUpdate() {
         this.setState({ scenarioCollection: serviceLocator.collectionManager.get('scenarios') });
+
+        // If a previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
+        // In that case, change it to undefined.
+        const routing = this.state.object;
+        const alternateRouting = this.state.alternateScenarioRouting;
+        const scenarioId1 = routing.attributes.scenarioId;
+        const scenario1 = this.state.scenarioCollection.getById(scenarioId1);
+        if (scenarioId1 !== undefined && scenario1 === undefined) {
+            routing.set('scenarioId', undefined);
+            this.onValueChange('alternateScenario1Id', { value: undefined });
+        }
+
+        const scenarioId2 = alternateRouting.attributes.scenarioId;
+        const scenario2 = this.state.scenarioCollection.getById(scenarioId2);
+        if (scenarioId2 !== undefined && scenario2 === undefined) {
+            alternateRouting.set('scenarioId', undefined);
+            this.onValueChange('alternateScenario2Id', { value: undefined });
+        }
+    }
+
+    onDataSourceCollectionUpdate() {
+        this.setState({ dataSourceCollection: serviceLocator.collectionManager.get('dataSources') });
+
+        // If we previously selected yes for calculating population and then delete all our data sources, the choice widget will disappear while the calculatePopulation value will still be at true.
+        // We use this to hard code it to false and the data source name to an empty string if we detect it to be true while there are no data sources.
+        const zonesDataSources = this.getZonesDataSource(this.state.dataSourceCollection);
+        const routing = this.state.object;
+        const alternateRouting = this.state.alternateScenarioRouting;
+
+        if (zonesDataSources.length === 0 && routing.attributes.calculatePopulation) {
+            this.updateBothRoutingEngines('calculatePopulation', { value: false }, alternateRouting);
+            this.updateBothRoutingEngines('populationDataSourceName', { value: '' }, alternateRouting);
+        }
     }
 
     async calculateRouting(refresh = false) {
@@ -316,21 +355,8 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
     }
 
     componentDidMount() {
-        // If a previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
-        // In that case, change it to undefined.
-        const scenarioId1 = this.state.object.attributes.scenarioId;
-        const scenario1 = this.state.scenarioCollection.getById(scenarioId1);
-        if (scenarioId1 !== undefined && scenario1 === undefined) {
-            this.state.object.set('scenarioId', undefined);
-            this.onValueChange('alternateScenario1Id', { value: undefined });
-        }
-
-        const scenarioId2 = this.state.alternateScenarioRouting.attributes.scenarioId;
-        const scenario2 = this.state.scenarioCollection.getById(scenarioId2);
-        if (scenarioId2 !== undefined && scenario2 === undefined) {
-            this.state.alternateScenarioRouting.set('scenarioId', undefined);
-            this.onValueChange('alternateScenario2Id', { value: undefined });
-        }
+        this.onScenarioCollectionUpdate();
+        this.onDataSourceCollectionUpdate();
 
         const contextMenu = document.getElementById('tr__main-map-context-menu');
         this.setState({
@@ -338,11 +364,13 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
             contextMenuRoot: contextMenu ? createRoot(contextMenu) : undefined
         });
         serviceLocator.eventManager.on('collection.update.scenarios', this.onScenarioCollectionUpdate);
+        serviceLocator.eventManager.on('collection.update.dataSources', this.onDataSourceCollectionUpdate);
         serviceLocator.eventManager.on('map.showMapComparisonContextMenu', this.showContextMenu);
     }
 
     componentWillUnmount() {
         serviceLocator.eventManager.off('collection.update.scenarios', this.onScenarioCollectionUpdate);
+        serviceLocator.eventManager.off('collection.update.dataSources', this.onDataSourceCollectionUpdate);
         serviceLocator.eventManager.off('map.showMapComparisonContextMenu', this.showContextMenu);
     }
 
@@ -534,8 +562,21 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
         return rgbaArray.join();
     };
 
+    private getZonesDataSource = (dataSourceCollection: any) => {
+        return dataSourceCollection.features
+            .filter((source) => {
+                return source._attributes.type === 'zones';
+            })
+            .map((source) => {
+                return {
+                    value: source._attributes.name,
+                    label: source._attributes.name
+                };
+            });
+    };
+
     render() {
-        if (!this.state.scenarioCollection) {
+        if (!this.state.scenarioCollection || !this.state.dataSourceCollection) {
             return <LoadingPage />;
         }
 
@@ -558,6 +599,8 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                 label: scenario.toString(false)
             };
         });
+
+        const zonesDataSources = this.getZonesDataSource(this.state.dataSourceCollection);
 
         const returnTabContent = (mode: string) => {
             return (
@@ -784,35 +827,54 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                                     max={MAX_WALKING_SPEED_KPH}
                                 />
                             </InputWrapper>
-                            <InputWrapper
-                                smallInput={true}
-                                label={this.props.t('transit:transitRouting:CalculatePopulation')}
-                            >
-                                <InputRadio
-                                    id={`formFieldTransitAccessibilityMapCalculatePopulation${routingId}`}
-                                    value={routing.attributes.calculatePopulation}
-                                    sameLine={true}
-                                    disabled={false}
-                                    choices={[
-                                        {
-                                            value: true
-                                        },
-                                        {
-                                            value: false
+                            {zonesDataSources.length >= 1 && ( // We only want this widget to appear if we have at least one appropriate data source.
+                                <InputWrapper
+                                    smallInput={true}
+                                    label={this.props.t('transit:transitRouting:CalculatePopulation')}
+                                >
+                                    <InputRadio
+                                        id={`formFieldTransitAccessibilityMapCalculatePopulation${routingId}`}
+                                        value={routing.attributes.calculatePopulation}
+                                        sameLine={true}
+                                        disabled={false}
+                                        choices={[
+                                            {
+                                                value: true
+                                            },
+                                            {
+                                                value: false
+                                            }
+                                        ]}
+                                        localePrefix="transit:transitRouting"
+                                        t={this.props.t}
+                                        isBoolean={true}
+                                        onValueChange={(e) =>
+                                            this.updateBothRoutingEngines(
+                                                'calculatePopulation',
+                                                { value: _toBool(e.target.value) },
+                                                alternateRouting
+                                            )
                                         }
-                                    ]}
-                                    localePrefix="transit:transitRouting"
-                                    t={this.props.t}
-                                    isBoolean={true}
-                                    onValueChange={(e) =>
-                                        this.updateBothRoutingEngines(
-                                            'calculatePopulation',
-                                            { value: _toBool(e.target.value) },
-                                            alternateRouting
-                                        )
-                                    }
-                                />
-                            </InputWrapper>
+                                    />
+                                </InputWrapper>
+                            )}
+                            {zonesDataSources.length >= 1 && routing.attributes.calculatePopulation && (
+                                <InputWrapper label={this.props.t('transit:transitRouting:PopulationDataSourceSelect')}>
+                                    <InputSelect
+                                        id={`formFieldTransitAccessibilityMapDataSourceSelect${routingId}`}
+                                        value={routing.attributes.populationDataSourceName}
+                                        choices={zonesDataSources}
+                                        t={this.props.t}
+                                        onValueChange={(e) =>
+                                            this.updateBothRoutingEngines(
+                                                'populationDataSourceName',
+                                                { value: e.target.value },
+                                                alternateRouting
+                                            )
+                                        }
+                                    />
+                                </InputWrapper>
+                            )}
                             <InputWrapper
                                 smallInput={true}
                                 label={this.props.t('transit:transitRouting:CalculatePois')}
@@ -981,6 +1043,7 @@ class AccessibilityComparisonForm extends ChangeEventsForm<AccessibilityComparis
                                 mode={mode}
                                 color1={this.changeAlphaValue(this.state.comparisonPolygon1Color, 1)}
                                 color2={this.changeAlphaValue(this.state.comparisonPolygon2Color, 1)}
+                                calculatePopulation={routing.attributes.calculatePopulation}
                             />
                         </React.Fragment>
                     )}

--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonStatsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonStatsComponent.tsx
@@ -18,6 +18,7 @@ export interface AccessibilityComparisonStatsComponentProps {
     mode: ComparisonMode;
     color1: string;
     color2: string;
+    calculatePopulation?: boolean;
 }
 
 const AccessibilityComparisonStatsComponent: React.FunctionComponent<AccessibilityComparisonStatsComponentProps> = (
@@ -164,13 +165,76 @@ const AccessibilityComparisonStatsComponent: React.FunctionComponent<Accessibili
                         )}
                     </td>
                 </tr>
-                {typeof properties1.population === 'number' && typeof properties2.population === 'number' && (
+                {/* TODO: If only one of the zones has no population data, make a special case for that instead of just not displaying this section altogether. */}
+                {typeof properties1.populationData?.population === 'number' &&
+                    typeof properties2.populationData?.population === 'number' && (
                     <tr>
                         <th>{t('transit:transitRouting:AccessibilityMapPopulation')}</th>
-                        <td>{properties1.population.toLocaleString(language)}</td>
-                        <td>{properties2.population.toLocaleString(language)}</td>
                         <td>
-                            {(properties2.population - properties1.population).toLocaleString(language, {
+                            {properties1.populationData?.population.toLocaleString(language)}
+                            {properties1.populationData?.dataSourceAreaRatio < 0.99 && (
+                                <React.Fragment>
+                                        &nbsp;
+                                    <span
+                                        className="apptr__form-warning-message"
+                                        data-tooltip-id={`data-source-incomplete-area-1-warning-${durationMinutes}`}
+                                    >
+                                            &#9888;
+                                        {/* Warning sign: ⚠ */}
+                                    </span>
+                                    <Tooltip
+                                        id={`data-source-incomplete-area-1-warning-${durationMinutes}`}
+                                        opacity={1}
+                                        style={{ maxWidth: '90%', zIndex: 100 }}
+                                    >
+                                        <span className="apptr__form-warning-message">
+                                            {t('transit:transitRouting:DataSourceWarningPopup', {
+                                                percentage: (
+                                                    Math.round(
+                                                        properties1.populationData?.dataSourceAreaRatio * 100 * 10
+                                                    ) / 10
+                                                ) // Round to the nearest percentage decimal point.
+                                                    .toLocaleString(language)
+                                            })}
+                                        </span>
+                                    </Tooltip>
+                                </React.Fragment>
+                            )}
+                        </td>
+                        <td>
+                            {properties2.populationData?.population?.toLocaleString(language)}
+                            {properties2.populationData?.dataSourceAreaRatio < 0.99 && (
+                                <React.Fragment>
+                                        &nbsp;
+                                    <span
+                                        className="apptr__form-warning-message"
+                                        data-tooltip-id={`data-source-incomplete-area-2-warning-${durationMinutes}`}
+                                    >
+                                            &#9888;
+                                    </span>
+                                    <Tooltip
+                                        id={`data-source-incomplete-area-2-warning-${durationMinutes}`}
+                                        opacity={1}
+                                        style={{ maxWidth: '90%', zIndex: 100 }}
+                                    >
+                                        <span className="apptr__form-warning-message">
+                                            {t('transit:transitRouting:DataSourceWarningPopup', {
+                                                percentage: (
+                                                    Math.round(
+                                                        properties2.populationData?.dataSourceAreaRatio * 100 * 10
+                                                    ) / 10
+                                                ) // Round to the nearest percentage decimal point.
+                                                    .toLocaleString(language)
+                                            })}
+                                        </span>
+                                    </Tooltip>
+                                </React.Fragment>
+                            )}
+                        </td>
+                        <td>
+                            {(
+                                properties2.populationData?.population - properties1.populationData?.population
+                            ).toLocaleString(language, {
                                 signDisplay: 'exceptZero'
                             })}
                         </td>
@@ -238,7 +302,20 @@ const AccessibilityComparisonStatsComponent: React.FunctionComponent<Accessibili
                         )}
                     </React.Fragment>
                 )}
-                <br />
+                {props.calculatePopulation &&
+                    (properties1.populationData?.population === null ||
+                        properties2.populationData?.population === null) && (
+                    <tr>
+                        <td colSpan={4} className="apptr__form-warning-message">
+                            <span className="apptr__form-warning-message">
+                                {t('transit:transitRouting:DataSourceNullWarningComparisonPopup')}
+                            </span>
+                        </td>
+                    </tr>
+                )}
+                <tr>
+                    <td colSpan={4} />
+                </tr>
             </React.Fragment>
         );
     });

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -24,22 +24,16 @@ import InputSelect from 'chaire-lib-frontend/lib/components/input/InputSelect';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { default as FormErrors } from 'chaire-lib-frontend/lib/components/pageParts/FormErrors';
-import Preferences from 'chaire-lib-common/lib/config/Preferences';
-import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
-import TransitAccessibilityMapRouting, {
-    MAX_DELTA_MINUTES,
-    MAX_DELTA_INTERVAL_MINUTES,
-    MIN_WALKING_SPEED_KPH,
-    MAX_WALKING_SPEED_KPH
-} from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
-import { calculateAccessibilityMap } from '../../../services/routing/RoutingUtils';
-import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
-import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
-import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
-import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import DownloadsUtils from 'chaire-lib-frontend/lib/services/DownloadsService';
 import { ChangeEventsForm, ChangeEventsState } from 'chaire-lib-frontend/lib/components/forms/ChangeEventsForm';
 import LoadingPage from 'chaire-lib-frontend/lib/components/pages/LoadingPage';
+import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
+
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
+import { mpsToKph, kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
+import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
+import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { _toInteger } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { _toBool } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import {
@@ -47,13 +41,22 @@ import {
     secondsToMinutes,
     minutesToSeconds
 } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
+
+import TransitAccessibilityMapRouting, {
+    MAX_DELTA_MINUTES,
+    MAX_DELTA_INTERVAL_MINUTES,
+    MIN_WALKING_SPEED_KPH,
+    MAX_WALKING_SPEED_KPH
+} from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapRouting';
+import { TransitAccessibilityMapWithPolygonResult } from 'transition-common/lib/services/accessibilityMap/TransitAccessibilityMapResult';
+
+import { calculateAccessibilityMap } from '../../../services/routing/RoutingUtils';
 import AccessibilityMapStatsComponent from './AccessibilityMapStatsComponent';
 import TimeOfTripComponent from '../transitRouting/widgets/TimeOfTripComponent';
 import TransitRoutingBaseComponent from '../transitRouting/widgets/TransitRoutingBaseComponent';
 import AccessibilityMapBatchForm from './AccessibilityMapBatchForm';
 import AccessibilityMapCoordinatesComponent from './widgets/AccessibilityMapCoordinateComponent';
-import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
-import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 export interface AccessibilityMapFormProps extends WithTranslation {
     addEventListeners?: () => void;
@@ -62,9 +65,10 @@ export interface AccessibilityMapFormProps extends WithTranslation {
     fileImportRef?: any;
 }
 
-interface TransitRoutingFormState extends ChangeEventsState<TransitAccessibilityMapRouting> {
+interface AccessibilityMapFormState extends ChangeEventsState<TransitAccessibilityMapRouting> {
     currentResult?: TransitAccessibilityMapWithPolygonResult;
     scenarioCollection: any;
+    dataSourceCollection: any;
     loading: boolean;
     routingErrors?: TranslatableMessage[];
     geojsonDownloadUrl: string | null;
@@ -72,7 +76,7 @@ interface TransitRoutingFormState extends ChangeEventsState<TransitAccessibility
     csvDownloadUrl: string | null;
 }
 
-class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, TransitRoutingFormState> {
+class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, AccessibilityMapFormState> {
     calculateRoutingNonce = new Object();
 
     constructor(props) {
@@ -84,6 +88,7 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         this.state = {
             object: routingEngine,
             scenarioCollection: serviceLocator.collectionManager.get('scenarios'),
+            dataSourceCollection: serviceLocator.collectionManager.get('dataSources'),
             loading: false,
             geojsonDownloadUrl: null,
             jsonDownloadUrl: null,
@@ -94,6 +99,7 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         this.polygonCalculated = this.polygonCalculated.bind(this);
         this.calculateRouting = this.calculateRouting.bind(this);
         this.onScenarioCollectionUpdate = this.onScenarioCollectionUpdate.bind(this);
+        this.onDataSourceCollectionUpdate = this.onDataSourceCollectionUpdate.bind(this);
 
         if (routingEngine.hasLocation()) {
             (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
@@ -105,6 +111,26 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
 
     onScenarioCollectionUpdate() {
         this.setState({ scenarioCollection: serviceLocator.collectionManager.get('scenarios') });
+
+        // If the previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
+        // In that case, change it to undefined.
+        const scenarioId = this.state.object.attributes.scenarioId;
+        const scenario = this.state.scenarioCollection.getById(scenarioId);
+        if (scenarioId !== undefined && scenario === undefined) {
+            this.onValueChange('scenarioId', { value: undefined });
+        }
+    }
+
+    onDataSourceCollectionUpdate() {
+        this.setState({ dataSourceCollection: serviceLocator.collectionManager.get('dataSources') });
+
+        // If we previously selected yes for calculating population and then delete all our data sources, the choice widget will disappear while the calculatePopulation value will still be at true.
+        // We use this to hard code it to false and the data source name to an empty string if we detect it to be true while there are no data sources.
+        const zonesDataSources = this.getZonesDataSource(this.state.dataSourceCollection);
+        if (zonesDataSources.length === 0 && this.state.object.attributes.calculatePopulation) {
+            this.onValueChange('calculatePopulation', { value: false });
+            this.onValueChange('populationDataSourceName', { value: '' });
+        }
     }
 
     async calculateRouting(refresh = false) {
@@ -174,19 +200,16 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
     }
 
     componentDidMount() {
-        // If the previously selected scenario was deleted, the current scenario ID will remain but the scenario itself will no longer exist, leading to an error.
-        // In that case, change it to undefined.
-        const scenarioId = this.state.object.attributes.scenarioId;
-        const scenario = this.state.scenarioCollection.getById(scenarioId);
-        if (scenarioId !== undefined && scenario === undefined) {
-            this.onValueChange('scenarioId', { value: undefined });
-        }
+        this.onScenarioCollectionUpdate();
+        this.onDataSourceCollectionUpdate();
 
         serviceLocator.eventManager.on('collection.update.scenarios', this.onScenarioCollectionUpdate);
+        serviceLocator.eventManager.on('collection.update.dataSources', this.onDataSourceCollectionUpdate);
     }
 
     componentWillUnmount() {
         serviceLocator.eventManager.off('collection.update.scenarios', this.onScenarioCollectionUpdate);
+        serviceLocator.eventManager.off('collection.update.dataSources', this.onDataSourceCollectionUpdate);
     }
 
     onValueChange(path: string, newValue: { value: any; valid?: boolean } = { value: null, valid: true }) {
@@ -217,8 +240,21 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
         }
     };
 
+    private getZonesDataSource = (dataSourceCollection: any) => {
+        return dataSourceCollection.features
+            .filter((source) => {
+                return source._attributes.type === 'zones';
+            })
+            .map((source) => {
+                return {
+                    value: source._attributes.name,
+                    label: source._attributes.name
+                };
+            });
+    };
+
     render() {
-        if (!this.state.scenarioCollection) {
+        if (!this.state.scenarioCollection || !this.state.dataSourceCollection) {
             return <LoadingPage />;
         }
 
@@ -240,6 +276,8 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                 label: scenario.toString(false)
             };
         });
+
+        const zonesDataSources = this.getZonesDataSource(this.state.dataSourceCollection);
 
         return (
             <React.Fragment>
@@ -353,31 +391,48 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                                     max={MAX_WALKING_SPEED_KPH}
                                 />
                             </InputWrapper>
-                            <InputWrapper
-                                smallInput={true}
-                                label={this.props.t('transit:transitRouting:CalculatePopulation')}
-                            >
-                                <InputRadio
-                                    id={`formFieldTransitAccessibilityMapCalculatePopulation${routingId}`}
-                                    value={routing.attributes.calculatePopulation}
-                                    sameLine={true}
-                                    disabled={false}
-                                    choices={[
-                                        {
-                                            value: true
-                                        },
-                                        {
-                                            value: false
+                            {zonesDataSources.length >= 1 && ( // We only want this widget to appear if we have at least one appropriate data source.
+                                <InputWrapper
+                                    smallInput={true}
+                                    label={this.props.t('transit:transitRouting:CalculatePopulation')}
+                                >
+                                    <InputRadio
+                                        id={`formFieldTransitAccessibilityMapCalculatePopulation${routingId}`}
+                                        value={routing.attributes.calculatePopulation}
+                                        sameLine={true}
+                                        disabled={false}
+                                        choices={[
+                                            {
+                                                value: true
+                                            },
+                                            {
+                                                value: false
+                                            }
+                                        ]}
+                                        localePrefix="transit:transitRouting"
+                                        t={this.props.t}
+                                        isBoolean={true}
+                                        onValueChange={(e) =>
+                                            this.onValueChange('calculatePopulation', {
+                                                value: _toBool(e.target.value)
+                                            })
                                         }
-                                    ]}
-                                    localePrefix="transit:transitRouting"
-                                    t={this.props.t}
-                                    isBoolean={true}
-                                    onValueChange={(e) =>
-                                        this.onValueChange('calculatePopulation', { value: _toBool(e.target.value) })
-                                    }
-                                />
-                            </InputWrapper>
+                                    />
+                                </InputWrapper>
+                            )}
+                            {zonesDataSources.length >= 1 && routing.attributes.calculatePopulation && (
+                                <InputWrapper label={this.props.t('transit:transitRouting:PopulationDataSourceSelect')}>
+                                    <InputSelect
+                                        id={`formFieldTransitAccessibilityMapDataSourceSelect${routingId}`}
+                                        value={routing.attributes.populationDataSourceName}
+                                        choices={zonesDataSources}
+                                        t={this.props.t}
+                                        onValueChange={(e) =>
+                                            this.onValueChange('populationDataSourceName', { value: e.target.value })
+                                        }
+                                    />
+                                </InputWrapper>
+                            )}
                             <InputWrapper
                                 smallInput={true}
                                 label={this.props.t('transit:transitRouting:CalculatePois')}
@@ -511,7 +566,10 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, T
                         )}
                     </div>
                     {this.state.currentResult && (
-                        <AccessibilityMapStatsComponent accessibilityPolygons={this.state.currentResult.polygons} />
+                        <AccessibilityMapStatsComponent
+                            accessibilityPolygons={this.state.currentResult.polygons}
+                            calculatePopulation={routing.attributes.calculatePopulation}
+                        />
                     )}
                 </form>
                 <AccessibilityMapBatchForm routingEngine={this.state.object} />

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapStatsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapStatsComponent.tsx
@@ -12,6 +12,7 @@ import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/I
 
 export interface AccessibilityMapStatsComponentProps {
     accessibilityPolygons: GeoJSON.FeatureCollection;
+    calculatePopulation?: boolean;
 }
 
 const AccessibilityMapStatsComponent: React.FunctionComponent<AccessibilityMapStatsComponentProps> = (
@@ -113,65 +114,105 @@ const AccessibilityMapStatsComponent: React.FunctionComponent<AccessibilityMapSt
         );
 
         return (
-            <table className="_statistics" key={properties.durationMinutes}>
-                <tbody>
-                    <tr>
-                        <th className="_header" colSpan={2}>
-                            {t('transit:transitRouting:AccessibilityMapAreaTitle', {
-                                n: Math.round(properties.durationMinutes)
-                            })}
-                        </th>
-                    </tr>
-                    <tr>
-                        <th>{t('transit:transitRouting:AccessibilityMapAreaSquareKm')}</th>
-                        <td>{(Math.round(properties.areaSqKm * 100) / 100).toLocaleString(language)}</td>
-                    </tr>
-                    {typeof properties.population === 'number' && (
+            <React.Fragment key={properties.durationMinutes}>
+                <table className="_statistics">
+                    <tbody>
                         <tr>
-                            <th>{t('transit:transitRouting:AccessibilityMapPopulation')}</th>
-                            <td>{properties.population.toLocaleString(language)}</td>
+                            <th className="_header" colSpan={2}>
+                                {t('transit:transitRouting:AccessibilityMapAreaTitle', {
+                                    n: Math.round(properties.durationMinutes)
+                                })}
+                            </th>
                         </tr>
-                    )}
-                    {categoryTotal > 0 && (
-                        <React.Fragment>
+                        <tr>
+                            <th>{t('transit:transitRouting:AccessibilityMapAreaSquareKm')}</th>
+                            <td>{(Math.round(properties.areaSqKm * 100) / 100).toLocaleString(language)}</td>
+                        </tr>
+                        {typeof properties.populationData?.population === 'number' && (
                             <tr>
-                                <th colSpan={2} className="_header" data-tooltip-id="accessible-POI-header">
-                                    {t('transit:transitRouting:NumberOfAccessiblePOIsInNMinutesByCategory', {
-                                        n: Math.round(properties.durationMinutes)
-                                    })}
-                                </th>
+                                <th>{t('transit:transitRouting:AccessibilityMapPopulation')}</th>
+                                <td>
+                                    {properties.populationData?.population?.toLocaleString(language)}
+                                    {properties.populationData?.dataSourceAreaRatio < 0.99 && (
+                                        <React.Fragment>
+                                            &nbsp;
+                                            <span
+                                                className="apptr__form-warning-message"
+                                                data-tooltip-id={`data-source-incomplete-area-warning-${properties.durationMinutes}`}
+                                            >
+                                                &#9888;
+                                                {/* Warning sign: ⚠ */}
+                                            </span>
+                                            <Tooltip
+                                                id={`data-source-incomplete-area-warning-${properties.durationMinutes}`}
+                                                opacity={1}
+                                                style={{ maxWidth: '90%', zIndex: 100 }}
+                                            >
+                                                <span className="apptr__form-warning-message">
+                                                    {t('transit:transitRouting:DataSourceWarningPopup', {
+                                                        percentage: (
+                                                            Math.round(
+                                                                properties.populationData?.dataSourceAreaRatio *
+                                                                    100 *
+                                                                    10
+                                                            ) / 10
+                                                        ).toLocaleString(language)
+                                                    })}
+                                                </span>
+                                            </Tooltip>
+                                        </React.Fragment>
+                                    )}
+                                </td>
                             </tr>
-                            <tr>
-                                <th colSpan={2}>
-                                    <div style={{ margin: 0 }}>
-                                        <Collapsible
-                                            trigger={
-                                                <div>
-                                                    {t('transit:transitRouting:TotalPOIs')}&nbsp;
-                                                    <span style={{ color: textEmphasizedColor }}>{categoryTotal}</span>
+                        )}
+                        {categoryTotal > 0 && (
+                            <React.Fragment>
+                                <tr>
+                                    <th colSpan={2} className="_header" data-tooltip-id="accessible-POI-header">
+                                        {t('transit:transitRouting:NumberOfAccessiblePOIsInNMinutesByCategory', {
+                                            n: Math.round(properties.durationMinutes)
+                                        })}
+                                    </th>
+                                </tr>
+                                <tr>
+                                    <th colSpan={2}>
+                                        <div style={{ margin: 0 }}>
+                                            <Collapsible
+                                                trigger={
+                                                    <div>
+                                                        {t('transit:transitRouting:TotalPOIs')}&nbsp;
+                                                        <span style={{ color: textEmphasizedColor }}>
+                                                            {categoryTotal}
+                                                        </span>
+                                                    </div>
+                                                }
+                                                triggerStyle={{ backgroundColor: collapsibleBackgroundColor }}
+                                                open={false}
+                                                transitionTime={100}
+                                            >
+                                                <div style={{ backgroundColor: collapsibleBackgroundColor }}>
+                                                    <div>{accessiblePlacesCountByCategory}</div>
+                                                    {accessiblePlacesCountByDetailedCategory.length > 0 &&
+                                                        detailedCategoryCollapsible}
+                                                    <br></br>
                                                 </div>
-                                            }
-                                            triggerStyle={{ backgroundColor: collapsibleBackgroundColor }}
-                                            open={false}
-                                            transitionTime={100}
-                                        >
-                                            <div style={{ backgroundColor: collapsibleBackgroundColor }}>
-                                                <div>{accessiblePlacesCountByCategory}</div>
-                                                {accessiblePlacesCountByDetailedCategory.length > 0 &&
-                                                    detailedCategoryCollapsible}
-                                                <br></br>
-                                            </div>
-                                        </Collapsible>
-                                    </div>
-                                </th>
-                            </tr>
-                        </React.Fragment>
-                    )}
-                </tbody>
+                                            </Collapsible>
+                                        </div>
+                                    </th>
+                                </tr>
+                            </React.Fragment>
+                        )}
+                    </tbody>
+                </table>
                 <Tooltip id="accessible-POI-header" opacity={1} style={{ maxWidth: '90%', zIndex: 100 }}>
                     <span>{t('transit:transitRouting:AccessiblePOIsPopup')}</span>
                 </Tooltip>
-            </table>
+                {props.calculatePopulation && properties.populationData?.population === null && (
+                    <div className="apptr__form-warning-message">
+                        {t('transit:transitRouting:DataSourceNullWarningPopup')}
+                    </div>
+                )}
+            </React.Fragment>
         );
     });
     return <div className="tr__form-section">{featureStats}</div>;


### PR DESCRIPTION
Calculating population in accessibility maps will now ask to enter a data source of the zones type. The population function also returns a second parameter which indicates how much of the polygon is covered by the zones in the data source, and will warn the user when it is below 99% (for example, if the accessibility map is calculated just outside of the data source's border).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Option to choose a population data source for population calculations; requests/results include the selected data source name.
  - Results return populationData (population + data-source area ratio) per area.

* **Improvements**
  - Per-area completeness indicators and tooltips when coverage is incomplete.
  - Validation now surfaces a clear error when a required population data source is missing.
  - Bad-request responses include an explanatory description.

* **Documentation / Localization**
  - Added UI strings for data-source selection, null/coverage warnings, and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->