### PR TITLE
networkDesign: create cache symlink when resuming task

### DIFF
--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper.ts
@@ -207,6 +207,16 @@ export class TransitNetworkDesignJobWrapper<
             `${absoluteCacheDirectory}/services.capnpbin`,
             true
         );
+
+        this.addCacheSymlink();
+
+        console.log(`Prepared cache directory files to ${absoluteCacheDirectory} from ${mainCacheDirectory}`);
+    };
+
+    addCacheSymlink = () => {
+        const absoluteCacheDirectory = this.getCacheDirectory();
+        const mainCacheDirectory = `${fileManager.directoryManager.cacheDirectory}/${config.projectShortname}`;
+
         // FIXME HACK Add a symlink from mainCacheDirectory to the job cache
         // directory because the path in the json to capnp server is relative to
         // main cache path Create symbolic link pointing to the job cache
@@ -234,8 +244,6 @@ export class TransitNetworkDesignJobWrapper<
         } catch (error) {
             console.warn(`Failed to create symbolic link: ${error}`);
         }
-
-        console.log(`Prepared cache directory files to ${absoluteCacheDirectory} from ${mainCacheDirectory}`);
     };
 
     async addMessages(messages: {

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
@@ -259,6 +259,9 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
         // FIXME We need to have the paths and lines loaded in a CollectionManager to save the scenarios and re-generate schedules at the end. But not the whole data
         await this.loadServerData(serviceLocator.socketEventManager);
 
+        // Add the symlink to the cache data, the main cache may have been reinitialized since the last execution.
+        this.addCacheSymlink();
+
         // Get the simulated lines from cache, to make sure the order is the same as before
         const simulatedLineCollection = await lineCollectionFromCache(this.getCacheDirectory() + '/simulatedLines');
         this.simulatedLineCollection = simulatedLineCollection;


### PR DESCRIPTION
The main cache directory may have been reset when the task is resumed, so we need to create the symlink in that case also.