### PR TITLE
Spawn multiple trRouting processes when asking for more than 16 threads

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
@@ -25,8 +25,14 @@ type TrRoutingBatchStartParameters = TrRoutingStartParameters & {
     memcachedServer?: string;
 };
 
-const getServiceName = function (port: number) {
-    return `trRouting${port}`;
+const getServiceName = function (port: number, processIndex: number = 0) {
+    // When spawning multiple instances, the first one will have the classic service name
+    // and the other ones (index 1 and above) will have the index added at the end
+    if (processIndex <= 0) {
+        return `trRouting${port}`;
+    } else {
+        return `trRouting${port}_${processIndex}`;
+    }
 };
 
 const startTrRoutingProcess = async (
@@ -45,10 +51,11 @@ const startTrRoutingProcess = async (
         cacheAllScenarios?: boolean; // Flag to enable the trRouting connection cache for all scenario
         logFiles: TrRoutingConfig['logs'];
         memcachedServer?: string; // If defined, enable use of memcached and use the value as the server URL
-    }
+    },
+    processIndex: number = -1
 ) => {
     const osrmWalkingServerInfo = osrmService.getMode('walking').getHostPort();
-    const serviceName = getServiceName(port);
+    const serviceName = getServiceName(port, processIndex);
     const tagName = 'trRouting';
 
     const [command, cwd] =
@@ -81,6 +88,10 @@ const startTrRoutingProcess = async (
     // Enable memcached usage in TrRouting
     if (memcachedServer) {
         commandArgs.push(`--useMemcached=${memcachedServer}`);
+    }
+
+    if (processIndex >= 0) {
+        commandArgs.push('--enableReusePort=true');
     }
 
     const waitString = 'ready.';
@@ -188,6 +199,8 @@ const status = async (parameters: { port?: number }) => {
     }
 };
 
+const MAX_THREADS_PER_PROCESS = 16; // TrRouting saturate at 24 threads, so let's not get there
+
 const startBatch = async function (
     numberOfCpus?: number,
     {
@@ -219,7 +232,19 @@ const startBatch = async function (
         memcachedServer: memcachedServer
     };
 
-    await startTrRoutingProcess(port, false, numberOfCpus, params);
+    // Since a single process cannot handle too many threads, we will spawn multiple process
+    // TODO This can go away if we change trRouting to handle more threads
+    // https://github.com/chairemobilite/trRouting/issues/340
+    const processCount = Math.ceil(numberOfCpus / MAX_THREADS_PER_PROCESS);
+    const threadsPerProcess = Math.ceil(numberOfCpus / processCount);
+
+    const startPromises: Promise<any>[] = [];
+    for (let i = 0; i < processCount; i++) {
+        // Last process may get fewer threads if total doesn't divide evenly
+        const threads = Math.min(threadsPerProcess, numberOfCpus - i * threadsPerProcess);
+        startPromises.push(startTrRoutingProcess(port, false, threads, params, i));
+    }
+    await Promise.all(startPromises);
 
     return {
         status: 'started',
@@ -229,8 +254,18 @@ const startBatch = async function (
 };
 
 const stopBatch = async function (port: number = serverConfig.getTrRoutingConfig('batch').port) {
-    await stop({ port: port });
-
+    await stop({ port: port }); // Stop the first one the normal way
+    // Since we don't have a good way to Iterate through the running extra instances
+    // We check for each index and stop if we cannot find one. Only check the first X instances, assuming
+    // the absolute max is 256 threads machines.
+    for (let i = 1; i <= 256 / MAX_THREADS_PER_PROCESS; i++) {
+        const serviceName = getServiceName(port, i);
+        if (await ProcessManager.isServiceRunning(serviceName)) {
+            await ProcessManager.stopProcess(serviceName, 'trRouting');
+        } else {
+            break; // No more processes
+        }
+    }
     return {
         status: 'stopped',
         service: 'trRoutingBatch',

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -510,7 +510,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -533,7 +533,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -560,7 +560,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=2', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -583,7 +583,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -609,7 +609,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: `trRouting${port}`,
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--cacheAllConnectionSets=true', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -637,7 +637,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', '--useMemcached=localhost:11212'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', '--useMemcached=localhost:11212', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -662,7 +662,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=14000`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--useMemcached=localhost:11212'],
+            commandArgs: [`--port=14000`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--useMemcached=localhost:11212', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -688,7 +688,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=4', '--enableReusePort=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -697,6 +697,41 @@ describe('TrRouting Process Manager: startBatch', () => {
                 nbLogFiles: logFiles.nbFiles,
                 maxFileSizeKB: logFiles.maxFileSizeKB
             }
+        });
+    });
+    test('start batch process with 32 cpus, should be split in 2 processes', async () => {
+        // Override the configuration
+        // TODO might have a better way to do this
+        config.maxParallelCalculators = 32;
+
+        const status = await TrRoutingProcessManager.startBatch(32);
+        expect(status).toEqual({
+            status: 'started',
+            service: 'trRoutingBatch',
+            port: 14000
+        });
+        expect(startProcessMock).toHaveBeenCalledTimes(2);
+
+        const expectedCommonArgs = {
+            tagName: 'trRouting',
+            command: 'trRouting',
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.projectDirectory}/cache/test`, '--threads=16', '--enableReusePort=true'],
+            waitString: 'ready.',
+            useShell: false,
+            cwd: undefined,
+            attemptRestart: false,
+            logFiles: {
+                nbLogFiles: 3,
+                maxFileSizeKB: 5120
+            }
+        };
+        expect(startProcessMock).toHaveBeenNthCalledWith(1, {
+            ...expectedCommonArgs,
+            serviceName: 'trRouting14000'
+        });
+        expect(startProcessMock).toHaveBeenNthCalledWith(2, {
+            ...expectedCommonArgs,
+            serviceName: 'trRouting14000_1'
         });
     });
 });


### PR DESCRIPTION
We discovered that trRouting struggle at dispatching http requests for more than 24 threads. To work around that, we spawn multiple processes (which share the port with SO_REUSEPORT) and the kernel will share the requests among them.

To manage the processes we happen an index to their service names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Process manager now supports running multiple parallel instances with per-instance names, controlled threading per process, and optional per-instance port reuse to enable safe multi-process operation; batch start/stop now manages multiple instances and scales work across processes.

* **Tests**
  * Test suite expanded to validate multi-instance startup/shutdown, per-instance naming, port-reuse behavior, and multi-process splitting across various thread/port configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->