### PR TITLE
Refactor fitBounds behaviour

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -380,6 +380,7 @@
         "New": "New path",
         "Edit": "Path",
         "Delete": "Delete path",
+        "FitBoundsToPath": "Fit map bounds to path",
         "ConfirmDelete": "Do you confirm deletion of this path? Path's timetables will be disabled.",
         "ImportFromGeojson": "Import paths (GEOJSON)",
         "Name": "Name",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -380,6 +380,7 @@
         "New": "Nouveau parcours",
         "Edit": "Parcours",
         "Delete": "Supprimer le parcours",
+        "FitBoundsToPath": "Ajuster les limites de la carte au parcours",
         "ConfirmDelete": "Confirmez-vous que vous désirez bien supprimer ce parcours? les horaires associés seront désactivés",
         "ImportFromGeojson": "Importer des parcours (GEOJSON)",
         "InternalId": "ID interne",

--- a/packages/transition-frontend/src/components/forms/comparison/ScenarioComparisonAlternativesSelect.tsx
+++ b/packages/transition-frontend/src/components/forms/comparison/ScenarioComparisonAlternativesSelect.tsx
@@ -7,8 +7,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons/faAngleRight';
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons/faAngleLeft';
-import { bbox as turfBbox, featureCollection as turfFeatureCollection } from '@turf/turf';
-
+import { featureCollection as turfFeatureCollection } from '@turf/turf';
 import ScenarioComparisonResults from './ScenarioComparisonResults';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { RoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
@@ -96,12 +95,7 @@ const AlternativesSelect: React.FunctionComponent<AlternativesSelectProps> = (pr
                 if (pathGeojson2?.features) allFeatures.push(...pathGeojson2.features);
 
                 if (allFeatures.length > 0) {
-                    const combined = turfFeatureCollection(allFeatures);
-                    const bounds = turfBbox(combined);
-                    serviceLocator.eventManager.emit('map.fitBounds', [
-                        [bounds[0], bounds[1]], // southwest
-                        [bounds[2], bounds[3]] // northeast
-                    ]);
+                    serviceLocator.eventManager.emit('map.fitBounds', turfFeatureCollection(allFeatures));
                 }
             } catch (error) {
                 console.error(

--- a/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathButton.tsx
@@ -41,6 +41,8 @@ const TransitPathButton: React.FunctionComponent<PathButtonProps> = (props: Path
                 serviceLocator.eventManager.emit('map.disableBoxZoom');
                 serviceLocator.selectedObjectsManager.setSelection('path', [path]); // auto deselect
                 serviceLocator.eventManager.emit('selected.updateLayers.path');
+                // the fitBounds if visible is handled in TransitPathNodeList,
+                // because it will change the map viewport size after the path is selected.
             });
         }
     };

--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -13,6 +13,7 @@ import { faRedoAlt } from '@fortawesome/free-solid-svg-icons/faRedoAlt';
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons/faTrashAlt';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import { faRoute } from '@fortawesome/free-solid-svg-icons/faRoute';
+import { faCrosshairs } from '@fortawesome/free-solid-svg-icons/faCrosshairs';
 import _toString from 'lodash/toString';
 import MathJax from 'react-mathjax';
 import { point as turfPoint, featureCollection as turfFeatureCollection } from '@turf/turf';
@@ -732,6 +733,18 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                     path.validate();
                                     serviceLocator.selectedObjectsManager.setSelection('path', [path]);
                                     serviceLocator.eventManager.emit('selected.updateLayers.path');
+                                }}
+                            />
+                        </span>
+                        <span title={this.props.t('transit:transitPath:FitBoundsToPath')}>
+                            <Button
+                                color="grey"
+                                icon={faCrosshairs}
+                                iconClass="_icon-alone"
+                                label=""
+                                disabled={!path.attributes.geography}
+                                onClick={() => {
+                                    serviceLocator.eventManager.emit('map.fitBounds', path.attributes.geography);
                                 }}
                             />
                         </span>

--- a/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/RoutingResultComponent.tsx
@@ -7,8 +7,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons/faAngleRight';
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons/faAngleLeft';
-import { bbox as turfBbox } from '@turf/turf';
-
 import TransitRoutingResults from './TransitRoutingResultComponent';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import { RoutingResult } from 'chaire-lib-common/lib/services/routing/RoutingResult';
@@ -48,14 +46,8 @@ const showCurrentAlternative = async (
         routingPathsStrokes: pathGeojson
     });
 
-    // Fit map bounds to the routing path
     if (fitBounds && pathGeojson && pathGeojson.features && pathGeojson.features.length > 0) {
-        const bounds = turfBbox(pathGeojson);
-        // bounds is [minX, minY, maxX, maxY] = [west, south, east, north]
-        serviceLocator.eventManager.emit('map.fitBounds', [
-            [bounds[0], bounds[1]], // southwest
-            [bounds[2], bounds[3]] // northeast
-        ]);
+        serviceLocator.eventManager.emit('map.fitBounds', pathGeojson);
     }
 };
 

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -37,6 +37,7 @@ import MapControlsMenu from './TransitionMapControlsMenu';
 import MapRenderer, { MapStyleSpec } from './MapRenderer';
 import { createDeckLayersFromMappings } from '../../config/deckLayers.config';
 import { resetClasses } from '../../services/map/MapCursorHelper';
