### PR TITLE
routing: log error code instead of whole error

### DIFF
--- a/packages/chaire-lib-backend/src/services/routing/Routing.ts
+++ b/packages/chaire-lib-backend/src/services/routing/Routing.ts
@@ -179,7 +179,10 @@ export class Routing {
             }
         } catch (error) {
             const origDestStr = `${routingAttributes.originGeojson.geometry.coordinates.join(',')} to ${routingAttributes.destinationGeojson.geometry.coordinates.join(',')}`;
-            console.error(`tripRouting: Error routing single mode ${routingMode} for ${origDestStr}:`, error);
+            console.error(
+                `tripRouting: Error routing single mode ${routingMode} for ${origDestStr}:`,
+                TrError.isTrError(error) ? error.getCode() : error
+            );
             return {
                 routingMode,
                 result: !TrError.isTrError(error)


### PR DESCRIPTION
A previous commit caused the whole error object to be displayed, which is very verbose in the logs, only the code is necessary for TrError to be explanatory. For other errors, having the whole error might still be useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging in routing functionality to display specific error codes instead of full error objects for better error tracking and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->