### PR TITLE
networkDesign: Make the config types not partial

### DIFF
--- a/packages/transition-backend/src/api/__tests__/simulations.routes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/simulations.routes.test.ts
@@ -63,7 +63,8 @@ const simulationAttributes1 = {
         algorithmConfiguration: {
             // Using 'test' as mock algorithm type, cast to any for test to work
             type: 'test' as any,
-            config: {}
+            // Casting as any to avoid having to provide all options for the test algorithm, which are not relevant for these tests, these routes will be removed with the new evolutionary algorithm architecture
+            config: {} as any
         }
     },
     isEnabled: true

--- a/packages/transition-backend/src/models/db/__tests__/simulationRuns.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/simulationRuns.db.test.ts
@@ -27,12 +27,18 @@ const simulationAttributes = {
             maxTotalTravelTimeSeconds: 1000
         },
         transitNetworkDesignParameters: {
-            maxTimeBetweenPassages: 15,
-            nbOfVehicles: 9
+            maxTimeBetweenPassages: 30,
+            nbOfVehicles: 7,
+            simulatedAgencies: ['arbitrary'],
+            numberOfLinesMin: 3,
+            numberOfLinesMax: 4,
+            minTimeBetweenPassages: 10,
+            nonSimulatedServices: [],
+            linesToKeep: []
         },
         algorithmConfiguration: {
             type: 'test' as any,
-            config: {}
+            config: {} as any
         }
     },
     isEnabled: true

--- a/packages/transition-backend/src/models/db/__tests__/simulations.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/simulations.db.test.ts
@@ -27,7 +27,7 @@ const newObjectAttributes = {
         transitNetworkDesignParameters: {
             maxTimeBetweenPassages: 15,
             nbOfVehicles: 9
-        }
+        } as any // Cast as any instead of defining all variables, these queries will be removed shortly anyway
     },
     isEnabled: true
 };