+import { fitBoundsIfNotVisible, safeFitBounds } from '../../services/map/MapBoundsUtils';
 
 /**
  * Optional custom raster tiles configuration that can be set in config.js.
@@ -143,13 +144,17 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         });
     }
 
-    fitBounds = (coordinates: [[number, number], [number, number]]) => {
+    fitBounds = (geojson: GeoJSON.GeoJSON) => {
         const map = this.mapRef.current?.getMap();
         if (map) {
-            map.fitBounds(coordinates, {
-                padding: 20,
-                bearing: map.getBearing()
-            });
+            safeFitBounds(map, geojson);
+        }
+    };
+
+    onFitBoundsIfNotVisible = (geojson: GeoJSON.GeoJSON) => {
+        const map = this.mapRef.current?.getMap();
+        if (map) {
+            fitBoundsIfNotVisible(map, geojson);
         }
     };
 
@@ -294,6 +299,7 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.on('map.paths.byAttribute.hide', this.hidePathsByAttribute);
         serviceLocator.eventManager.on('map.paths.clearFilter', this.clearPathsFilter);
         serviceLocator.eventManager.on('map.fitBounds', this.fitBounds);
+        serviceLocator.eventManager.on('map.fitBoundsIfNotVisible', this.onFitBoundsIfNotVisible);
         serviceLocator.eventManager.on('map.setCenter', this.setCenter);
         serviceLocator.eventManager.on('map.enableBoxZoom', this.onEnableBoxZoom);
         serviceLocator.eventManager.on('map.disableBoxZoom', this.onDisableBoxZoom);
@@ -335,6 +341,7 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.off('map.paths.byAttribute.hide', this.hidePathsByAttribute);
         serviceLocator.eventManager.off('map.paths.clearFilter', this.clearPathsFilter);
         serviceLocator.eventManager.off('map.fitBounds', this.fitBounds);
+        serviceLocator.eventManager.off('map.fitBoundsIfNotVisible', this.onFitBoundsIfNotVisible);
         serviceLocator.eventManager.off('map.setCenter', this.setCenter);
         serviceLocator.eventManager.off('map.enableBoxZoom', this.onEnableBoxZoom);
         serviceLocator.eventManager.off('map.disableBoxZoom', this.onDisableBoxZoom);

--- a/packages/transition-frontend/src/services/map/MapBoundsUtils.ts
+++ b/packages/transition-frontend/src/services/map/MapBoundsUtils.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { type LngLatBoundsLike, type Map as MaplibreMap } from 'maplibre-gl';
+import {
+    bbox as turfBbox,
+    bboxPolygon as turfBboxPolygon,
+    booleanIntersects as turfBooleanIntersects
+} from '@turf/turf';
+
+const MIN_BBOX_DELTA = 0.001; // ~111 m latitude, ~79 m longitude at 45°N
+
+/**
+ * Computes safe bounds from any GeoJSON object, returning undefined when
+ * the input has no computable extent (empty FeatureCollection, empty
+ * coordinates, etc.). Degenerate (zero-area) bounding boxes are expanded
+ * to a minimum span of ~111 m so MapLibre always receives a valid rectangle.
+ *
+ * @param geojson - Any GeoJSON object (Geometry, Feature, or FeatureCollection)
+ * @returns A MapLibre-compatible LngLatBoundsLike with a guaranteed minimum
+ *          span, or undefined if the input is empty
+ */
+const safeBoundsFromGeojson = (geojson: GeoJSON.GeoJSON): LngLatBoundsLike | undefined => {
+    const bbox = turfBbox(geojson);
+    // We do not support 3D bboxes, so only accept 2D bboxes:
+    if (bbox.length !== 4) {
+        return undefined;
+    }
+    if (
+        !Number.isFinite(bbox[0]) ||
+        !Number.isFinite(bbox[1]) ||
+        !Number.isFinite(bbox[2]) ||
+        !Number.isFinite(bbox[3])
+    ) {
+        return undefined;
+    }
+    let [minLng, minLat, maxLng, maxLat] = bbox;
+    if (maxLng - minLng < MIN_BBOX_DELTA) {
+        const midLng = (minLng + maxLng) / 2;
+        minLng = midLng - MIN_BBOX_DELTA / 2;
+        maxLng = midLng + MIN_BBOX_DELTA / 2;
+    }
+    if (maxLat - minLat < MIN_BBOX_DELTA) {
+        const midLat = (minLat + maxLat) / 2;
+        minLat = midLat - MIN_BBOX_DELTA / 2;
+        maxLat = midLat + MIN_BBOX_DELTA / 2;
+    }
+    minLng = Math.min(180, Math.max(-180, minLng));
+    maxLng = Math.min(180, Math.max(-180, maxLng));
+    minLat = Math.min(90, Math.max(-90, minLat));
+    maxLat = Math.min(90, Math.max(-90, maxLat));
+    return [
+        [minLng, minLat],
+        [maxLng, maxLat]
+    ];
+};
+
+/**
+ * Computes safe bounds from any GeoJSON object and calls map.fitBounds.
+ * Silently skips the call when the GeoJSON has no computable extent
+ * (empty FeatureCollection, empty coordinates, etc.).
+ * Note: There could be errors in bounds if the map is rotated. TODO: handle this? if needed...
+ *
+ * @param map - The MapLibre map instance
+ * @param geojson - Any GeoJSON object (Geometry, Feature, or FeatureCollection)
+ * @param padding - Pixel padding around the fitted bounds (default 20)
+ */
+export const safeFitBounds = (map: MaplibreMap, geojson: GeoJSON.GeoJSON, padding = 20): void => {
+    const bounds = safeBoundsFromGeojson(geojson);
+    if (bounds) {
+        map.fitBounds(bounds, { padding, bearing: map.getBearing() });
+    }
+};
+
+/** Fraction of the viewport to shrink on each side for the visibility test. */
+const VIEWPORT_MARGIN_RATIO = 0.05;
+
+/**
+ * Tests whether any part of a GeoJSON object intersects the given viewport
+ * polygon. Handles FeatureCollections (skipping null geometries), Features
+ * with null geometry (always invisible), and bare Geometry objects.
+ *
+ * @param geojson - Any GeoJSON object (Geometry, Feature, or FeatureCollection)
+ * @param viewport - The viewport as a GeoJSON Polygon feature
+ * @returns True if any part of the geojson intersects the viewport, false otherwise
+ */
+const geojsonIntersectsViewport = (geojson: GeoJSON.GeoJSON, viewport: GeoJSON.Feature<GeoJSON.Polygon>): boolean => {
+    if (geojson.type === 'FeatureCollection') {
+        return geojson.features
+            .filter((f) => f.geometry !== null && f.geometry !== undefined)
+            .some((f) => turfBooleanIntersects(f, viewport));
+    }
+    if (geojson.type === 'Feature' && (geojson.geometry === null || geojson.geometry === undefined)) {
+        return false;
+    }
+    return turfBooleanIntersects(geojson, viewport);
+};
+
+/**
+ * Returns the current map viewport as a GeoJSON Polygon feature, optionally
+ * shrunk by {@link marginRatio} on every side. A margin of 0 gives the full
+ * viewport; the default ({@link VIEWPORT_MARGIN_RATIO}) yields the "inner"
+ * viewport used by visibility tests.
+ *
+ * @param map - The MapLibre map instance
+ * @param marginRatio - Fraction of viewport width/height to trim per side (default {@link VIEWPORT_MARGIN_RATIO}), clamped to 0.49
+ */
+
+const getMapViewportAsGeoJSON = (
+    map: MaplibreMap,
+    marginRatio = VIEWPORT_MARGIN_RATIO
+): GeoJSON.Feature<GeoJSON.Polygon> => {
+    const viewportBounds = map.getBounds();
+    const clampedMarginRatio = Math.min(0.49, Math.max(0, marginRatio));
+    const marginLng = Math.max(0, (viewportBounds.getEast() - viewportBounds.getWest()) * clampedMarginRatio);
+    const marginLat = Math.max(0, (viewportBounds.getNorth() - viewportBounds.getSouth()) * clampedMarginRatio);
+    return turfBboxPolygon([
+        viewportBounds.getWest() + marginLng,
+        viewportBounds.getSouth() + marginLat,
+        viewportBounds.getEast() - marginLng,
+        viewportBounds.getNorth() - marginLat
+    ]);
+};
+
+/**
+ * Returns true when the map's internal canvas size (in CSS pixels) no
+ * longer matches the container element, meaning `getBounds()` would
+ * return a stale viewport. This happens when a panel mounts or resizes
+ * right before a bounds query and MapLibre's ResizeObserver hasn't
+ * fired yet. The 0.5 px tolerance absorbs sub-pixel rounding that
+ * occurs when the browser converts between CSS and device pixels.
+ *
+ * @param map - The MapLibre map instance
+ * @returns True if the map's canvas size is out of sync with the container, false otherwise
+ */
+const isMapCanvasOutOfSync = (map: MaplibreMap): boolean => {
+    const canvas = map.getCanvas();
+    const container = map.getContainer();
+    const dpr = window.devicePixelRatio || 1;
+    return (
+        Math.abs(canvas.width / dpr - container.clientWidth) > 0.5 ||
+        Math.abs(canvas.height / dpr - container.clientHeight) > 0.5
+    );
+};
+
+/**
+ * Calls fitBounds on the map when the actual GeoJSON geometry does not
+ * intersect the *inner* portion of the viewport (shrunk by
+ * {@link VIEWPORT_MARGIN_RATIO} on every side).
+ *
+ * Unlike a bounding-box check, this tests the real geometry so that
+ * concave shapes (e.g. a C-shaped path whose bbox covers the viewport
+ * but whose line does not cross it) correctly trigger a fit.
+ *
+ * Silently skips when the GeoJSON has no computable extent.
+ *
+ * @param map - The MapLibre map instance
+ * @param geojson - Any GeoJSON object (Geometry, Feature, or FeatureCollection)
+ * @param padding - Pixel padding around the fitted bounds (default 20)
+ */
+export const fitBoundsIfNotVisible = (map: MaplibreMap, geojson: GeoJSON.GeoJSON, padding = 20): void => {
+    const bounds = safeBoundsFromGeojson(geojson);
+    if (!bounds) {
+        return;
+    }
+    if (isMapCanvasOutOfSync(map)) {
+        map.resize();
+    }
+    const innerViewport = getMapViewportAsGeoJSON(map);
+    const visible = geojsonIntersectsViewport(geojson, innerViewport);
+    if (!visible) {
+        map.fitBounds(bounds, { padding, bearing: map.getBearing() });
+    }
+};

