### PR TITLE
workerPool: poll job status only instead of refreshing job

### DIFF
--- a/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/jobs.db.test.ts
@@ -199,6 +199,20 @@ describe(`${objectName}`, () => {
         expect(_collection3.length).toBe(0);
     });
 
+    test('getJobStatus should return the status of a job', async() => {
+        // Job status was updated to inProgress in a previous test, so should return that status
+        const status = await dbQueries.getJobStatus(currentIdForObject1 as number);
+        expect(status).toBe(newObjectAttributes.status);
+
+    });
+
+    test('getJobStatus should return undefined for a non-existent job', async() => {
+        // Job does not exist, so it should return undefined, not throw an error
+        const status = await dbQueries.getJobStatus(currentIdForObject1 as number + 100);
+        expect(status).toBeUndefined();
+
+    });
+
     test('Read collections for specific user', async() => {
 
         // Add a user and a job for this user

--- a/packages/transition-backend/src/models/db/jobs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/jobs.db.queries.ts
@@ -179,6 +179,20 @@ const read = async (id: number): Promise<JobAttributes<JobDataType>> => {
     }
 };
 
+const getJobStatus = async (id: number): Promise<JobStatus | undefined> => {
+    try {
+        const rows = await knex(tableName).select('status').where('id', id);
+
+        return rows.length === 1 ? rows[0].status : undefined;
+    } catch (error) {
+        throw new TrError(
+            `Cannot get job status for job with id ${id} from table ${tableName} (knex error: ${error})`,
+            'DBQRS0001',
+            'DatabaseCannotGetJobStatusBecauseDatabaseError'
+        );
+    }
+};
+
 const create = async (job: Omit<JobAttributes<JobDataType>, 'id'>): Promise<number> => {
     try {
         const returningArray = await knex(tableName).insert(attributesCleaner(job)).returning('id');
@@ -248,5 +262,6 @@ export default {
     delete: deleteRecord,
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
-    collection
+    collection,
+    getJobStatus
 };

--- a/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
+++ b/packages/transition-backend/src/services/executableJob/ExecutableJob.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import { EventEmitter } from 'events';
 import path from 'path';
 
-import Job, { JobAttributes, JobDataType, fileKey } from 'transition-common/lib/services/jobs/Job';
+import Job, { JobAttributes, JobDataType, JobStatus, fileKey } from 'transition-common/lib/services/jobs/Job';
 import jobsDbQueries from '../../models/db/jobs.db.queries';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import { execJob } from '../../tasks/serverWorkerPool';
@@ -51,6 +51,15 @@ export class ExecutableJob<TData extends JobDataType> extends Job<TData> {
     static async loadTask<TData extends JobDataType>(id: number): Promise<ExecutableJob<TData>> {
         const jobAttributes = await jobsDbQueries.read(id);
         return new ExecutableJob<TData>(jobAttributes as JobAttributes<TData>);
+    }
+
+    /**
+     * Get the current status of a job by its ID, from the database.
+     * @param id The job ID
+     * @returns The job status, or `undefined` if the job does not exist
+     */
+    static async getJobStatus(id: number): Promise<JobStatus | undefined> {
+        return await jobsDbQueries.getJobStatus(id);
     }
 
     static async collection(options: {


### PR DESCRIPTION
Add a function in `ExecutableJob#getJobStatus`, which returns just the current status of the job from the database, or `undefined` if the job does not exist. Also add the corresponding db query.

The cancel listener, instead of refreshing the entire job, now just polls its current status, as the refresh could be a source of conflict and race conditions on the Job object when the task running it updates and saves the Job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ability to query and retrieve a job's current status by ID.

* **Improvements**
  * Cancellation polling now uses the status query for more accurate cancellation detection.
  * Polling stops and reflects undefined status on repeated read errors.
  * Worker flows refresh task state after execution before saving results.

* **Tests**
  * Added tests covering existing, missing, and varied job statuses; test setup simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->