--- a/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
@@ -58,7 +58,7 @@ beforeAll(async () => {
     await simulationDbQueries.create({
         id: simulationId,
         data: {
-            transitNetworkDesignParameters: {},
+            transitNetworkDesignParameters: {} as any, // Casting as `any` to avoid having to define all parameters, simulations will be removed shortly anyway
             routingAttributes: {}
         }
     });

--- a/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
@@ -87,7 +87,7 @@ beforeAll(async () => {
     await simulationDbQueries.create({
         id: simulationId,
         data: {
-            transitNetworkDesignParameters: {},
+            transitNetworkDesignParameters: {} as any, // Casting as `any` to avoid having to define all parameters, simulations will be removed shortly anyway
             routingAttributes: {}
         }
     });

--- a/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
@@ -97,7 +97,7 @@ beforeAll(async () => {
     await simulationDbQueries.create({
         id: simulationId,
         data: {
-            transitNetworkDesignParameters: {},
+            transitNetworkDesignParameters: {} as any, // Casting as `any` to avoid having to define all parameters, simulations will be removed shortly anyway
             routingAttributes: {}
         }
     });

--- a/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
@@ -26,6 +26,7 @@ import {
     SimulationRuntimeOptions
 } from 'transition-common/lib/services/simulation/SimulationRun';
 import scenarioDbQueries from './transitScenarios.db.queries';
+import { TransitNetworkDesignParameters } from 'transition-common/lib/services/networkDesign/transit/TransitNetworkDesignParameters';
 
 const tableName = 'tr_simulation_runs';
 const runToScenarioTableName = 'tr_simulation_run_scenario';
@@ -77,8 +78,8 @@ const attributesParser = ({
                 transitNetworkDesignParameters === undefined &&
                 simulationParameters !== undefined &&
                 simulationParameters !== null
-                    ? simulationParameters
-                    : transitNetworkDesignParameters
+                    ? (simulationParameters as TransitNetworkDesignParameters)
+                    : (transitNetworkDesignParameters as TransitNetworkDesignParameters)
         },
         ...rest
     };

--- a/packages/transition-backend/src/models/db/simulations.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulations.db.queries.ts
@@ -22,6 +22,7 @@ import {
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { SimulationAttributes, SimulationDataAttributes } from 'transition-common/lib/services/simulation/Simulation';
+import { TransitNetworkDesignParameters } from 'transition-common/lib/services/networkDesign/transit/TransitNetworkDesignParameters';
 
 const tableName = 'tr_simulations';
 
@@ -71,8 +72,8 @@ const attributesParser = ({
                 transitNetworkDesignParameters === undefined &&
                 simulationParameters !== undefined &&
                 simulationParameters !== null
-                    ? simulationParameters
-                    : transitNetworkDesignParameters
+                    ? (simulationParameters as TransitNetworkDesignParameters)
+                    : (transitNetworkDesignParameters as TransitNetworkDesignParameters)
         },
         ...rest
     };

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/__tests__/LineAndNumberOfVehiclesNetworkCandidate.test.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/__tests__/LineAndNumberOfVehiclesNetworkCandidate.test.ts
@@ -76,7 +76,10 @@ const simulationRun = new SimulationRun({
                 mutationProbability: 0.5,
                 tournamentSize: 2,
                 tournamentProbability: 0.6,
-                shuffleGenes: false
+                numberOfGenerations: 3,
+                shuffleGenes: false,
+                keepGenerations: 1,
+                keepCandidates: 1
             }
         }
     },

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/__tests__/LineAndNumberOfVehiclesGeneration.test.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/__tests__/LineAndNumberOfVehiclesGeneration.test.ts
@@ -86,7 +86,10 @@ const simulationRun = new SimulationRun({
                 mutationProbability: 0.5,
                 tournamentSize: 2,
                 tournamentProbability: 0.6,
-                shuffleGenes: true
+                numberOfGenerations: 3,
+                shuffleGenes: true,
+                keepGenerations: 1,
+                keepCandidates: 1
             }
         }
     },

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/preparation/__tests__/ServicePreparation.test.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/preparation/__tests__/ServicePreparation.test.ts
@@ -209,7 +209,11 @@ describe('Test with a single line', () => {
                     crossoverProbability: 0.3,
                     mutationProbability: 0.5,
                     tournamentSize: 2,
-                    tournamentProbability: 0.6
+                    tournamentProbability: 0.6,
+                    numberOfGenerations: 3,
+                    shuffleGenes: true,
+                    keepGenerations: 1,
+                    keepCandidates: 1
                 }
             }
         },

--- a/packages/transition-common/src/services/networkDesign/transit/algorithm/index.ts
+++ b/packages/transition-common/src/services/networkDesign/transit/algorithm/index.ts
@@ -25,7 +25,7 @@ export type AlgorithmType = keyof AlgorithmRegistry;
  */
 export type AlgorithmConfigurationByType<T extends AlgorithmType> = {
     type: T;
-    config: Partial<AlgorithmRegistry[T]>;
+    config: AlgorithmRegistry[T];
 };
 
 /**

--- a/packages/transition-common/src/services/networkDesign/transit/simulationMethod/index.ts
+++ b/packages/transition-common/src/services/networkDesign/transit/simulationMethod/index.ts
@@ -33,7 +33,7 @@ export type SimulationMethodType = keyof SimulationMethodRegistry;
  */
 export type SimulationMethodConfigurationByType<T extends SimulationMethodType> = {
     type: T;
-    config: Partial<SimulationMethodRegistry[T]>;
+    config: SimulationMethodRegistry[T];
 };
 
 /**

--- a/packages/transition-common/src/services/simulation/Simulation.ts
+++ b/packages/transition-common/src/services/simulation/Simulation.ts
@@ -128,7 +128,9 @@ class Simulation extends ObjectWithHistory<SimulationAttributes> implements Save
                     // TODO Add a method to set the type of the algorithm and initialize the data
                     const options = algorithmDescriptor.getOptions();
                     if (algoConfig.config === undefined) {
-                        algoConfig.config = {};
+                        // FIXME: Temporary any to avoid typing issues, but this
+                        // whole class will be replaced by an ExecutableJob
+                        algoConfig.config = {} as any;
                     }
                     const erroneousFields = Object.keys(options).filter(
                         (option) =>

--- a/packages/transition-common/src/services/simulation/__tests__/Simulation.test.ts
+++ b/packages/transition-common/src/services/simulation/__tests__/Simulation.test.ts
@@ -165,7 +165,7 @@ test('should construct new simulations and set default algorithm values', functi
     attributes.data.algorithmConfiguration = {
         // Using 'mockAlgorithm' as mock algorithm type, cast to any for test to compile
         type: 'mockAlgorithm' as any,
-        config: {}
+        config: {} as any
     }
     const simulation1 = new Simulation(attributes, true);
     expect(Object.keys(simulation1.attributes.data.algorithmConfiguration?.config || {}).length).toEqual(Object.keys(stubAlgorithm.getOptions()).length);


### PR DESCRIPTION
The types should not be partial, in the backend, they are meant to be complete. Only the frontend will have partial types to support entering the configuration, so the frontend will build their own types accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/adjusted evolutionary algorithm test parameters for broader coverage; added type casts in several test fixtures to satisfy stricter typings.

* **Refactor**
  * Tightened configuration types to require full algorithm and simulation method configurations (no partials).

* **Bug Fixes**
  * Made transit network parameter selection more consistent when multiple sources are present, ensuring a single prioritized source is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->