### PR TITLE
Fix nested horizontal scroll in schedule period form

### DIFF
--- a/packages/chaire-lib-frontend/src/components/input/InputSelect.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/InputSelect.tsx
@@ -24,6 +24,7 @@ export type InputSelectProps = {
     localePrefix?: string;
     t?: (string) => string;
     disabled?: boolean;
+    style?: React.CSSProperties;
 };
 
 type defaultInputType = {
@@ -44,7 +45,8 @@ const InputSelect: React.FunctionComponent<InputSelectProps> = ({
     choices = [],
     localePrefix = 'main',
     t = (_str) => '',
-    disabled = false
+    disabled = false,
+    style
 }: InputSelectProps) => {
     const actualValue = value === undefined ? defaultValue : value;
     const defaultAttributes: defaultInputType = {
@@ -94,7 +96,8 @@ const InputSelect: React.FunctionComponent<InputSelectProps> = ({
             style={{
                 overflow: 'hidden',
                 whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis'
+                textOverflow: 'ellipsis',
+                ...style
             }}
         >
             {!noBlank && <option key={'_blank'} value=""></option>}

--- a/packages/transition-frontend/src/components/forms/schedules/TransitSchedulePeriod.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitSchedulePeriod.tsx
@@ -78,11 +78,19 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
 
     const actualOutboundPathId = schedulePeriod.outbound_path_id;
     const outboundPathId =
-        actualOutboundPathId || (outboundPathsChoices.length === 1 ? outboundPathsChoices[0].value : '');
+        actualOutboundPathId !== undefined
+            ? actualOutboundPathId
+            : outboundPathsChoices.length === 1
+                ? outboundPathsChoices[0].value
+                : '';
 
     const actualInboundPathId = schedulePeriod.inbound_path_id;
     const inboundPathId =
-        actualInboundPathId || (inboundPathsChoices.length === 1 ? inboundPathsChoices[0].value : undefined);
+        actualInboundPathId !== undefined
+            ? actualInboundPathId
+            : inboundPathsChoices.length === 1
+                ? inboundPathsChoices[0].value
+                : undefined;
 
     const outboundTripsCells: React.ReactNode[] = [];
     const inboundTripsCells: React.ReactNode[] = [];
@@ -167,12 +175,15 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
 
     return (
         <div
-            className="tr__form-section _flex-container-row"
+            className="tr__form-section"
             key={periodShortname}
             style={{
+                display: 'flex',
+                flexDirection: 'row',
+                flexShrink: 0,
                 borderRight: '1px solid rgba(255,255,255,0.2)',
                 alignItems: 'flex-start',
-                minWidth: '20rem'
+                width: 'fit-content'
             }}
         >
             <h4 className="_aside-heading-container" style={{ minHeight: '30rem' }}>
@@ -183,7 +194,7 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
                     <span className="_strong">{periodEndAtTimeStr}</span> <span>• {periodName}</span>
                 </span>
             </h4>
-            <div className="tr__form-section">
+            <div className="tr__form-section" style={{ maxWidth: '300px' }}>
                 <div className="tr__form-section">
                     <div className="apptr__form-input-container">
                         <label>{t('transit:transitSchedule:OutboundPath')}</label>
@@ -193,6 +204,7 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
                             choices={outboundPathsChoices}
                             disabled={isFrozen}
                             t={t}
+                            style={{ width: '100%' }}
                             onValueChange={(e) =>
                                 onValueChange(`periods[${periodIndex}].outbound_path_id`, {
                                     value: e.target.value
@@ -240,6 +252,7 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
                             choices={inboundPathsChoices}
                             disabled={isFrozen}
                             t={t}
+                            style={{ width: '100%' }}
                             onValueChange={(e) =>
                                 onValueChange(`periods[${periodIndex}].inbound_path_id`, {
                                     value: e.target.value
@@ -338,12 +351,13 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
                 <div className="tr__form-section">
                     {isFrozen !== true && (
                         <div className="tr__form-buttons-container _left">
-                            {isReadyForScheduleGeneration(
-                                calculationMode,
-                                inboundIntervalSeconds,
-                                outboundIntervalSeconds,
-                                numberOfUnits
-                            ) && (
+                            {!_isBlank(outboundPathId) &&
+                                isReadyForScheduleGeneration(
+                                    calculationMode,
+                                    inboundIntervalSeconds,
+                                    outboundIntervalSeconds,
+                                    numberOfUnits
+                                ) && (
                                 <Button
                                     color="blue"
                                     icon={faSyncAlt}


### PR DESCRIPTION
- Remove nested horizontal scroll by dropping _flex-container-row class from the period (kept on the parent list only), using inline flex styles instead.
- Constrain period width with maxWidth on the form section and selects so long path names no longer stretch each column.
- Allow clearing outbound/inbound path when only one choice is available (distinguish 'never set' vs 'user cleared').
- Hide the Generate button when no outbound path is selected, since the backend rejects schedule generation without one.
- Add optional style prop to InputSelect for per-usage width constraints.

We can see a preview here the main goal is to remove a scroll in a scroll horizontally and make generate trip without an outbound selection unavailable since it is not allowed: 
<img width="946" height="640" alt="Screenshot 2026-04-04 at 12 43 41 PM" src="https://github.com/user-attachments/assets/f1d2e474-beb0-439c-b208-342f0fd7df0a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented schedule-generation button from appearing when outbound path is blank, avoiding invalid submissions.

* **Improvements**
  * Select inputs now accept custom inline styling for greater layout flexibility.
  * Schedule period form layout refined with explicit flex row sizing, fit-content width and tighter inner width constraints for improved alignment and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->