### PR TITLE
Add hybridRailTires support for Montreal metro

### DIFF
--- a/packages/transition-backend/src/services/generalizedCostFunction/__tests__/GeneralizedCostFunction.test.ts
+++ b/packages/transition-backend/src/services/generalizedCostFunction/__tests__/GeneralizedCostFunction.test.ts
@@ -40,6 +40,7 @@ const createDefaultWeights = (): GeneralizedCostFunctionWeights => ({
     inVehicleTravelTimeWeightBySupport: {
         rail: 0.85,
         tires: 1.0,
+        hybridRailTires: 0.9,
         water: 1.1,
         suspended: 0.9,
         magnetic: 0.85,

--- a/packages/transition-common/src/services/line/types.ts
+++ b/packages/transition-common/src/services/line/types.ts
@@ -67,6 +67,8 @@ export type ReliabilityRatio = number | undefined;
 /** Support
  * rail: steel on steel
  * tires: rubber tires on pavement (car, bus, etc.)
+ * hybridRailTires: example: Montreal/Paris metro: rubber tires with backup rail wheels on tracks
+ *   See https://en.wikipedia.org/wiki/Rubber-tyred_metro
  * water: buoyancy (can induce sickness and or fear to some people)
  * suspended: suspended gondola (can induce fear to some people)
  * magnetic: magnetic levitation (maglev)
@@ -78,6 +80,7 @@ export type ReliabilityRatio = number | undefined;
 export const supports = [
     'rail',
     'tires',
+    'hybridRailTires',
     'water',
     'suspended',
     'magnetic',


### PR DESCRIPTION
The Montreal metro and some metro in Paris are using an hybrid of rubber tires and rail wheels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hybrid rail-tire transportation mode, a new vehicle type featuring rubber tires with backup rail wheels for track-based operation. This mode is now available for routing calculations and transit service planning with optimized weight parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->