### PR TITLE
Quick fix batch result db insert

### DIFF
--- a/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
+++ b/packages/transition-backend/src/services/executableJob/JobCheckpointTracker.ts
@@ -18,7 +18,7 @@ import { EventEmitter } from 'events';
 export class CheckpointTracker {
     private indexes: number[] = [];
     private lastCheckpointIdx: number;
-
+    private doEmitPromises: Promise<void>[] = [];
     /**
      * Constructor
      * @param chunkSize Number of steps in a chunk.
@@ -92,14 +92,15 @@ export class CheckpointTracker {
             console.log('Emitting checkpoint at index ', checkpoint);
             this.progressEmitter.emit('checkpoint', checkpoint);
         };
-        doEmit().catch((err) => console.error(`CheckpointTracker: error before checkpoint ${checkpoint}:`, err));
+        this.doEmitPromises.push(doEmit().catch((err) => console.error(`CheckpointTracker: error before checkpoint ${checkpoint}:`, err)));
     }
 
     /**
      * Call when all steps have been completed. If the last chunk is not full,
      * it will emit a 'checkpoint' event with the last index handled.
      */
-    completed = (): void => {
+    completed = async ():  Promise<void> => {
+        await Promise.all(this.doEmitPromises);
         const lastChunkIndex = this.lastCheckpointIdx + 1;
         const lastChunkSize = this.indexes[lastChunkIndex];
         if (lastChunkSize !== undefined && lastChunkSize > 0) {

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -207,7 +207,7 @@ export class TrRoutingBatchExecutor {
                 await resultsDbQueries.createMany(remaining);
             }
             console.log('Batch odTrip routing completed for job %d', this.job.id);
-            checkpointTracker.completed();
+            await checkpointTracker.completed();
 
             this.options.progressEmitter.emit('progress', { name: 'BatchRouting', progress: 1.0 });
 
@@ -330,6 +330,13 @@ export class TrRoutingBatchExecutor {
                 tripIndex: odTripIndex,
                 data: routingResult
             });
+            // Immediately flush if we get above 100
+            if (this.resultBuffer.length > 100) {
+                const toFlush = this.resultBuffer.splice(0);
+                if (toFlush.length > 0) {
+                    await resultsDbQueries.createMany(toFlush);
+                }
+            }
             options.logAfter(odTripIndex);
 
             return routingResult;

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -406,10 +406,14 @@ describe('Batch route from checkpoint', () => {
         expect(checkpointListenerMock).toHaveBeenCalledWith(750);
         expect(checkpointListenerMock).toHaveBeenCalledWith(756);
 
-        expect(mockResultCreateMany).toHaveBeenCalledTimes(4); // Once per checkpoint
+        expect(mockResultCreateMany).toHaveBeenCalledTimes(10); // Once per checkpoint and every 100 entries
         expect(mockResultCreateMany).toHaveBeenNthCalledWith(1, expect.arrayContaining([
             expect.objectContaining({ tripIndex: 0 }),
-            expect.objectContaining({ tripIndex: 249 })
+            expect.objectContaining({ tripIndex: 99 })
+        ]));
+        expect(mockResultCreateMany).toHaveBeenNthCalledWith(2, expect.arrayContaining([
+            expect.objectContaining({ tripIndex: 101 }),
+            expect.objectContaining({ tripIndex: 199 })
         ]));
     });
 


### PR DESCRIPTION
Two fixes:
* Flush queue at every 100 insert. (To make sure we don't insert too big of a chunk in the DB
* Save all the doEmit promise and await them in the completed() call.