### PR TITLE
Chore: Add .vscode/tasks.json.example for task automation and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ services/json2capnp/testData
 # vscode
 .vscode/launch.json
 .vscode/restore-terminals.json
+.vscode/tasks.json
 
 # custom
 public/dist/

--- a/.vscode/tasks.json.example
+++ b/.vscode/tasks.json.example
@@ -1,0 +1,129 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Update Main",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Git Checkout Main",
+        "Git Pull Origin Main",
+        "Yarn Install Dependencies",
+        "Yarn Compile",
+        "Yarn Migrate"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Start Dev Terminals",
+      "type": "shell",
+      "command": "",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "dependsOn": ["Compile Dev", "Build Dev", "Start Json2Capnp", "Start"]
+    },
+    {
+      "label": "Compile Dev",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["compile:dev"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Build Dev",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["build:dev"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Start Json2Capnp",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "run",
+        "--release",
+        "--",
+        "2000",
+        "${workspaceFolder}/examples/runtime/cache/demo_transition"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/services/json2capnp"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Start",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["start"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Git Checkout Main",
+      "type": "shell",
+      "command": "git",
+      "args": ["checkout", "main"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Git Pull Origin Main",
+      "type": "shell",
+      "command": "git",
+      "args": ["pull", "origin", "main"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Yarn Install Dependencies",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["install"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Yarn Compile",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["compile"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "label": "Yarn Migrate",
+      "type": "shell",
+      "command": "yarn",
+      "args": ["migrate"],
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Pull request

## Description

Chore: Add .vscode/tasks.json.example for task automation and update gitignore
- Introduced a new example tasks.json file for Visual Studio Code, providing a set of predefined tasks for project setup and development.
- Updated .gitignore to include .vscode/tasks.json to prevent tracking of user-specific task configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an example Visual Studio Code tasks configuration to the repository to streamline common build, setup, and development workflows.
  * Updated project configuration to ignore local VSCode task files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->