### PR TITLE
networkDesign: add sample line count and weight to debug

### DIFF
--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
@@ -499,7 +499,9 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
             simulationMethod: '',
             fitnessScore: undefined,
             routedCount: undefined,
-            nonRoutedCount: undefined
+            nonRoutedCount: undefined,
+            sampleFileLinesCount: undefined,
+            sampleTotalWeight: undefined
         };
 
         // Register the output files and create streams
@@ -549,7 +551,11 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
                 simulationMethod: row.simulation_method,
                 fitnessScore: parseFloat(row.fitness_score),
                 routedCount: typeof row.data?.routedCount === 'number' ? row.data.routedCount : undefined,
-                nonRoutedCount: typeof row.data?.nonRoutedCount === 'number' ? row.data.nonRoutedCount : undefined
+                nonRoutedCount: typeof row.data?.nonRoutedCount === 'number' ? row.data.nonRoutedCount : undefined,
+                sampleFileLinesCount:
+                    typeof row.data?.sampleFileLinesCount === 'number' ? row.data.sampleFileLinesCount : undefined,
+                sampleTotalWeight:
+                    typeof row.data?.sampleTotalWeight === 'number' ? row.data.sampleTotalWeight : undefined
             };
             simulationsCsvStream.write(unparse([csvAttributes], { header: false }) + '\n');
         }

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
@@ -62,6 +62,8 @@ export class OdTripFitnessVisitor implements BatchRouteResultVisitor<SimulationS
     private totalWaitingTimeMinutes = 0;
     private totalTravelTimeMinutes = 0;
     private countByNumberOfTransfers = new Array(6).fill(0); // max 4, last is 5+
+    private sampleFileLinesCount = 0;
+    private sampleTotalWeight = 0;
 
     constructor(
         private job: ExecutableJob<BatchRouteJobType>,
@@ -100,6 +102,8 @@ export class OdTripFitnessVisitor implements BatchRouteResultVisitor<SimulationS
     visitTripResult = async (odTripResult: OdTripRouteResult) => {
         const transitResult = odTripResult.results?.transit;
         const expansionFactor = this.getExpansionFactor(odTripResult);
+        this.sampleFileLinesCount++;
+        this.sampleTotalWeight += expansionFactor;
         if (transitResult && transitResult.error === undefined) {
             const route = transitResult.paths[0];
 
@@ -171,7 +175,9 @@ export class OdTripFitnessVisitor implements BatchRouteResultVisitor<SimulationS
             routableHourlyCost: Math.round(this.totalRoutableUsersCost / durationHours),
             nonRoutableHourlyCost: Math.round(this.totalNonRoutableUsersCost / durationHours),
             totalTravelTimeSecondsFromTrRouting: 0, // TODO Is that used
-            countByNumberOfTransfers: this.countByNumberOfTransfers
+            countByNumberOfTransfers: this.countByNumberOfTransfers,
+            sampleFileLinesCount: this.sampleFileLinesCount,
+            sampleTotalWeight: this.sampleTotalWeight
         };
     }
 }

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulationFitnessFunctions.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulationFitnessFunctions.ts
@@ -30,6 +30,9 @@ export type SimulationStats = {
     nonRoutableHourlyCost: number;
     totalTravelTimeSecondsFromTrRouting: number;
     countByNumberOfTransfers: { [key: number]: number };
+    sampleFileLinesCount: number;
+    // Total weight of the sample, which can be different from the total count if the sample is weighted
+    sampleTotalWeight: number;
 };
 
 /**


### PR DESCRIPTION
In order to determine for large sample if the current sampling approach (where each line has x% chance of being in the sample, instead of exactly x% of the file) can cause result biases, we add to the simulation results the number of lines effectively in the sample file and the total weight that it represents. From that information, we can decide how urgent it is to change the sampling algorithm (see the FIXME in `OdTripSimulation#sampleOdTripFile` function).