### PR TITLE
Augment size of batch db write in TrRoutingBatch

### DIFF
--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -335,8 +335,8 @@ export class TrRoutingBatchExecutor {
                 tripIndex: odTripIndex,
                 data: routingResult
             });
-            // Immediately flush if we get above 100
-            if (this.resultBuffer.length > 100) {
+            // Immediately flush if we get above 200
+            if (this.resultBuffer.length > 200) {
                 const toFlush = this.resultBuffer.splice(0);
                 if (toFlush.length > 0) {
                     await resultsDbQueries.createMany(toFlush);

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrRoutingBatch.test.ts
@@ -406,14 +406,14 @@ describe('Batch route from checkpoint', () => {
         expect(checkpointListenerMock).toHaveBeenCalledWith(750);
         expect(checkpointListenerMock).toHaveBeenCalledWith(756);
 
-        expect(mockResultCreateMany).toHaveBeenCalledTimes(10); // Once per checkpoint and every 100 entries
+        expect(mockResultCreateMany).toHaveBeenCalledTimes(7); // Once per checkpoint and every 200 entries
         expect(mockResultCreateMany).toHaveBeenNthCalledWith(1, expect.arrayContaining([
             expect.objectContaining({ tripIndex: 0 }),
-            expect.objectContaining({ tripIndex: 99 })
+            expect.objectContaining({ tripIndex: 199 })
         ]));
         expect(mockResultCreateMany).toHaveBeenNthCalledWith(2, expect.arrayContaining([
-            expect.objectContaining({ tripIndex: 101 }),
-            expect.objectContaining({ tripIndex: 199 })
+            expect.objectContaining({ tripIndex: 201 }),
+            expect.objectContaining({ tripIndex: 250 })
         ]));
     });
 


### PR DESCRIPTION
We had a flush of the db write queue every 100 entries, but that was killing the performance quite a bit. Setting it to every 200 brings back the expected performance.