### PR TITLE
routing: remove debug console.logs from calculation code

### DIFF
--- a/packages/chaire-lib-backend/src/services/routing/Routing.ts
+++ b/packages/chaire-lib-backend/src/services/routing/Routing.ts
@@ -120,10 +120,6 @@ export class Routing {
         // ** backend
         const routingPromises: Promise<TransitOrRouteCalculatorResult>[] = [];
 
-        const origDestStr = `${routingAttributes.originGeojson.geometry.coordinates.join(',')} to ${routingAttributes.destinationGeojson.geometry.coordinates.join(',')}`;
-        console.log(
-            `tripRouting: Routing beginning with ${routingAttributes.routingModes.length} modes for ${origDestStr}`
-        );
         for (const routingMode of routingAttributes.routingModes) {
             if (isCancelled && isCancelled()) {
                 throw 'Cancelled';
@@ -144,7 +140,6 @@ export class Routing {
             throw 'Cancelled';
         }
 
-        console.log(`tripRouting: Routing done for ${origDestStr}`);
         const maxWalkingTime = Math.min(
             routingAttributes.maxTotalTravelTimeSeconds || 10800,
             2 * (routingAttributes.maxAccessEgressTravelTimeSeconds || 1200)
@@ -163,9 +158,7 @@ export class Routing {
         routingMode: RoutingMode | TransitMode,
         routingAttributes: TripRoutingQueryAttributes
     ): Promise<TransitOrRouteCalculatorResult> {
-        const origDestStr = `${routingAttributes.originGeojson.geometry.coordinates.join(',')} to ${routingAttributes.destinationGeojson.geometry.coordinates.join(',')}`;
         try {
-            console.log(`tripRouting: Routing single mode ${routingMode} for ${origDestStr}`);
             if (routingMode === 'transit') {
                 return {
                     routingMode,
@@ -185,7 +178,8 @@ export class Routing {
                 };
             }
         } catch (error) {
-            console.log(`tripRouting: Error routing single mode ${routingMode} for ${origDestStr}`);
+            const origDestStr = `${routingAttributes.originGeojson.geometry.coordinates.join(',')} to ${routingAttributes.destinationGeojson.geometry.coordinates.join(',')}`;
+            console.error(`tripRouting: Error routing single mode ${routingMode} for ${origDestStr}:`, error);
             return {
                 routingMode,
                 result: !TrError.isTrError(error)
@@ -195,8 +189,6 @@ export class Routing {
                     })
                     : error
             };
-        } finally {
-            console.log(`tripRouting: Done routing single mode ${routingMode} for ${origDestStr}`);
         }
     }
 }

--- a/packages/chaire-lib-backend/src/services/transitRouting/TransitRoutingService.ts
+++ b/packages/chaire-lib-backend/src/services/transitRouting/TransitRoutingService.ts
@@ -250,10 +250,7 @@ class TransitRoutingService {
         params: TrRoutingApi.TransitRouteQueryOptions,
         hostPort?: TrRoutingApi.HostPort
     ): Promise<TrRoutingRouteResult> {
-        const origDestStr = `${params.originDestination[0].geometry.coordinates.join(',')} to ${params.originDestination[1].geometry.coordinates.join(',')}`;
-        console.log(`tripRouting: Getting route from trRouting service for ${origDestStr}`);
         const responseStatus = await this.callRoute({ parameters: params, hostPort });
-        console.log(`tripRouting: Received route response from trRouting service for ${origDestStr}`);
         if (Status.isStatusError(responseStatus)) {
             this.handleErrorStatus(responseStatus);
         }

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -148,7 +148,6 @@ class TrRoutingBatch {
                         promiseQueue.clear();
                     }
                     try {
-                        console.log('tripRouting: Start handling batch routing odTrip %d', odTripIndex);
                         await this.odTripTask(odTripIndex, {
                             trRoutingPort,
                             logBefore: logOdTripBefore,
@@ -163,7 +162,6 @@ class TrRoutingBatch {
                                     progress: completedRoutingsCount / odTripsCount
                                 });
                             }
-                            console.log('tripRouting: Handled batch routing odTrip %d', odTripIndex);
                             checkpointTracker.handled(odTripIndex);
                         } catch (error) {
                             console.error(
@@ -294,8 +292,6 @@ class TrRoutingBatch {
             }
             options.logBefore(odTripIndex);
 
-            const origDestStr = `${odTrip.attributes.origin_geography.coordinates.join(',')} to ${odTrip.attributes.destination_geography.coordinates.join(',')}`;
-            console.log('tripRouting: Routing odTrip %d with coordinates %s', odTripIndex, origDestStr);
             const routingResult = await routeOdTrip(odTrip, {
                 trRoutingPort: options.trRoutingPort,
                 routing: this.job.attributes.data.parameters.transitRoutingAttributes,

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingOdTrip.ts
@@ -47,17 +47,14 @@ const routeOdTrip = async function (odTrip: BaseOdTrip, parameters: RouteOdTripP
         timeSecondsSinceMidnight: odTrip.attributes.timeOfTrip,
         timeType: odTrip.attributes.timeType
     };
-    const origDestStr = `${originGeojson.geometry.coordinates.join(',')} to ${destinationGeojson.geometry.coordinates.join(',')}`;
 
     try {
-        console.log('tripRouting: Routing single trip... %s', origDestStr);
         const results: RoutingResultsByMode = await Routing.calculate(tripQueryAttributes);
 
         // We do not need the walkOnlyPath in the results, as it is already present in the other modes
         if (results.transit) {
             delete results.transit.walkOnlyPath;
         }
-        console.log('tripRouting: Done routing single trip %s', origDestStr);
 
         return {
             uuid,
@@ -67,7 +64,6 @@ const routeOdTrip = async function (odTrip: BaseOdTrip, parameters: RouteOdTripP
             results
         };
     } catch (error) {
-        console.log('tripRouting: Error routing single trip %s', origDestStr);
         return {
             uuid,
             internalId,


### PR DESCRIPTION
These logs were added to investigate an issue with requests in the infra. Turns out the issue was that the infra ran out of sockets and caused missed checkpoints. The logs have not been used since then (and have not even been that useful for the problem under investigation) and the create a lot of noise in the output.

If we ever want to track requests, we should rather move to structured logging that has this exact purpose instead of text console.logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed internal debug/logging output across routing and transit-routing services, including batch and per-trip routing flows.
  * No functional changes to routing behavior, APIs, or public interfaces—this trims runtime noise and improves maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->