### PR TITLE
Use a global TrRouting for a whole Generation

### DIFF
--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/Generation.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/Generation.ts
@@ -18,6 +18,7 @@ import { TransitNetworkDesignJobWrapper } from '../../networkDesign/transitNetwo
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { ResultSerialization } from '../candidate/types';
 import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
+import { TrRoutingBatchManager } from '../../transitRouting/TrRoutingBatchManager';
 
 abstract class Generation {
     protected fitnessSorter: (fitnessA: number, fitnessB: number) => number;
@@ -104,6 +105,15 @@ abstract class Generation {
         console.time(` generation ${this.generationNumber}: simulated candidates`);
         console.log(`  generation ${this.generationNumber}: simulating candidates`);
 
+        // Start TrRouting for the generation
+        const memcachedServer = this.jobWrapper.getMemcachedInstance()?.getServer();
+        const realBatchManager = new TrRoutingBatchManager(new EventEmitter());
+        const startResults = await realBatchManager.startBatch(
+            1000, // TODO Fake high number to get above maxparallelCalculator
+            { cacheDirectoryPath: this.jobWrapper.getCacheDirectory(), memcachedServer }
+        );
+        this.jobWrapper.setTrRoutingBatchStartResult(startResults);
+
         const candidatesCount = this.getSize();
         const validCandidates = this.getCandidates().filter((candidate) => candidate.getScenario() !== undefined);
         if (validCandidates.length < this.jobWrapper.parameters.algorithmConfiguration.config.populationSizeMin) {
@@ -130,7 +140,7 @@ abstract class Generation {
         await promiseQueue.onIdle();
         console.log('done with promises');
         this.sortCandidates();
-
+        await realBatchManager.stopBatch();
         console.timeEnd(` generation ${this.generationNumber}: simulated candidates`);
 
         this.logger.doLog(this);

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper.ts
@@ -23,6 +23,9 @@ import { LineServices } from '../../evolutionaryAlgorithm/internalTypes';
 import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import { MemcachedInstance } from 'chaire-lib-backend/lib/utils/processManagers/MemcachedProcessManager';
 
+import { TrRoutingBatchManager, TrRoutingBatchStartResult } from '../../transitRouting/TrRoutingBatchManager';
+import { FakeTrRoutingBatchManager } from '../../transitRouting/FakeTrRoutingBatchManager';
+
 // Type to extract parameters from a job data type
 type ExtractParameters<TJobType extends JobDataType> = TJobType extends { data: { parameters: infer P } } ? P : never;
 
@@ -46,6 +49,7 @@ export class TransitNetworkDesignJobWrapper<
     private _lineServices: LineServices | undefined = undefined;
     private _collectionManager: CollectionManager | undefined = undefined;
     protected memcachedInstance: MemcachedInstance | undefined | null = undefined;
+    private _trRoutingBatchStartResult: TrRoutingBatchStartResult | undefined = undefined;
 
     constructor(
         private wrappedJob: ExecutableJob<TJobType>,
@@ -129,6 +133,21 @@ export class TransitNetworkDesignJobWrapper<
         return this.memcachedInstance;
     };
 
+    setTrRoutingBatchStartResult(startResult: TrRoutingBatchStartResult) {
+        this._trRoutingBatchStartResult = startResult;
+    }
+
+    getFakeTrRoutingBatchManager(progressEmitter: EventEmitter): TrRoutingBatchManager {
+        if (this._trRoutingBatchStartResult) {
+            return new FakeTrRoutingBatchManager(
+                progressEmitter,
+                this._trRoutingBatchStartResult.threadCount,
+                this._trRoutingBatchStartResult.port
+            );
+        } else {
+            throw new Error('Fake trRoutingBatchManager not set yet');
+        }
+    }
     loadServerData = async (socket: EventEmitter): Promise<void> => {
         const collectionManager = new CollectionManager(undefined);
         const lines = new LineCollection([], {});

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
@@ -299,11 +299,18 @@ export default class OdTripSimulation implements SimulationMethod {
             // I would normally do routingJob.run() here, but it was not implemented like that :P
 
             // This is copied from wrapBatchRoute in `TransitionWorkerPool.ts`
-            const batchJobExecutor = new TrRoutingBatchExecutor(routingJob, {
-                // Child job needs its own progress emitter to avoid conflicts with the parent's
-                progressEmitter: new EventEmitter(),
-                isCancelled: this.jobWrapper.privexecutorOptions.isCancelled
-            });
+
+            // Child job needs its own progress emitter to avoid conflicts with the parent's
+            const childProgressEmitter = new EventEmitter();
+
+            const batchJobExecutor = new TrRoutingBatchExecutor(
+                routingJob,
+                {
+                    progressEmitter: childProgressEmitter,
+                    isCancelled: this.jobWrapper.privexecutorOptions.isCancelled
+                },
+                this.jobWrapper.getFakeTrRoutingBatchManager(childProgressEmitter)
+            );
             const execResults = await batchJobExecutor.run();
             if (execResults.completed === true) {
                 const facPerField = this.options.demandAttributes.fileAndMapping.fieldMappings.expansionFactor;

--- a/packages/transition-backend/src/services/transitRouting/FakeTrRoutingBatchManager.ts
+++ b/packages/transition-backend/src/services/transitRouting/FakeTrRoutingBatchManager.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+
+import { TrRoutingBatchJobParameters } from './TrRoutingBatchJobParameters';
+
+import { TrRoutingBatchManager, TrRoutingBatchStartResult } from './TrRoutingBatchManager';
+
+/**
+ * Fake the lifecycle of the TrRoutingBatchManager
+ * Aim to just pass information from an actual run of TrRoutingBatchManager
+ * and do nothing.
+ * Mainly used to have a global TrRouting shared between TrRoutingBatch jobs
+ */
+export class FakeTrRoutingBatchManager extends TrRoutingBatchManager {
+    /**
+     * Create a new TrRoutingBatchManager.
+     *
+     * @param progressEmitter - EventEmitter for progress reporting
+     */
+    constructor(
+        progressEmitter: EventEmitter,
+        private threadCount,
+        private port
+    ) {
+        super(progressEmitter);
+        // Nothing else to do
+    }
+
+    /**
+     * Return the stored threadCount and port
+     */
+    async startBatch(workloadSize: number, options?: TrRoutingBatchJobParameters): Promise<TrRoutingBatchStartResult> {
+        return {
+            threadCount: this.threadCount,
+            port: this.port
+        };
+    }
+
+    /**
+     * Do nothing, since we did not start anything
+     */
+    async stopBatch(): Promise<void> {}
+}

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -92,9 +92,14 @@ export class TrRoutingBatchExecutor {
         private options: {
             progressEmitter: EventEmitter;
             isCancelled: () => boolean;
-        }
+        },
+        batchManager?: TrRoutingBatchManager
     ) {
-        this.batchManager = new TrRoutingBatchManager(options.progressEmitter);
+        if (batchManager) {
+            this.batchManager = batchManager;
+        } else {
+            this.batchManager = new TrRoutingBatchManager(options.progressEmitter);
+        }
     }
 
     run = async (): Promise<TransitBatchCalculationResult> => {


### PR DESCRIPTION
In some benchmarks, it took 30 seconds to start TrRouting and 45s to run the calculation When running 20 candidates for a generation, that's 10 minutes lost. Since we use the same capnp file for the whole generation, we can share the same trRouting. Each candidate points to a different scenario.

We use TrRoutingBatchManager to start trRouting in the Generation. We create a FakeTrRoutingBatchManager class to pass to the TrRoutingBatchExecutor, which will contains the number of threads and port information to be used as if each run would have started their own TrRouting.