### PR TITLE
networkDesign: update icons for light/dark theme

### DIFF
--- a/packages/transition-common/src/config/project.config.ts
+++ b/packages/transition-common/src/config/project.config.ts
@@ -57,14 +57,9 @@ const defaultSectionsConfig = {
     },
     networkDesign: {
         localizedTitle: 'transit:networkDesign:NetworkDesign',
-        icon: '/dist/images/icons/interface/networkDesign_white.svg',
+        iconWhite: '/dist/images/icons/interface/networkDesign_white.svg',
+        iconBlack: '/dist/images/icons/interface/networkDesign_black.svg', // FIXME This file is missing, need to create it
         enabled: true // TODO Do not enable yet in main branche!! Until everything is well documented and functional
-    },
-    simulations: {
-        localizedTitle: 'transit:simulation:Simulations',
-        iconWhite: '/dist/images/icons/interface/simulation_white.svg',
-        iconBlack: '/dist/images/icons/interface/simulation_black.svg',
-        enabled: false // Disabled by default as accessing this features requires CLI access
     },
     gtfsImport: {
         localizedTitle: 'transit:gtfs:Import',


### PR DESCRIPTION
The fields for icons in the section configuration has been updated to `iconWhite` and `iconBlack`, so the field is renamed to `iconWhite`. The path for `iconBlack` is set, but the icon does not exist.

Also remove the `simulations` section, which is not used anymore.