### PR TITLE
networkDesign: change DB data type of fitness from numeric to float

### DIFF
--- a/packages/transition-backend/src/models/db/migrations/20260214104900_updateNetworkDesignFitnessType.ts
+++ b/packages/transition-backend/src/models/db/migrations/20260214104900_updateNetworkDesignFitnessType.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { Knex } from 'knex';
+
+const tableName = 'tr_jobs_network_design_results';
+const simulationMethodTableName = 'tr_jobs_network_design_simulation_results';
+
+/**
+ * Update the fitness score type from decimal to float to avoid large
+ * fitnesses scores causing database errors.
+ * @param knex
+ * @returns
+ */
+export async function up(knex: Knex): Promise<unknown> {
+    await knex.schema.alterTable(simulationMethodTableName, (table: Knex.TableBuilder) => {
+        table.double('fitness_score').notNullable().alter();
+    });
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.double('total_fitness').notNullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<unknown> {
+    await knex.schema.alterTable(simulationMethodTableName, (table: Knex.TableBuilder) => {
+        table.decimal('fitness_score').notNullable().alter();
+    });
+    return knex.schema.alterTable(tableName, (table: Knex.TableBuilder) => {
+        table.decimal('total_fitness').notNullable().alter();
+    });
+}


### PR DESCRIPTION
The `decimal` knex data type converts by default to a `numeric(8,2)` in postgres, effectively making maxing the value to 6 digits with 2 decimals. We use `float` instead to support any floating point value for the fitness score, as it can be quite high for large simulations.