### PR TITLE
Delete the square meters from accessibility map stats.

### DIFF
--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonStatsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonStatsComponent.tsx
@@ -163,16 +163,6 @@ const AccessibilityComparisonStatsComponent: React.FunctionComponent<Accessibili
                         )}
                     </td>
                 </tr>
-                <tr>
-                    <th>{t('transit:transitRouting:AccessibilityMapAreaSquarem')}</th>
-                    <td>{Math.round(properties1.areaSqM).toLocaleString(language)}</td>
-                    <td>{Math.round(properties2.areaSqM).toLocaleString(language)}</td>
-                    <td>
-                        {Math.round(properties2.areaSqM - properties1.areaSqM).toLocaleString(language, {
-                            signDisplay: 'exceptZero'
-                        })}
-                    </td>
-                </tr>
                 {typeof properties1.population === 'number' && typeof properties2.population === 'number' && (
                     <tr>
                         <th>{t('transit:transitRouting:AccessibilityMapPopulation')}</th>

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapStatsComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapStatsComponent.tsx
@@ -126,10 +126,6 @@ const AccessibilityMapStatsComponent: React.FunctionComponent<AccessibilityMapSt
                         <th>{t('transit:transitRouting:AccessibilityMapAreaSquareKm')}</th>
                         <td>{(Math.round(properties.areaSqKm * 100) / 100).toLocaleString(language)}</td>
                     </tr>
-                    <tr>
-                        <th>{t('transit:transitRouting:AccessibilityMapAreaSquarem')}</th>
-                        <td>{Math.round(properties.areaSqM).toLocaleString(language)}</td>
-                    </tr>
                     {typeof properties.population === 'number' && (
                         <tr>
                             <th>{t('transit:transitRouting:AccessibilityMapPopulation')}</th>


### PR DESCRIPTION
They are much too precise for what we need, and we already show the square kilometers anyways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed area measurements in square meters from accessibility statistics displays, streamlining the interface while retaining other key metrics like area in square kilometers and population data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->