### PR TITLE
ci: add `railCurveRadius` branch to docker build

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: 
       - "main"
-      - "deck-gl-poc"
       - "validationTrajets"
       - "evolutionaryTransitNetworkDesign"
+      - "railCurveRadius"
   workflow_dispatch:
   schedule:
     # Do a daily rebuild at 2:00 AM UTC


### PR DESCRIPTION
This branch adds the curve-aware manual train routing, with interactive visualization, to better analyze train speeds and travel times.

And remove the `deck-gl-poc` branch that has been merged in `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to adjust which branches trigger automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->