--- a/packages/transition-frontend/src/services/map/__tests__/MapBoundsUtils.test.ts
+++ b/packages/transition-frontend/src/services/map/__tests__/MapBoundsUtils.test.ts
@@ -1,0 +1,763 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import { bbox as turfBbox } from '@turf/turf';
+import { safeFitBounds, fitBoundsIfNotVisible } from '../MapBoundsUtils';
+
+jest.mock('@turf/turf', () => ({
+    ...jest.requireActual('@turf/turf'),
+    bbox: jest.fn((...args: Parameters<typeof turfBbox>) => (jest.requireActual('@turf/turf') as typeof import('@turf/turf')).bbox(...args))
+}));
+const mockedTurfBbox = turfBbox as jest.MockedFunction<typeof turfBbox>;
+
+type MockMap = jest.Mocked<Pick<MaplibreMap, 'getBounds' | 'getBearing' | 'fitBounds' | 'getCanvas' | 'getContainer' | 'resize'>>;
+
+const makeViewportBounds = (west: number, south: number, east: number, north: number) => ({
+    getWest: () => west,
+    getEast: () => east,
+    getSouth: () => south,
+    getNorth: () => north
+});
+
+/**
+ * Returns a mock that satisfies the MaplibreMap methods used by
+ * safeFitBounds / fitBoundsIfNotVisible. The internal object is
+ * typed as MockMap for IDE hints and refactor safety; the outer
+ * return type is MaplibreMap so callers don't need any cast.
+ */
+const makeMockMap = (
+    west: number,
+    south: number,
+    east: number,
+    north: number,
+    bearing = 0,
+    canvas?: { width: number; height: number },
+    container?: { clientWidth: number; clientHeight: number }
+): MockMap & MaplibreMap => {
+    const mock: MockMap = {
+        getBounds: jest.fn().mockReturnValue(makeViewportBounds(west, south, east, north)),
+        getBearing: jest.fn().mockReturnValue(bearing),
+        fitBounds: jest.fn().mockReturnThis(),
+        getCanvas: jest.fn().mockReturnValue(canvas ?? { width: 800, height: 600 }),
+        getContainer: jest.fn().mockReturnValue(container ?? { clientWidth: 800, clientHeight: 600 }),
+        resize: jest.fn().mockReturnThis()
+    };
+    return mock as MockMap & MaplibreMap;
+};
+
+/** Helper: builds a LineString whose turf bbox matches the given SW/NE. */
+const lineStringFromBounds = (
+    swLng: number,
+    swLat: number,
+    neLng: number,
+    neLat: number
+): GeoJSON.LineString => ({
+    type: 'LineString',
+    coordinates: [
+        [swLng, swLat],
+        [neLng, neLat]
+    ]
+});
+
+// turfBbox (from @turf/turf) returns zero-area bounding boxes when all
+// coordinates are co-located (e.g. a single Point or a LineString whose
+// endpoints coincide). safeBoundsFromGeojson detects these degenerate
+// bboxes and expands them so the map always receives a valid extent.
+// These tests verify the behaviour through safeFitBounds (the public API).
+describe('safeFitBounds', () => {
+    it('should call fitBounds with correct bounds for a normal geometry', () => {
+        const map = makeMockMap(0, 0, 1, 1, 10);
+
+        safeFitBounds(map, lineStringFromBounds(-75.0, 46.0, -74.5, 46.5));
+
+        expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            [[-75.0, 46.0], [-74.5, 46.5]],
+            { padding: 20, bearing: 10 }
+        );
+    });
+
+    it('should call fitBounds for a FeatureCollection with features', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+        const fc: GeoJSON.FeatureCollection = {
+            type: 'FeatureCollection',
+            features: [{ type: 'Feature', geometry: lineStringFromBounds(-75.0, 46.0, -74.5, 46.5), properties: {} }]
+        };
+
+        safeFitBounds(map, fc);
+
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            [[-75.0, 46.0], [-74.5, 46.5]],
+            expect.objectContaining({ padding: 20 })
+        );
+    });
+
+    it('should use custom padding when provided', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, lineStringFromBounds(-75.0, 46.0, -74.5, 46.5), 50);
+
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            expect.anything(),
+            { padding: 50, bearing: 0 }
+        );
+    });
+
+    it('should expand a co-located point to a non-zero-area rectangle', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, { type: 'Point', coordinates: [-73.5, 45.5] });
+
+        expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        const [[swLng, swLat], [neLng, neLat]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(neLng - swLng).toBeGreaterThan(0);
+        expect(neLat - swLat).toBeGreaterThan(0);
+        expect((swLng + neLng) / 2).toBeCloseTo(-73.5, 5);
+        expect((swLat + neLat) / 2).toBeCloseTo(45.5, 5);
+    });
+
+    it('should expand a bbox degenerate only in longitude', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, lineStringFromBounds(-73.5, 45.3, -73.5, 45.6));
+
+        const [[swLng, swLat], [neLng, neLat]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(neLng - swLng).toBeGreaterThan(0);
+        expect(swLat).toBe(45.3);
+        expect(neLat).toBe(45.6);
+    });
+
+    it('should expand a bbox degenerate only in latitude', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, lineStringFromBounds(-73.8, 45.5, -73.4, 45.5));
+
+        const [[swLng, swLat], [neLng, neLat]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(swLng).toBe(-73.8);
+        expect(neLng).toBe(-73.4);
+        expect(neLat - swLat).toBeGreaterThan(0);
+    });
+
+    test.each([
+        { name: 'near north pole', coords: [0, 89.9999] as [number, number] },
+        { name: 'near south pole', coords: [0, -89.9999] as [number, number] },
+        { name: 'near antimeridian +', coords: [179.9999, 0] as [number, number] },
+        { name: 'near antimeridian -', coords: [-179.9999, 0] as [number, number] },
+        { name: 'at longitude 180', coords: [180, 0] as [number, number] },
+        { name: 'at longitude -180', coords: [-180, 0] as [number, number] },
+        { name: 'at latitude 90', coords: [0, 90] as [number, number] },
+        { name: 'at latitude -90', coords: [0, -90] as [number, number] }
+    ])('should clamp bounds to valid range for point $name', ({ coords }) => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, { type: 'Point', coordinates: coords });
+
+        expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        const [[swLng, swLat], [neLng, neLat]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(swLng).toBeGreaterThanOrEqual(-180);
+        expect(neLng).toBeLessThanOrEqual(180);
+        expect(swLat).toBeGreaterThanOrEqual(-90);
+        expect(neLat).toBeLessThanOrEqual(90);
+        expect(neLng - swLng).toBeGreaterThan(0);
+        expect(neLat - swLat).toBeGreaterThan(0);
+    });
+
+    it('should clamp when turfBbox returns out-of-range longitudes', () => {
+        mockedTurfBbox.mockReturnValueOnce([181, 0, 182, 1]);
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, { type: 'Point', coordinates: [0, 0] });
+
+        const [[swLng], [neLng]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(swLng).toBe(180);
+        expect(neLng).toBe(180);
+    });
+
+    it('should clamp when turfBbox returns out-of-range latitudes', () => {
+        mockedTurfBbox.mockReturnValueOnce([0, 91, 1, 92]);
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, { type: 'Point', coordinates: [0, 0] });
+
+        const [[, swLat], [, neLat]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(swLat).toBe(90);
+        expect(neLat).toBe(90);
+    });
+
+    it('should handle a bbox that spans the full valid range', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, lineStringFromBounds(-180, -90, 180, 90));
+
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            [[-180, -90], [180, 90]],
+            expect.anything()
+        );
+    });
+
+    it('should expand co-located LineString endpoints', () => {
+        const map = makeMockMap(0, 0, 1, 1);
+        const geojson: GeoJSON.LineString = {
+            type: 'LineString',
+            coordinates: [[-73.5, 45.5], [-73.5, 45.5]]
+        };
+
+        safeFitBounds(map, geojson);
+
+        const [[swLng, swLat], [neLng, neLat]] = map.fitBounds.mock.calls[0][0] as [[number, number], [number, number]];
+        expect(neLng - swLng).toBeGreaterThan(0);
+        expect(neLat - swLat).toBeGreaterThan(0);
+    });
+
+    test.each([
+        { name: 'empty FeatureCollection', geojson: { type: 'FeatureCollection' as const, features: [] } },
+        { name: 'empty GeometryCollection', geojson: { type: 'GeometryCollection' as const, geometries: [] } },
+        { name: 'Feature with null geometry', geojson: { type: 'Feature' as const, geometry: null, properties: {} } },
+        {
+            name: 'FeatureCollection with only null-geometry features',
+            geojson: {
+                type: 'FeatureCollection' as const,
+                features: [{ type: 'Feature' as const, geometry: null, properties: {} }]
+            }
+        }
+    ])('should not call fitBounds for $name', ({ geojson }) => {
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, geojson as GeoJSON.GeoJSON);
+
+        expect(map.fitBounds).not.toHaveBeenCalled();
+    });
+
+    it('should not call fitBounds when turfBbox returns a 3D (6-element) bbox', () => {
+        mockedTurfBbox.mockReturnValueOnce([-75, 46, 100, -74.5, 46.5, 200]);
+        const map = makeMockMap(0, 0, 1, 1);
+
+        safeFitBounds(map, { type: 'Point', coordinates: [-73.5, 45.5, 150] });
+
+        expect(map.fitBounds).not.toHaveBeenCalled();
+    });
+});
+
+describe('fitBoundsIfNotVisible', () => {
+    // Viewport centred roughly on Montreal: lon [-73.8, -73.4], lat [45.3, 45.6]
+    const VP = { west: -73.8, south: 45.3, east: -73.4, north: 45.6 };
+
+    it('should call fitBounds when geometry is completely outside viewport', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north, 15);
+
+        fitBoundsIfNotVisible(map, lineStringFromBounds(-75.0, 46.0, -74.5, 46.5));
+
+        expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            [[-75.0, 46.0], [-74.5, 46.5]],
+            { padding: 20, bearing: 15 }
+        );
+    });
+
+    it('should preserve current map bearing in fitBounds options', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north, 42);
+
+        fitBoundsIfNotVisible(map, lineStringFromBounds(-75.0, 46.0, -74.5, 46.5));
+
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ bearing: 42 })
+        );
+    });
+
+    it('should pass bearing: 0 explicitly and not skip falsy zero', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north, 0);
+
+        fitBoundsIfNotVisible(map, lineStringFromBounds(-75.0, 46.0, -74.5, 46.5));
+
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            expect.anything(),
+            { padding: 20, bearing: 0 }
+        );
+    });
+
+    it('should use custom padding when provided', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north, 0);
+
+        fitBoundsIfNotVisible(map, lineStringFromBounds(-75.0, 46.0, -74.5, 46.5), 50);
+
+        expect(map.fitBounds).toHaveBeenCalledWith(
+            expect.anything(),
+            { padding: 50, bearing: 0 }
+        );
+    });
+
+    it('should not call fitBounds for an empty GeometryCollection', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north);
+
+        fitBoundsIfNotVisible(map, { type: 'GeometryCollection', geometries: [] });
+
+        expect(map.fitBounds).not.toHaveBeenCalled();
+    });
+
+    it('should not throw for a Feature with null geometry', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north);
+        const nullGeomFeature: GeoJSON.Feature = { type: 'Feature', geometry: null as unknown as GeoJSON.Geometry, properties: {} };
+
+        expect(() => fitBoundsIfNotVisible(map, nullGeomFeature)).not.toThrow();
+        expect(map.fitBounds).not.toHaveBeenCalled();
+    });
+
+    // Viewport:       [-73.8, 45.3] to [-73.4, 45.6]
+    // Inner (5% margin): [-73.78, 45.315] to [-73.42, 45.585]
+    //
+    // Geometry is tested against the inner viewport. shouldCallFitBounds=true means
+    // the geometry does NOT intersect the inner viewport (so fitBounds fires).
+    //
+    //  lat
+    //  46.0 |                                     N (north)
+    //       |                                     |
+    //  45.8 |                              corner +---+ NE
+    //       |                                 +---+   |
+    //  45.6 |        +========================+---+---+
+    //       |        | outer viewport         |
+    //  45.585        |  +==================+  |
+    //       |        |  | inner viewport   |  |
+    //  45.5 |  W     |  |   fully inside   |  |     E (east)
+    //       |  |     |  |   [-73.7→-73.5,  |  |     |
+    //  45.4 |  +-----+--+---45.4→45.5]-----+--+-----+
+    //       |        |  |                  |  |
+    //  45.315        |  +==================+  |
+    //       |        |         margin zone  |  |
+    //  45.3 |        +========================+
+    //       |                 |
+    //  45.1 |           S (south)
+    //       +--------+--+-------------------+--+---------> lng
+    //      -75.0  -73.8 -73.78           -73.42 -73.4  -73.0
+    //         |                                           |
+    //     W (west)                                    NE (northeast)
+    //
+    test.each([
+        //  +==================+
+        //  |    A---------B   |  fully inside inner viewport
+        //  +==================+
+        { name: 'fully inside', geojson: lineStringFromBounds(-73.7, 45.4, -73.5, 45.5), shouldCallFitBounds: false },
+
+        //  +========================+
+        //  |A======================B|  identical to outer viewport, crosses inner
+        //  +========================+
+        { name: 'identical to viewport', geojson: lineStringFromBounds(-73.8, 45.3, -73.4, 45.6), shouldCallFitBounds: false },
+
+        //       +==================+
+        //  A----+======B           |  overlaps left edge, crosses inner
+        //       +==================+
+        { name: 'overlaps left edge deeply', geojson: lineStringFromBounds(-74.0, 45.4, -73.6, 45.5), shouldCallFitBounds: false },
+
+        //  +==================+
+        //  |           A======+----B  overlaps right edge, crosses inner
+        //  +==================+
+        { name: 'overlaps right edge deeply', geojson: lineStringFromBounds(-73.5, 45.4, -73.2, 45.5), shouldCallFitBounds: false },
+
+        //       A---------B
+        //  +=====|========|====+
+        //  |     A--------B   |      overlaps top edge, crosses inner
+        //  +==================+
+        { name: 'overlaps top edge deeply', geojson: lineStringFromBounds(-73.7, 45.5, -73.5, 45.8), shouldCallFitBounds: false },
+
+        //  +==================+
+        //  |     A--------B   |      overlaps bottom edge, crosses inner
+        //  +=====|========|====+
+        //       A---------B
+        { name: 'overlaps bottom edge deeply', geojson: lineStringFromBounds(-73.7, 45.1, -73.5, 45.4), shouldCallFitBounds: false },
+
+        //  A--------------------------+
+        //  | +========================+ |
+        //  | |  +==================+  | |  diagonal encloses entire viewport
+        //  | |  |                  |  | |
+        //  | +========================+ |
+        //  +--------------------------B
+        { name: 'diagonal that encloses viewport', geojson: lineStringFromBounds(-74.0, 45.0, -73.0, 46.0), shouldCallFitBounds: false },
+
+        //  +========================+
+        //  | AB |                   |  A-B sits in the left margin zone
+        //  | +==================+  |   (between outer and inner edge)
+        //  +========================+
+        { name: 'inside but within left margin zone', geojson: lineStringFromBounds(-73.80, 45.4, -73.79, 45.5), shouldCallFitBounds: true },
+
+        //  +========================+
+        //  |  +==================+  |
+        //  |  |      A------B    |  |  A-B sits in the bottom margin zone
+        //  +========================+
+        { name: 'inside but within bottom margin zone', geojson: lineStringFromBounds(-73.6, 45.30, -73.5, 45.31), shouldCallFitBounds: true },
+
+        //  +========================+
+        //  |                        A---B  A at outer corner, in margin zone
+        //  +========================+
+        { name: 'shares only a corner (in margin)', geojson: lineStringFromBounds(-73.4, 45.6, -73.2, 45.8), shouldCallFitBounds: true },
+
+        //                     +========================+
+        //  A-----------B      |  +==================+  |  entirely west
+        //                     +========================+
+        { name: 'entirely to the west', geojson: lineStringFromBounds(-75.0, 45.4, -74.0, 45.5), shouldCallFitBounds: true },
+
+        //  +========================+
+        //  |  +==================+  |      A-----------B  entirely east
+        //  +========================+
+        { name: 'entirely to the east', geojson: lineStringFromBounds(-73.2, 45.4, -72.5, 45.5), shouldCallFitBounds: true },
+
+        //       A---------B
+        //
+        //  +========================+
+        //  |  +==================+  |  entirely north
+        //  +========================+
+        { name: 'entirely to the north', geojson: lineStringFromBounds(-73.7, 46.0, -73.5, 46.5), shouldCallFitBounds: true },
+
+        //  +========================+
+        //  |  +==================+  |  entirely south
+        //  +========================+
+        //
+        //       A---------B
+        { name: 'entirely to the south', geojson: lineStringFromBounds(-73.7, 44.0, -73.5, 44.5), shouldCallFitBounds: true },
+
+        //  +========================+
+        //  |  +==================+  |
+        //  +========================+ A----B  northeast, outside viewport
+        { name: 'to the northeast', geojson: lineStringFromBounds(-73.3, 45.7, -73.0, 46.0), shouldCallFitBounds: true }
+    ])('$name → shouldCallFitBounds=$shouldCallFitBounds', ({ geojson, shouldCallFitBounds }) => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north);
+
+        fitBoundsIfNotVisible(map, geojson);
+
+        if (shouldCallFitBounds) {
+            expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        } else {
+            expect(map.fitBounds).not.toHaveBeenCalled();
+        }
+    });
+
+    // C-shape whose bbox covers viewport but no segment enters inner viewport:
+    //
+    //  lat
+    //  45.7 |  C--------------D              path opens to the right
+    //       |  |
+    //  45.6 |  |  +========================+
+    //       |  |  | outer viewport         |
+    //  45.585  |  |  +==================+  |
+    //       |  |  |  | inner viewport   |  |
+    //       |  |  |  |                  |  |
+    //  45.315  |  |  +==================+  |
+    //  45.3 |  |  +========================+
+    //       |  |
+    //  45.2 |  B--------------A
+    //       +--+--------------+---> lng
+    //       -73.9          -73.5
+    //
+    // Path: A(-73.5,45.2) → B(-73.9,45.2) → C(-73.9,45.7) → D(-73.5,45.7)
+    // Opens to the right. The left side at lng -73.9 is west of the outer
+    // viewport (-73.8). Top/bottom segments at lat 45.7/45.2 are above/below
+    // the viewport. No segment crosses the inner viewport → fitBounds fires.
+    //
+    it('should fitBounds for a C-shaped path whose bbox covers the viewport but geometry does not', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north);
+        const cShape: GeoJSON.LineString = {
+            type: 'LineString',
+            coordinates: [
+                [-73.5, 45.2],
+                [-73.9, 45.2],
+                [-73.9, 45.7],
+                [-73.5, 45.7]
+            ]
+        };
+
+        fitBoundsIfNotVisible(map, cShape);
+
+        expect(map.fitBounds).toHaveBeenCalledTimes(1);
+    });
+
+    // C-shape where the top segment crosses the inner viewport:
+    //
+    //  lat
+    //  45.585|        |  +==================+  |
+    //        |        |  |  inner viewport  |  |
+    //  45.45 |  C-----+--+-----D            |  |  segment C→D at lat 45.45
+    //        |  |     |  |                  |  |  crosses inner viewport
+    //  45.315|  |     |  +==================+  |
+    //  45.3  |  |     +========================+
+    //        |  |
+    //  45.2  |  B--------------A
+    //        +--+--------------+---> lng
+    //        -73.9          -73.5
+    //
+    // Path: A(-73.5,45.2) → B(-73.9,45.2) → C(-73.9,45.45) → D(-73.5,45.45)
+    // Opens downward. The top segment C→D at lat 45.45 is between inner
+    // south (45.315) and inner north (45.585), and spans lng -73.9 to -73.5
+    // which crosses through the inner viewport → visible, no fitBounds.
+    //
+    it('should not fitBounds for a C-shaped path when a segment crosses the inner viewport', () => {
+        const map = makeMockMap(VP.west, VP.south, VP.east, VP.north);
+        const cShapeCrossing: GeoJSON.LineString = {
+            type: 'LineString',
+            coordinates: [
+                [-73.5, 45.2],
+                [-73.9, 45.2],
+                [-73.9, 45.45],
+                [-73.5, 45.45]
+            ]
+        };
+
+        fitBoundsIfNotVisible(map, cShapeCrossing);
+
+        expect(map.fitBounds).not.toHaveBeenCalled();
+    });
+
+    // -- geojsonIntersectsViewport behaviour through fitBoundsIfNotVisible --
+    //
+    // Uses a simple [-1,-1,1,1] viewport so the inner viewport (5% margin)
+    // is [-0.9, -0.9, 0.9, 0.9]:
+    //
+    //   lat
+    //    1 |  +----------+
+    //  0.9 |  | +------+ |
+    //      |  | |      | |
+    //    0 |  | | inner | |   viewport [-1,-1,1,1]
+    //      |  | |      | |
+    // -0.9 |  | +------+ |
+    //   -1 |  +----------+
+    //      +--+-----------+---> lng
+    //       -1 -0.9     0.9 1
+    //
+    // -- bare Geometry / Feature --
+    //
+    //   lat
+    //    1 |  +----------+
+    //      |  |       *G |      *G Feature<Point> inside (0.5,0.5)
+    //    0 A==|=== *C ===|==B   A----B LineString crossing
+    //      |  |          |      *C Point inside (0,0)
+    //   -1 |  +----------+
+    //      +--+-----------+---> lng
+    //       -2 -1         1  2
+    //
+    //                          *D (5,5) Point outside
+    //                          E----F (3,3)→(4,4) Feature<LineString> outside
+    //                          *G (0.5,0.5) Feature<Point> inside
+    //                          *H (5,5) Feature<Point> outside
+    //
+    describe('intersection detection (simple viewport)', () => {
+        const SIMPLE_VP = { west: -1, south: -1, east: 1, north: 1 };
+
+        test.each([
+            {
+                name: 'LineString crossing the viewport', // A-B
+                geojson: { type: 'LineString' as const, coordinates: [[-2, 0], [2, 0]] },
+                shouldCallFitBounds: false
+            },
+            {
+                name: 'Point inside the viewport', // C
+                geojson: { type: 'Point' as const, coordinates: [0, 0] },
+                shouldCallFitBounds: false
+            },
+            {
+                name: 'Point outside the viewport', // D
+                geojson: { type: 'Point' as const, coordinates: [5, 5] },
+                shouldCallFitBounds: true
+            },
+            {
+                name: 'Feature wrapping a LineString entirely outside the viewport', // E-F
+                geojson: { type: 'Feature' as const, geometry: { type: 'LineString' as const, coordinates: [[3, 3], [4, 4]] }, properties: {} },
+                shouldCallFitBounds: true
+            },
+            {
+                name: 'Feature wrapping a Point inside', // G
+                geojson: { type: 'Feature' as const, geometry: { type: 'Point' as const, coordinates: [0.5, 0.5] }, properties: {} },
+                shouldCallFitBounds: false
+            },
+            {
+                name: 'Feature wrapping a Point outside', // H
+                geojson: { type: 'Feature' as const, geometry: { type: 'Point' as const, coordinates: [5, 5] }, properties: {} },
+                shouldCallFitBounds: true
+            }
+        ])('$name → shouldCallFitBounds=$shouldCallFitBounds', ({ geojson, shouldCallFitBounds }) => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+
+            fitBoundsIfNotVisible(map, geojson as GeoJSON.GeoJSON);
+
+            if (shouldCallFitBounds) {
+                expect(map.fitBounds).toHaveBeenCalledTimes(1);
+            } else {
+                expect(map.fitBounds).not.toHaveBeenCalled();
+            }
+        });
+
+        it('should not call fitBounds for a Feature with null geometry', () => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+            const nullGeom: GeoJSON.Feature = { type: 'Feature', geometry: null as unknown as GeoJSON.Geometry, properties: {} };
+
+            fitBoundsIfNotVisible(map, nullGeom);
+
+            expect(map.fitBounds).not.toHaveBeenCalled();
+        });
+
+        // -- FeatureCollection --
+        //
+        //   lat
+        //    1 |  +----------+
+        //      |  |          |
+        //    0 |  |   *B     |    A=(5,5) outside, B=(0,0) inside
+        //      |  |          |
+        //   -1 |  +----------+                    *A
+        //      +--+-----------+---> lng
+        //       -2 -1         1  2  ...  5
+        //
+        it('should not call fitBounds when at least one feature intersects', () => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+            const fc: GeoJSON.FeatureCollection = {
+                type: 'FeatureCollection',
+                features: [
+                    { type: 'Feature', geometry: { type: 'Point', coordinates: [5, 5] }, properties: {} },
+                    { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }
+                ]
+            };
+
+            fitBoundsIfNotVisible(map, fc);
+
+            expect(map.fitBounds).not.toHaveBeenCalled();
+        });
+
+        //   lat
+        //    1 |  +----------+
+        //      |  |          |
+        //    0 |  | (empty)  |    A=(5,5) outside, B=(6,6) outside
+        //      |  |          |
+        //   -1 |  +----------+              *A    *B
+        //      +--+-----------+---> lng
+        //       -2 -1         1  ... 5  6
+        //
+        it('should call fitBounds when no feature intersects', () => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+            const fc: GeoJSON.FeatureCollection = {
+                type: 'FeatureCollection',
+                features: [
+                    { type: 'Feature', geometry: { type: 'Point', coordinates: [5, 5] }, properties: {} },
+                    { type: 'Feature', geometry: { type: 'Point', coordinates: [6, 6] }, properties: {} }
+                ]
+            };
+
+            fitBoundsIfNotVisible(map, fc);
+
+            expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not call fitBounds for an empty FeatureCollection', () => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+            const fc: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
+
+            fitBoundsIfNotVisible(map, fc);
+
+            expect(map.fitBounds).not.toHaveBeenCalled();
+        });
+
+        //   lat
+        //    1 |  +----------+
+        //      |  |          |
+        //    0 |  |   *B     |    A=null geometry (skipped), B=(0,0) inside
+        //      |  |          |
+        //   -1 |  +----------+
+        //      +--+-----------+---> lng
+        //       -2 -1         1
+        //
+        it('should skip null-geometry features and still detect intersecting ones', () => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+            const fc: GeoJSON.FeatureCollection = {
+                type: 'FeatureCollection',
+                features: [
+                    { type: 'Feature', geometry: null as unknown as GeoJSON.Geometry, properties: {} },
+                    { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }
+                ]
+            };
+
+            fitBoundsIfNotVisible(map, fc);
+
+            expect(map.fitBounds).not.toHaveBeenCalled();
+        });
+
+        it('should call fitBounds for a FeatureCollection with only null-geometry features', () => {
+            const map = makeMockMap(SIMPLE_VP.west, SIMPLE_VP.south, SIMPLE_VP.east, SIMPLE_VP.north);
+            const fc: GeoJSON.FeatureCollection = {
+                type: 'FeatureCollection',
+                features: [
+                    { type: 'Feature', geometry: null as unknown as GeoJSON.Geometry, properties: {} },
+                    { type: 'Feature', geometry: null as unknown as GeoJSON.Geometry, properties: {} }
+                ]
+            };
+
+            fitBoundsIfNotVisible(map, fc);
+
+            expect(map.fitBounds).not.toHaveBeenCalled();
+        });
+    });
+
+    // -- isMapCanvasOutOfSync behaviour through fitBoundsIfNotVisible --
+    //
+    // When canvas and container sizes diverge (accounting for devicePixelRatio),
+    // fitBoundsIfNotVisible calls resize() before the visibility test.
+    describe('canvas out-of-sync detection', () => {
+        const savedDpr = window.devicePixelRatio;
+        afterEach(() => {
+            Object.defineProperty(window, 'devicePixelRatio', { value: savedDpr, writable: true });
+        });
+
+        test.each([
+            { dpr: 1, canvasW: 800, canvasH: 600, containerW: 800, containerH: 600, shouldResize: false, name: 'dpr=1, sizes match' },
+            { dpr: 1, canvasW: 1024, canvasH: 600, containerW: 800, containerH: 600, shouldResize: true, name: 'dpr=1, width mismatch' },
+            { dpr: 1, canvasW: 800, canvasH: 768, containerW: 800, containerH: 600, shouldResize: true, name: 'dpr=1, height mismatch' },
+            { dpr: 2, canvasW: 1600, canvasH: 1200, containerW: 800, containerH: 600, shouldResize: false, name: 'dpr=2, sizes match (canvas = 2x container)' },
+            { dpr: 2, canvasW: 1602, canvasH: 1200, containerW: 800, containerH: 600, shouldResize: true, name: 'dpr=2, width off by >0.5 CSS px' },
+            { dpr: 2, canvasW: 1601, canvasH: 1200, containerW: 800, containerH: 600, shouldResize: false, name: 'dpr=2, width off by 0.5 CSS px (within tolerance)' },
+            { dpr: 3, canvasW: 2400, canvasH: 1800, containerW: 800, containerH: 600, shouldResize: false, name: 'dpr=3, sizes match (canvas = 3x container)' },
+            { dpr: 3, canvasW: 2404, canvasH: 1800, containerW: 800, containerH: 600, shouldResize: true, name: 'dpr=3, width off by >0.5 CSS px' }
+        ])('$name → shouldResize=$shouldResize', ({ dpr, canvasW, canvasH, containerW, containerH, shouldResize }) => {
+            Object.defineProperty(window, 'devicePixelRatio', { value: dpr, writable: true });
+            const map = makeMockMap(
+                VP.west, VP.south, VP.east, VP.north, 0,
+                { width: canvasW, height: canvasH },
+                { clientWidth: containerW, clientHeight: containerH }
+            );
+            const outside = lineStringFromBounds(-75.0, 46.0, -74.5, 46.5);
+
+            fitBoundsIfNotVisible(map, outside);
+
+            if (shouldResize) {
+                expect(map.resize).toHaveBeenCalledTimes(1);
+            } else {
+                expect(map.resize).not.toHaveBeenCalled();
+            }
+            expect(map.fitBounds).toHaveBeenCalledTimes(1);
+        });
+
+        it('should default to dpr=1 when devicePixelRatio is undefined', () => {
+            Object.defineProperty(window, 'devicePixelRatio', { value: undefined, writable: true });
+            const map = makeMockMap(
+                VP.west, VP.south, VP.east, VP.north, 0,
+                { width: 800, height: 600 },
+                { clientWidth: 800, clientHeight: 600 }
+            );
+            const outside = lineStringFromBounds(-75.0, 46.0, -74.5, 46.5);
+
+            fitBoundsIfNotVisible(map, outside);
+
+            expect(map.resize).not.toHaveBeenCalled();
+        });
+
+        it('should not call resize() when geojson has no computable extent', () => {
+            Object.defineProperty(window, 'devicePixelRatio', { value: 1, writable: true });
+            const map = makeMockMap(
+                VP.west, VP.south, VP.east, VP.north, 0,
+                { width: 1024, height: 768 },
+                { clientWidth: 800, clientHeight: 600 }
+            );
+
+            fitBoundsIfNotVisible(map, { type: 'FeatureCollection', features: [] });
+
+            expect(map.resize).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
The fitBounds implementation is now more robust to empty geometry or very small paths. It also is moved to a single file.

All calls to fitBounds have been updated.

Also, when selecting a path (from the map or right panel), the map no longer jumps to the path bounds if any part of it is already in the viewport. A manual "Fit map to path" button (crosshairs icon) is added to the path edit form for when the user does want to re-center.

- Skip auto fitBounds when selected path is visible
- Move fitBounds logic from TransitPathNodeList (UI panel) to the path selection handlers in PathSectionMapEvents and TransitPathButton
- Add MapBoundsUtils with fitBoundsIfNotVisible that accepts GeoJSON geometry directly and computes bbox via turf internally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Fit map bounds to path" button (crosshairs) in the path editor to center the map on the selected path; button disabled when no path geometry.

* **Improvements**
  * Unified, visibility-aware map fitting across path editing, scenario comparison, routing results, and main map to avoid incorrect or degenerate bounds and unnecessary re-centering.

* **Localization**
  * Added English and French labels for the new bounds control.

* **Tests**
  * Comprehensive unit tests covering bounds calculations, visibility checks, and fit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->