### PR TITLE
Implement batch DB write in TrRoutingBatch

### DIFF
--- a/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
+++ b/packages/transition-backend/src/models/db/batchRouteResults.db.queries.ts
@@ -34,6 +34,26 @@ const create = async (result: TripJobResult): Promise<void> => {
     }
 };
 
+// TODO Should we remove create and juste keep createMany ? Either keep the create interface that calls createMany or delete it completely
+const createMany = async (results: TripJobResult[]): Promise<void> => {
+    if (results.length === 0) return;
+    try {
+        await knex(tableName).insert(
+            results.map((result) => ({
+                job_id: result.jobId,
+                trip_index: result.tripIndex,
+                data: result.data
+            }))
+        );
+    } catch (error) {
+        throw new TrError(
+            `Cannot bulk insert ${results.length} results for job ${results[0].jobId} in table ${tableName} (knex error: ${error})`,
+            'DBBRR0004',
+            'DatabaseCannotBulkCreateBecauseDatabaseError'
+        );
+    }
+};
+
 const attributesParser = ({
     job_id,
     trip_index,
@@ -171,6 +191,7 @@ const deleteForJob = async (jobId: number, tripIndex?: number): Promise<void> =>
 
 export default {
     create,
+    createMany,
     collection,
     streamResults,
     countResults,

--- a/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
+++ b/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
@@ -27,11 +27,14 @@ export class CheckpointTracker {
      * chunk size * nb of terminated chunks
      * @param currentCheckpoint If resuming a task, this is the last checkpoint
      * that was registered in previous run
+     * @param beforeCheckpoint, an optional callback to call before finalizing
+     * the checkpoint
      */
     constructor(
         private chunkSize: number,
         private progressEmitter: EventEmitter,
-        currentCheckpoint = 0
+        currentCheckpoint = 0,
+        private beforeCheckpoint?: (checkpoint: number) => Promise<void>
     ) {
         this.lastCheckpointIdx = Math.floor(currentCheckpoint / chunkSize) - 1;
         // Add items to the last checkpoint, in case the chunk size is not a multiple of the current checkpoint
@@ -74,10 +77,22 @@ export class CheckpointTracker {
             while (this.indexes[indexToNotify + 1] === this.chunkSize) {
                 indexToNotify++;
             }
-            console.log('Emitting checkpoint at index ', chkIndex);
-            this.progressEmitter.emit('checkpoint', (indexToNotify + 1) * this.chunkSize);
             this.lastCheckpointIdx = indexToNotify;
+            const checkpoint = (indexToNotify + 1) * this.chunkSize;
+            this.emitCheckpoint(checkpoint);
         }
+    }
+
+    private emitCheckpoint(checkpoint: number): void {
+        const doEmit = async () => {
+            // If defined, call the beforeCheckpoint callback to do finalization before confirming checkpoint
+            if (this.beforeCheckpoint !== undefined) {
+                await this.beforeCheckpoint(checkpoint);
+            }
+            console.log('Emitting checkpoint at index ', checkpoint);
+            this.progressEmitter.emit('checkpoint', checkpoint);
+        };
+        doEmit().catch((err) => console.error(`CheckpointTracker: error before checkpoint ${checkpoint}:`, err));
     }
 
     /**

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -21,6 +21,7 @@ import { ExecutableJob } from '../executableJob/ExecutableJob';
 import { BatchRouteJobType, BatchRouteResultVisitor } from './BatchRoutingJob';
 import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { BatchRouteFileResultVisitor } from './batchRouteCalculation/BatchRouteFileResultVisitor';
+import { OdTripRouteResult } from './types';
 
 const CHECKPOINT_INTERVAL = 250;
 
@@ -58,6 +59,7 @@ class TrRoutingBatch {
     private odTrips: BaseOdTrip[] = [];
     private errors: TranslatableMessage[] = [];
     private batchManager: TrRoutingBatchManager;
+    private resultBuffer: Array<{ jobId: number; tripIndex: number; data: OdTripRouteResult }> = [];
 
     constructor(
         private job: ExecutableJob<BatchRouteJobType>,
@@ -139,7 +141,14 @@ class TrRoutingBatch {
             const checkpointTracker = new CheckpointTracker(
                 CHECKPOINT_INTERVAL,
                 this.options.progressEmitter,
-                this.job.attributes.internal_data.checkpoint
+                this.job.attributes.internal_data.checkpoint,
+                async (_checkpoint: number) => {
+                    // Use splice to empty the array and return the current content
+                    const toFlush = this.resultBuffer.splice(0);
+                    if (toFlush.length > 0) {
+                        await resultsDbQueries.createMany(toFlush);
+                    }
+                }
             );
             for (let odTripIndex = startIndex; odTripIndex < odTripsCount; odTripIndex++) {
                 promiseQueue.add(async () => {
@@ -173,6 +182,11 @@ class TrRoutingBatch {
             }
 
             await promiseQueue.onIdle();
+            // Drain any remaining buffered results not yet flushed by a checkpoint
+            const remaining = this.resultBuffer.splice(0);
+            if (remaining.length > 0) {
+                await resultsDbQueries.createMany(remaining);
+            }
             console.log('Batch odTrip routing completed for job %d', this.job.id);
             checkpointTracker.completed();
 
@@ -309,8 +323,9 @@ class TrRoutingBatch {
                     }
                 });
             }
-            // FIXME Do not synchronously wait for the save (~10% time overhead). When we have checkpoint support, we can do .then/catch to handle completion instead
-            await resultsDbQueries.create({
+
+            // No await — push to buffer, let the checkpoint listener flush in bulk
+            this.resultBuffer.push({
                 jobId: this.job.id,
                 tripIndex: odTripIndex,
                 data: routingResult

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -111,12 +111,14 @@ jest.mock('../../../models/db/batchRouteResults.db.queries', () => {
 
     return {
         resultParser: originalModule.default.resultParser,
-        create: jest.fn().mockImplementation(({ jobId, tripIndex, data }) => {
-            resultsInDb.push({
-                job_id: jobId,
-                trip_index: tripIndex,
-                data
-            })
+        createMany: jest.fn().mockImplementation((results: { jobId: number; tripIndex: number; data: any }[]) => {
+            results.forEach(({ jobId, tripIndex, data }) => {
+                resultsInDb.push({
+                    job_id: jobId,
+                    trip_index: tripIndex,
+                    data
+                });
+            });
         }),
         collection: jest.fn().mockImplementation((jobId, options) => ({ totalCount: resultsInDb.length, tripResults: resultsInDb })),
         deleteForJob: jest.fn(),
@@ -124,7 +126,7 @@ jest.mock('../../../models/db/batchRouteResults.db.queries', () => {
         countResults: jest.fn().mockResolvedValue(0) // The result is used for logging, any value works
     };
 });
-const mockResultCreate = resultDbQueries.create as jest.MockedFunction<typeof resultDbQueries.create>;
+const mockResultCreateMany = resultDbQueries.createMany as jest.MockedFunction<typeof resultDbQueries.createMany>;
 const mockResultCollection = resultDbQueries.collection as jest.MockedFunction<typeof resultDbQueries.collection>;
 const mockResultDeleteForJob = resultDbQueries.deleteForJob as jest.MockedFunction<typeof resultDbQueries.deleteForJob>;
 const mockStreamResults = resultDbQueries.streamResults as jest.MockedFunction<typeof resultDbQueries.streamResults>;
@@ -182,7 +184,7 @@ beforeEach(async () => {
     resultsInDbCnt = 0;
     routeOdTripMock.mockClear();
     mockCreateStream.mockClear();
-    mockResultCreate.mockClear();
+    mockResultCreateMany.mockClear();
     mockResultCollection.mockClear();
     mockResultDeleteForJob.mockClear();
     mockStreamResults.mockClear();
@@ -233,13 +235,13 @@ test('Batch route to csv', async () => {
     );
 
     // Validate the result database calls
-    expect(mockResultCreate).toHaveBeenCalledTimes(odTrips.length);
-    for (let i = 0; i < odTrips.length; i++) {
-        expect(mockResultCreate).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockResultCreateMany).toHaveBeenCalledTimes(Math.ceil(odTrips.length / 250)); //Called only once per checkpoint
+    expect(mockResultCreateMany).toHaveBeenCalledWith(
+        odTrips.map((_, i) => expect.objectContaining({
             jobId,
             tripIndex: i
-        }));
-    }
+        }))
+    );
     expect(mockStreamResults).toHaveBeenCalledTimes(1);
     expect(mockStreamResults).toHaveBeenCalledWith(jobId);
     expect(mockResultDeleteForJob).toHaveBeenCalledTimes(1);
@@ -309,13 +311,13 @@ test('Batch route with some errors', async () => {
     expect(csvStream.data.length).toEqual(odTrips.length + 1);
 
     // Validate the result database calls
-    expect(mockResultCreate).toHaveBeenCalledTimes(odTrips.length);
-    for (let i = 0; i < odTrips.length; i++) {
-        expect(mockResultCreate).toHaveBeenCalledWith(expect.objectContaining({
+    expect(mockResultCreateMany).toHaveBeenCalledTimes(Math.ceil(odTrips.length / 250)); //Called only once per checkpoint
+    expect(mockResultCreateMany).toHaveBeenCalledWith(
+        odTrips.map((_, i) => expect.objectContaining({
             jobId,
             tripIndex: i
-        }));
-    }
+        }))
+    );
     expect(mockStreamResults).toHaveBeenCalledTimes(1);
     expect(mockStreamResults).toHaveBeenCalledWith(jobId);
     expect(mockResultDeleteForJob).toHaveBeenCalledTimes(1);
@@ -338,7 +340,7 @@ test('Batch route with too many errors', async () => {
     });
 
     // Validate the result database calls
-    expect(mockResultCreate).not.toHaveBeenCalled();
+    expect(mockResultCreateMany).not.toHaveBeenCalled();
     expect(mockResultCollection).not.toHaveBeenCalled();
     expect(mockResultDeleteForJob).not.toHaveBeenCalled();
 });
@@ -403,6 +405,12 @@ describe('Batch route from checkpoint', () => {
         expect(checkpointListenerMock).toHaveBeenCalledWith(500);
         expect(checkpointListenerMock).toHaveBeenCalledWith(750);
         expect(checkpointListenerMock).toHaveBeenCalledWith(756);
+
+        expect(mockResultCreateMany).toHaveBeenCalledTimes(4); // Once per checkpoint
+        expect(mockResultCreateMany).toHaveBeenNthCalledWith(1, expect.arrayContaining([
+            expect.objectContaining({ tripIndex: 0 }),
+            expect.objectContaining({ tripIndex: 249 })
+        ]));
     });
 
     test('Checkpoint callback is called after resuming', async () => {


### PR DESCRIPTION
Instead of writing to the DB for each OD pairs, we accumulate the results in an array, and commit them to the database once before we do the checkpoint. This should reduce the latency in the batch job by removing many database round-trip.

We add a callback to the JobCheckpointTracker object, to be called before we commit a checkpoint. This is used in TrRoutingBatch to flush the accumulated data to database.

With this, at the moment, we accumulate 250 results entry in the array. If we realize that memory usage is too high, we could call the write to database more often.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional pre-checkpoint callbacks in route processing for enhanced extensibility.

* **Performance Improvements**
  * Implemented bulk insertion of route calculation results, replacing individual writes with batched operations.
  * Added result buffering mechanism during checkpoint operations to optimize data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->