### PR TITLE
Disable gzip negociation in http connection to OSRM

### DIFF
--- a/packages/chaire-lib-backend/src/utils/osrm/OSRMMode.ts
+++ b/packages/chaire-lib-backend/src/utils/osrm/OSRMMode.ts
@@ -22,6 +22,12 @@ type OSRMServiceTypes = 'route' | 'nearest' | 'table' | 'match' | 'trip' | 'tile
 
 type OSRMOptions = osrm.MatchOptions | osrm.RouteOptions | osrm.TableOptions;
 
+const COMMON_FETCH_OPTIONS = {
+    headers: {
+        'Accept-Encoding': 'identity' // Adding header to disable gzip negociation
+    }
+};
+
 /*
 Represent a configured routing mode for OSRM.
 
@@ -87,7 +93,7 @@ class OSRMMode {
 
         const routeQuery = this.buildOsrmQuery('route', params.points, optionKeys, parameters);
 
-        const response = await fetch(routeQuery);
+        const response = await fetch(routeQuery, COMMON_FETCH_OPTIONS);
 
         const routingResultJson = await response.json();
 
@@ -128,7 +134,7 @@ class OSRMMode {
 
         const matchQuery = this.buildOsrmQuery('match', params.points, optionKeys, parameters);
 
-        const response = await fetch(matchQuery);
+        const response = await fetch(matchQuery, COMMON_FETCH_OPTIONS);
 
         const routingResultJson = await response.json();
 
@@ -166,7 +172,7 @@ class OSRMMode {
 
         const tableFromQuery = this.buildOsrmQuery('table', features, optionKeys, options);
 
-        const response = await fetch(tableFromQuery);
+        const response = await fetch(tableFromQuery, COMMON_FETCH_OPTIONS);
 
         const routingResultJson = await response.json();
 
@@ -223,7 +229,7 @@ class OSRMMode {
 
         const tableToQuery = this.buildOsrmQuery('table', features, optionKeys, options);
 
-        const response = await fetch(tableToQuery);
+        const response = await fetch(tableToQuery, COMMON_FETCH_OPTIONS);
 
         const routingResultJson = await response.json();
 

--- a/packages/chaire-lib-backend/src/utils/osrm/__tests__/OSRMMode.test.ts
+++ b/packages/chaire-lib-backend/src/utils/osrm/__tests__/OSRMMode.test.ts
@@ -70,7 +70,7 @@ describe('OSRM Mode tests', () => {
 
         const result = await aMode.route(params);
         expect(mockedFetch).toHaveBeenCalledTimes(1);
-        expect(mockedFetch).toHaveBeenCalledWith('http://localhost:4000/route/v1/walking/-73,45;-73.1,45.1?alternatives=false&steps=false&annotations=false&continue_straight=default&geometries=geojson&overview=full', undefined);
+        expect(mockedFetch).toHaveBeenCalledWith('http://localhost:4000/route/v1/walking/-73,45;-73.1,45.1?alternatives=false&steps=false&annotations=false&continue_straight=default&geometries=geojson&overview=full', {"headers": {"Accept-Encoding": "identity"}});
 
 
     });
@@ -154,7 +154,7 @@ describe('OSRM Mode tests', () => {
         mockedFetch.mockResolvedValue(response);
         const result = await aMode.route(params);
         expect(mockedFetch).toHaveBeenCalledTimes(1);
-        expect(mockedFetch).toHaveBeenCalledWith('http://localhost:4000/route/v1/walking/-73,45;-73.1,45.1?alternatives=false&steps=false&annotations=false&continue_straight=default&geometries=geojson&overview=full', undefined);
+        expect(mockedFetch).toHaveBeenCalledWith('http://localhost:4000/route/v1/walking/-73,45;-73.1,45.1?alternatives=false&steps=false&annotations=false&continue_straight=default&geometries=geojson&overview=full', {"headers": {"Accept-Encoding": "identity"}});
 
         //Check result
         expect(Status.unwrap(result)).toHaveProperty('waypoints');
@@ -268,7 +268,7 @@ describe('OSRM Mode tests', () => {
 
         const result = await aMode.match(params);
         expect(mockedFetch).toHaveBeenCalledTimes(1);
-        expect(mockedFetch).toHaveBeenCalledWith('http://localhost:4000/match/v1/busUrban/-73.576361,45.454669;-73.576504,45.454872?radiuses=17;17&timestamps=0;189&steps=true&annotations=false&gaps=ignore&geometries=geojson&overview=full', undefined);
+        expect(mockedFetch).toHaveBeenCalledWith('http://localhost:4000/match/v1/busUrban/-73.576361,45.454669;-73.576504,45.454872?radiuses=17;17&timestamps=0;189&steps=true&annotations=false&gaps=ignore&geometries=geojson&overview=full', {"headers": {"Accept-Encoding": "identity"}});
 
         //Check result
         expect(Status.unwrap(result)).toHaveProperty('tracepoints');
@@ -348,7 +348,7 @@ describe('OSRM Mode tests', () => {
         const EXPECTED_QUERY = 'http://localhost:5000/table/v1/walking/-73.663473,45.611544;-73.663473,45.611544;-73.663473,45.611544;-73.663083,45.612892;-73.660853,45.612142?sources=0&annotations=duration,distance';
 
         expect(mockedFetch).toHaveBeenCalledTimes(1);
-        expect(mockedFetch).toHaveBeenCalledWith(EXPECTED_QUERY, undefined);
+        expect(mockedFetch).toHaveBeenCalledWith(EXPECTED_QUERY, {"headers": {"Accept-Encoding": "identity"}});
 
 
         //Check result
@@ -402,7 +402,7 @@ describe('OSRM Mode tests', () => {
         const EXPECTED_QUERY = 'http://localhost:5000/table/v1/walking/-73.663473,45.611544;-73.663473,45.611544;-73.663473,45.611544;-73.663083,45.612892;-73.660853,45.612142?destinations=0&annotations=duration,distance';
 
         expect(mockedFetch).toHaveBeenCalledTimes(1);
-        expect(mockedFetch).toHaveBeenCalledWith(EXPECTED_QUERY, undefined);
+        expect(mockedFetch).toHaveBeenCalledWith(EXPECTED_QUERY, {"headers": {"Accept-Encoding": "identity"}});
 
         //Check result
         expect(Status.unwrap(result)).toHaveProperty('query');


### PR DESCRIPTION
We usually run OSRM locally, adding GZIP compression on top is an unnecessary CPU cost. We add the header Accept-Encoding and set it to identity to disable that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request handling for routing services to ensure reliable response processing by preventing unnecessary compression negotiation, reducing failures or corrupted responses.

* **Tests**
  * Updated test expectations to align with the improved HTTP behavior, ensuring routing-related request/response handling is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->