### PR TITLE
Use PQueue to make the zones import less flaky.

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -23,7 +23,7 @@ packages/transition-backend/lib/scripts/disseminationBlocks/importDisseminationB
 
 ### Description
 
-Imports data from Statistics Canada relating to dissemination blocks (the smallest division level used by the Canadian census) in the database. Though it is meant to work with two specific files (found at <https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/index2021-eng.cfm?year=21> and <https://www150.statcan.gc.ca/n1/pub/17-26-0002/172600022023001-eng.htm>), it should in theory work with other levels of census divisions, as long as the corresponding files use the same format and structure.
+Imports data from Statistics Canada relating to dissemination blocks (the smallest division level used by the Canadian census) in the database. Though it is meant to work with two specific files (found at <https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/index2021-eng.cfm?year=21> with the "Dissemination blocks" and "gml" option, and <https://www150.statcan.gc.ca/n1/pub/17-26-0002/172600022023001-eng.htm>), it should in theory work with other levels of census divisions, as long as the corresponding files use the same format and structure.
 
 First, the task parses a GML file containing the geographic boundaries of all the blocks, importing it and adding new entries to the `zones` table, as well as converting the boundaries from the coordinate system used in the file to WGS84, the system used by Transition.
 


### PR DESCRIPTION
Due to limitations of the gml parser, the database function call was not awaited, making the task quite flaky. This rewrites it with PQueue instead to be more reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved zone import reliability and throughput by serializing and rate-limiting backend writes, enhancing error handling, and ensuring final batches are processed; progress and completion messages updated for clearer status.
* **Documentation**
  * Clarified the import task to specify the accepted StatCan source options ("Dissemination blocks" and "gml").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->