### PR TITLE
networkDesign: add a few log statements during execution

### DIFF
--- a/packages/chaire-lib-backend/src/services/json2capnp/Json2CapnpRust.ts
+++ b/packages/chaire-lib-backend/src/services/json2capnp/Json2CapnpRust.ts
@@ -55,7 +55,9 @@ class Json2CapnpRust implements Json2CapnpBase {
             }
             return args.collection;
         } else {
-            console.error(`error loading ${collectionName} collection cache using json2capnp`);
+            console.error(
+                `error loading ${collectionName} collection cache using json2capnp with args: ${JSON.stringify(args)}, response: ${typeof response === 'string' ? response : typeof response === 'object' && response !== null ? Object.keys(response) : typeof response}`
+            );
             throw new TrError(`Cannot load ${collectionName} collection`, 'CAQCFC0001', 'CannotLoadCacheBecauseError');
         }
     }

--- a/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
+++ b/packages/transition-backend/src/tasks/TransitionWorkerPool.ts
@@ -128,7 +128,7 @@ const wrapEvolutionaryTransitNetworkDesign = async (task: EvolutionaryTransitNet
         progressEmitter: newProgressEmitter(task),
         isCancelled: getTaskCancelledFct(task)
     });
-    console.log('Evolutionary transit network design job completed with status ', status);
+    console.log(`Evolutionary transit network design job ${task.attributes.id} completed with status ${status}`);
     // TODO Handle results here
     return status === 'success';
 };


### PR DESCRIPTION
Get more information when the cache collection reading fails and the job ID in completion status update.