### PR TITLE
gtfs export: Add newline between batch when exporting schedule

### DIFF
--- a/packages/transition-backend/src/services/gtfsExport/ScheduleExporter.ts
+++ b/packages/transition-backend/src/services/gtfsExport/ScheduleExporter.ts
@@ -192,7 +192,7 @@ const exportScheduleForLineSubset = async (
                     newline: '\n',
                     quotes: options.quotesFct,
                     header: shouldWriteTripHeader
-                })
+                }) + '\n' // add trailing newline between batches which was not added by papaparse
             );
             // Wait for the stream to drain if necessary to avoid losing data when writing more later
             if (!fileOk) {
@@ -208,7 +208,7 @@ const exportScheduleForLineSubset = async (
                     newline: '\n',
                     quotes: options.quotesFct,
                     header: shouldWriteStopTimesHeader
-                })
+                }) + '\n' // add trailing newline between batches which was not added by papaparse
             );
             // Wait for the stream to drain if necessary to avoid losing data when writing more later
             if (!fileOk) {


### PR DESCRIPTION
With the change in 4767e2cba gtfs: export schedules in chunks, we were missing a newline between each batch, which had the effect of putting 2 entries on the same line.

This change as the effect of always adding a newline at the end of the stop_times.txt and trips.txt files. The GTFS standard accept both files with and without a newline, so this does not changes the validity of the export.

We added new expect to catch the problem of the lack of newline between chunk. And adjust other tests to account for the new added newline at the end  of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GTFS schedule export CSV formatting to consistently append a trailing newline between consecutive export batches for trips and stop times. This ensures proper separation and correct line counts when concatenating outputs, improving file integrity and compatibility with import and third‑party processing tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->