### PR TITLE
scenarios: allow to select multiple scenarios and delete them

### DIFF
--- a/locales/en/notifications.json
+++ b/locales/en/notifications.json
@@ -200,6 +200,7 @@
   "DeletingLines": "Deleting lines",
   "DeletingAgencies": "Deleting agencies",
   "DeletingScenarios": "Deleting scenarios",
+  "DeletingSelectedScenarios": "Deleting selected scenarios",
   "DeletingServices": "Deleting services",
   "DeletingUnusedServices": "Deleting unused services",
   "DeletingSelectedServices": "Deleting selected services",

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -110,7 +110,10 @@
         "New": "New scenario",
         "Edit": "Scenario",
         "Delete": "Delete scenario",
+        "DeleteSelected": "Delete selected scenarios",
         "ConfirmDelete": "Do you confirm deletion of this scenario?",
+        "ConfirmDeleteSelected": "Do you confirm deletion of {{count}} selected scenarios? This operation cannot be undone.",
+        "ConfirmDeleteSelected_one": "Do you confirm deletion of the selected scenario? This operation cannot be undone.",
         "DuplicateScenario": "Duplicate scenario",
         "ImportFromJson": "Import scenarios (JSON)",
         "errors": {
@@ -145,6 +148,7 @@
         "ConfirmDeleteWithSchedule": "Do you confirm deletion of this service? Schedules associated with this service will also be deleted. This operation cannot be undone.",
         "ConfirmDeleteUnused": "Do you confirm deletion of all unused services? The unused services are those with no schedules associated with it.",
         "ConfirmDeleteSelected": "Do you confirm deletion of {{count}} selected services? Schedules associated with these services will also be deleted. This operation cannot be undone.",
+        "ConfirmDeleteSelected_one": "Do you confirm deletion of the selected service? Schedules associated with this service will also be deleted. This operation cannot be undone.",
         "ImportFromJson": "Import services (JSON)",
         "DuplicateService": "Duplicate service",
         "oneLine": "Line (1)",

--- a/locales/fr/notifications.json
+++ b/locales/fr/notifications.json
@@ -200,6 +200,7 @@
   "DeletingLines": "Suppression des lignes",
   "DeletingAgencies": "Suppression des agences",
   "DeletingScenarios": "Suppression des scénarios",
+  "DeletingSelectedScenarios": "Suppression des scénarios sélectionnés",
   "DeletingServices": "Suppression des services",
   "DeletingUnusedServices": "Suppression des services inutilisés",
   "DeletingSelectedServices": "Suppression des services sélectionnés",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -110,7 +110,10 @@
         "Color": "Couleur",
         "Edit": "Scénario",
         "Delete": "Supprimer le scénario",
+        "DeleteSelected": "Supprimer les scénarios sélectionnés",
         "ConfirmDelete": "Confirmez-vous que vous désirez bien supprimer ce scénario?",
+        "ConfirmDeleteSelected": "Confirmez-vous que vous désirez bien supprimer les {{count}} scénarios sélectionnés? Cette opération est irréversible.",
+        "ConfirmDeleteSelected_one": "Confirmez-vous que vous désirez bien supprimer le scénario sélectionné? Cette opération est irréversible.",
         "DuplicateScenario": "Dupliquer le scénario",
         "ImportFromJson": "Importer des scénarios (JSON)",
         "errors": {
@@ -145,6 +148,7 @@
         "ConfirmDeleteWithSchedule": "Confirmez-vous que vous désirez bien supprimer ce service? Les horaires associés à ce service seront aussi supprimés. Cette opération est irréversible.",
         "ConfirmDeleteUnused": "Confirmez-vous que vous désirez bien supprimer les services inutilisés? Ce sont les services auxquels aucun horaire n'est présentement associé.",
         "ConfirmDeleteSelected": "Confirmez-vous que vous désirez bien supprimer les {{count}} services sélectionnés? Les horaires associés à ces services seront aussi supprimés. Cette opération est irréversible.",
+        "ConfirmDeleteSelected_one": "Confirmez-vous que vous désirez bien supprimer le service sélectionné? Les horaires associés à ce service seront aussi supprimés. Cette opération est irréversible.",
         "ImportFromJson": "Importer des services (JSON)",
         "DuplicateService": "Dupliquer le service",
         "oneLine": "Ligne (1)",

--- a/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
@@ -25,13 +25,34 @@ const mockScheduleDataHandler: TransitObjectDataHandler = {
         }
     }),
 };
+const mockDataHandlerWithAllFunctions: TransitObjectDataHandler = {
+    lowerCaseName: 'object',
+    className: 'Object',
+    classNamePlural: 'Objects',
+    create: jest.fn().mockResolvedValue({}),
+    read: jest.fn().mockResolvedValue({}),
+    update: jest.fn().mockResolvedValue({}),
+    delete: jest.fn().mockResolvedValue({}),
+    deleteMultiple: jest.fn().mockResolvedValue({}),
+    geojsonCollection: jest.fn().mockResolvedValue({}),
+    collection: jest.fn().mockResolvedValue({}),
+    saveCache: jest.fn().mockResolvedValue({}),
+    deleteCache: jest.fn().mockResolvedValue({}),
+    deleteMultipleCache: jest.fn().mockResolvedValue({}),
+    loadCache: jest.fn().mockResolvedValue({}),
+    saveCollectionCache: jest.fn().mockResolvedValue({}),
+    loadCollectionCache: jest.fn().mockResolvedValue({})
+};
+
 jest.mock('../../services/transitObjects/TransitObjectsDataHandler', () => ({
     __esModule: true,
     default: {
-        schedules: mockScheduleDataHandler
+        schedules: mockScheduleDataHandler,
+        objects: mockDataHandlerWithAllFunctions
     },
     createDataHandlers: jest.fn(() => ({
-        schedules: mockScheduleDataHandler
+        schedules: mockScheduleDataHandler,
+        objects: mockDataHandlerWithAllFunctions
     })),
     TransitObjectDataHandler: jest.fn()
 }));
@@ -60,6 +81,39 @@ transitObjectRoutes(socketStub);
 
 beforeEach(() => {
     jest.clearAllMocks();
+});
+
+describe('Object socket routes', () => {
+    // FIXME Add tests for create, read, update, delete, geojsonCollection,
+    // collection, saveCache, deleteCache, deleteMultipleCache, loadCache,
+    // saveCollectionCache, loadCollectionCache routes
+
+    describe('deleteMultiple route', () => {
+        test('deleteMultiple when the route exists', (done) => {
+            // Create ids to delete and set the mock to return those ids as deleted
+            const objectIdsToDelete = [uuidV4(), uuidV4()];
+            (mockDataHandlerWithAllFunctions.deleteMultiple as jest.MockedFunction<Exclude<typeof mockDataHandlerWithAllFunctions.deleteMultiple, undefined>>).mockResolvedValueOnce(Status.createOk({ deletedIds: objectIdsToDelete }));
+            socketStub.emit('transitObjects.deleteMultiple', objectIdsToDelete, (status: Status.Status<{ deletedIds: string[] }>) => {
+                expect(Status.isStatusOk(status)).toEqual(true);
+                expect(Status.unwrap(status)).toEqual({ deletedIds: objectIdsToDelete});
+                expect(mockDataHandlerWithAllFunctions.deleteMultiple).toHaveBeenLastCalledWith(socketStub, objectIdsToDelete);
+                done();
+            });
+        });
+
+        test('deleteMultiple route is not registered for schedules', () => {
+            const eventName = 'transitSchedules.deleteMultiple';
+
+            // Route is not registered
+            expect(socketStub.listenerCount(eventName)).toBe(0);
+
+            // Optional stronger check: emit returns false when no listeners exist
+            const callback = jest.fn();
+            const emitted = socketStub.emit(eventName, ['id-1'], callback);
+            expect(emitted).toBe(false);
+            expect(callback).not.toHaveBeenCalled();
+        });
+    });
 });
 
 describe('Service duplication route', () => {

--- a/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
+++ b/packages/transition-backend/src/api/transitObjects.socketRoutes.ts
@@ -46,6 +46,14 @@ function setupObjectSocketRoutes(socket: EventEmitter) {
             }
         );
 
+        // Delete multiple objects from database
+        if (dataHandler.deleteMultiple) {
+            socket.on(`transit${dataHandler.classNamePlural}.deleteMultiple`, async (ids: string[], callback) => {
+                const response = await dataHandler.deleteMultiple!(socket, ids);
+                callback(response);
+            });
+        }
+
         // Get the geojson collection from DB if there is a geojson collection function
         if (dataHandler.geojsonCollection) {
             socket.on(

--- a/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
+++ b/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
@@ -45,6 +45,8 @@ export interface TransitObjectDataHandler {
     read: (id: string, customCachePath: string | undefined) => Promise<Record<string, any>>;
     update: (socket: EventEmitter, id: string, attributes: GenericAttributes) => Promise<Record<string, any>>;
     delete: (socket: EventEmitter, id: string, customCachePath: string | undefined) => Promise<Record<string, any>>;
+    // Optional function to delete multiple objects. Only objects supporting it will have this function
+    deleteMultiple?: (socket: EventEmitter, ids: string[]) => Promise<Status.Status<{ deletedIds: string[] }>>;
     geojsonCollection?: (
         params?
     ) => Promise<
@@ -106,7 +108,8 @@ const transitClassesConfig = {
         dbQueries: scenariosDbQueries,
         cacheQueries: scenariosCacheQueries,
         collection: new ScenarioCollection([], {}),
-        saveCollectionToCacheFct: dbToCacheQueries.loadAndSaveScenariosToCache
+        saveCollectionToCacheFct: dbToCacheQueries.loadAndSaveScenariosToCache,
+        deleteMultiple: scenariosDbQueries.deleteMultiple
     },
     services: {
         lowerCaseName: 'service',
@@ -263,6 +266,55 @@ function createDataHandlers(): Record<string, TransitObjectDataHandler> {
                 }
             }
         };
+
+        // Delete multiple objects from database. Delete multiple needs to be
+        // explicitly added, even if a `deleteMultiple` query exists in the DB
+        // as we don't necessarily want to expose them all by default.
+        if (transitClassConfig.deleteMultiple) {
+            // FIXME Support deleting object cache if it is implemented.
+            // Currently not implemented, because not all requested objects to
+            // delete may have been deleted, we need to know exactly which ones
+            // were really deleted to delete the corresponding cache files. This
+            // should affect the lines only (no delete multiple for nodes), so
+            // when we implement the multiple delete for lines, it will need to
+            // be implemented
+            if (transitClassConfig.cacheQueries.deleteObjectCache) {
+                console.warn(
+                    'Transit object class ' +
+                        transitClassConfig.className +
+                        ' has deleteMultiple DB query but also have a deleteObjectCache cache query. Deleting such objects is not yet supported, as it will keep the cache with orphan files.'
+                );
+            }
+            dataHandler.deleteMultiple = async (socket: EventEmitter, ids: string[]) => {
+                try {
+                    // FIXME remove this if when this is supported. We still
+                    // want to add the handler and throw here as the previous
+                    // console.warn would be displayed on the server console
+                    // upon connection (and who reads that). Throwing will cause
+                    // the error to also be displayed in the UI when people try
+                    // to test the functionality and may be noticed more.
+                    if (transitClassConfig.cacheQueries.deleteObjectCache) {
+                        throw new TrError(
+                            'Deleting multiple objects with individual cache files is not yet supported',
+                            'SKTTRDM0001',
+                            'DeleteMultipleWithObjectCacheNotSupported'
+                        );
+                    }
+                    const deletedIds = await transitClassConfig.deleteMultiple(ids);
+                    if (deletedIds.length > 0 && isSocketIo(socket)) {
+                        // Objects were deleted, notify clients
+                        socket.broadcast.emit('data.updated');
+                        socket.emit('cache.dirty');
+                    }
+                    return Status.createOk({ deletedIds });
+                } catch (error) {
+                    console.error('Error deleting multiple objects: ', error);
+                    return Status.createError(
+                        TrError.isTrError(error) ? error.message : 'Error deleting multiple objects'
+                    );
+                }
+            };
+        }
 
         // Get the geojson collection from DB if there is a geojson collection function
         if (transitClassConfig.dbQueries.geojsonCollection) {

--- a/packages/transition-backend/src/services/transitObjects/__tests__/TransitObjectDataHandler.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/__tests__/TransitObjectDataHandler.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { EventEmitter } from 'events';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
+import transitObjectDataHandlers from '../TransitObjectsDataHandler';
+import scenariosDbQueries from '../../../models/db/transitScenarios.db.queries';
+import { isSocketIo } from '../../../api/socketUtils';
+
+jest.mock('../../../models/db/transitAgencies.db.queries', () => ({}));
+jest.mock('../../../models/db/transitLines.db.queries', () => ({}));
+jest.mock('../../../models/db/transitNodes.db.queries', () => ({}));
+jest.mock('../../../models/db/transitPaths.db.queries', () => ({}));
+jest.mock('../../../models/db/transitServices.db.queries', () => ({}));
+jest.mock('../../../models/db/transitSchedules.db.queries', () => ({}));
+jest.mock('../../../models/db/transitScenarios.db.queries', () => ({
+    deleteMultiple: jest.fn()
+}));
+
+jest.mock('../../../models/capnpCache/transitAgencies.cache.queries', () => ({}));
+jest.mock('../../../models/capnpCache/transitLines.cache.queries', () => ({}));
+jest.mock('../../../models/capnpCache/transitNodes.cache.queries', () => ({}));
+jest.mock('../../../models/capnpCache/transitPaths.cache.queries', () => ({}));
+jest.mock('../../../models/capnpCache/transitScenarios.cache.queries', () => ({}));
+jest.mock('../../../models/capnpCache/transitServices.cache.queries', () => ({}));
+jest.mock('../../capnpCache/dbToCache', () => ({}));
+
+jest.mock('../../../api/socketUtils', () => ({
+    isSocketIo: jest.fn()
+}));
+
+const mockedScenariosDeleteMultiple =
+    scenariosDbQueries.deleteMultiple as jest.MockedFunction<Exclude<typeof scenariosDbQueries.deleteMultiple, undefined>>;
+const mockedIsSocketIo = isSocketIo as jest.MockedFunction<typeof isSocketIo>;
+
+// Mock the socket with an EventEmitter mock that has an emit function we can spy on
+const socketStub = {
+    emit: jest.fn(),
+    broadcast: {
+        emit: jest.fn()
+    }
+} as unknown as EventEmitter;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedIsSocketIo.mockReturnValue(false);
+});
+
+describe('TransitObjectDataHandler scenarios', () => {
+    test('check exposed scenarios handler', () => {
+        expect(transitObjectDataHandlers.scenarios).toEqual({
+            lowerCaseName: 'scenario',
+            className: 'Scenario',
+            classNamePlural: 'Scenarios',
+            create: expect.any(Function),
+            read: expect.any(Function),
+            update: expect.any(Function),
+            delete: expect.any(Function),
+            deleteMultiple: expect.any(Function)
+        });
+    });
+
+    describe('deleteMultiple', () => {
+
+        test('returns ok and emits socket notifications when some objects were deleted', async () => {
+            const idsToDelete = ['scenario-1', 'scenario-2'];
+            mockedScenariosDeleteMultiple.mockResolvedValueOnce(idsToDelete);
+            mockedIsSocketIo.mockReturnValue(true);
+
+            const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, idsToDelete);
+
+            expect(mockedScenariosDeleteMultiple).toHaveBeenCalledWith(idsToDelete);
+            expect(Status.isStatusOk(status)).toEqual(true);
+            expect(Status.unwrap(status)).toEqual({ deletedIds: idsToDelete });
+            expect((socketStub as any).broadcast.emit).toHaveBeenCalledWith('data.updated');
+            expect((socketStub as any).emit).toHaveBeenCalledWith('cache.dirty');
+        });
+
+        test('returns ok and does not emit when socket is not Socket.IO', async () => {
+            const idsToDelete = ['scenario-1', 'scenario-2'];
+            mockedScenariosDeleteMultiple.mockResolvedValueOnce(idsToDelete);
+            mockedIsSocketIo.mockReturnValue(false);
+
+            const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, idsToDelete);
+
+            expect(mockedScenariosDeleteMultiple).toHaveBeenCalledWith(idsToDelete);
+            expect(Status.isStatusOk(status)).toEqual(true);
+            expect(Status.unwrap(status)).toEqual({ deletedIds: idsToDelete });
+            expect((socketStub as any).broadcast.emit).not.toHaveBeenCalled();
+            expect((socketStub as any).emit).not.toHaveBeenCalled();
+        });
+
+        test('does not emit notifications when no object was deleted', async () => {
+            mockedScenariosDeleteMultiple.mockResolvedValueOnce([]);
+            mockedIsSocketIo.mockReturnValue(true);
+
+            const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, ['scenario-1']);
+
+            expect(Status.isStatusOk(status)).toEqual(true);
+            expect(Status.unwrap(status)).toEqual({ deletedIds: [] });
+            expect((socketStub as any).broadcast.emit).not.toHaveBeenCalled();
+            expect((socketStub as any).emit).not.toHaveBeenCalled();
+        });
+
+        test('returns an error status when database deletion throws', async () => {
+            mockedScenariosDeleteMultiple.mockRejectedValueOnce(new Error('db error'));
+
+            const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, ['scenario-1']);
+
+            expect(Status.isStatusError(status)).toEqual(true);
+            expect((status as any).error).toEqual('Error deleting multiple objects');
+            expect((socketStub as any).broadcast.emit).not.toHaveBeenCalled();
+            expect((socketStub as any).emit).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/transition-common/src/services/scenario/ScenarioCollection.ts
+++ b/packages/transition-common/src/services/scenario/ScenarioCollection.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import Scenario from './Scenario';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
 import CollectionCacheable from 'chaire-lib-common/lib/services/objects/CollectionCacheable';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
 import CollectionLoadable from 'chaire-lib-common/lib/services/objects/CollectionLoadable';
@@ -51,6 +52,23 @@ class ScenarioCollection extends GenericObjectCollection<Scenario> implements Pr
                 only_modes: attributes.only_modes ? attributes.only_modes.join('|') : '',
                 except_modes: attributes.except_modes ? attributes.except_modes.join('|') : ''
             };
+        });
+    }
+
+    async deleteByIds(ids: string[], socket): Promise<string[]> {
+        // FIXME This should only be called by the frontend as it calls the
+        // socket route. Our collections currently all use methods that call the
+        // backend through socket routes (saves and loads), so it makes sense to
+        // keep it here for now, but eventually, they should all be moved
+        // elsewhere, in frontend.
+        return new Promise((resolve, reject) => {
+            socket.emit('transitScenarios.deleteMultiple', ids, (response: Status.Status<{ deletedIds: string[] }>) => {
+                if (Status.isStatusOk(response)) {
+                    resolve(Status.unwrap(response).deletedIds);
+                } else {
+                    reject(response.error);
+                }
+            });
         });
     }
 

--- a/packages/transition-common/src/services/scenario/__tests__/ScenarioCollection.test.ts
+++ b/packages/transition-common/src/services/scenario/__tests__/ScenarioCollection.test.ts
@@ -7,7 +7,9 @@
 
 import { v4 as uuidV4 } from 'uuid';
 import _cloneDeep from 'lodash/cloneDeep';
+import EventEmitter from 'events';
 
+import * as Status from 'chaire-lib-common/lib/utils/Status';
 import EventManagerMock from 'chaire-lib-common/lib/test/services/events/EventManagerMock';
 import Scenario from '../Scenario';
 import ScenarioCollection from '../ScenarioCollection';
@@ -18,6 +20,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 const eventManager = EventManagerMock.eventManagerMock;
 const collectionManager = new CollectionManager(eventManager);
 serviceLocator.addService('collectionManager', collectionManager);
+const socketMock = new EventEmitter();
 
 const scenarioAttributes1 = {
     id: uuidV4(),
@@ -121,6 +124,70 @@ test('should construct scenario collection with or without features', function()
         only_modes: scenarioAttributes3.only_modes.join('|'),
         except_modes: scenarioAttributes3.except_modes.join('|'),
         description: scenarioAttributes3.description
+    });
+
+});
+
+describe('deleteByIds', () => {
+    const deleteMultipleSocketMock = jest.fn().mockImplementation(async (deletedIds, callback) => callback(Status.createOk({ deletedIds })));
+
+    beforeAll(() => {
+        socketMock.on('transitScenarios.deleteMultiple', deleteMultipleSocketMock);
+    });
+
+    afterAll(() => {
+        socketMock.removeAllListeners();
+    })
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('deleteByIds should call socket route and handle success response', async () => {
+        // Just need a scenario collection, no need for scenarios to actually exist to be deleted on server
+        const collection = new ScenarioCollection([], {}, eventManager);
+        
+        const serviceIds = [uuidV4(), uuidV4(), uuidV4()];
+        const deletedIds = await collection.deleteByIds(serviceIds, socketMock);
+
+        expect(deletedIds).toEqual(serviceIds);
+        expect(deleteMultipleSocketMock).toHaveBeenCalledTimes(1);
+        expect(deleteMultipleSocketMock).toHaveBeenCalledWith(serviceIds, expect.any(Function));
+    });
+
+    test('deleteByIds should call socket route and handle partial success response', async () => {
+        // Just need a scenario collection, no need for scenarios to actually exist to be deleted on server
+        const collection = new ScenarioCollection([], {}, eventManager);
+
+        // Return a successful response with only the first service id deleted
+        deleteMultipleSocketMock.mockImplementationOnce(async (ids, callback) => callback(Status.createOk({ deletedIds: [ids[0]] })));
+        
+        const serviceIds = [uuidV4(), uuidV4(), uuidV4()];
+        const deletedIds = await collection.deleteByIds(serviceIds, socketMock);
+
+        expect(deletedIds).toEqual([serviceIds[0]]);
+        expect(deleteMultipleSocketMock).toHaveBeenCalledTimes(1);
+        expect(deleteMultipleSocketMock).toHaveBeenCalledWith(serviceIds, expect.any(Function));
+    });
+
+    test('deleteByIds should call socket route and handle error response', async () => {
+        // Just need a scenario collection, no need for scenarios to actually exist to be deleted on server
+        const collection = new ScenarioCollection([], {}, eventManager);
+
+        // Return an error response from the socket
+        deleteMultipleSocketMock.mockImplementationOnce(async (_ids, callback) => callback(Status.createError('Error deleting')));
+        
+        const serviceIds = [uuidV4(), uuidV4(), uuidV4()];
+        let thrownError: any = undefined;
+        try {
+            await collection.deleteByIds(serviceIds, socketMock);
+        } catch(error) {
+            thrownError = error;
+        }
+        expect(thrownError).toBeDefined();
+
+        expect(deleteMultipleSocketMock).toHaveBeenCalledTimes(1);
+        expect(deleteMultipleSocketMock).toHaveBeenCalledWith(serviceIds, expect.any(Function));
     });
 
 });

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioButton.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioButton.tsx
@@ -5,19 +5,20 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Scenario from 'transition-common/lib/services/scenario/Scenario';
 import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
 
-interface ScenarioButtonProps extends WithTranslation {
+interface ScenarioButtonProps {
     scenario: Scenario;
     selectedScenario?: Scenario;
 }
 
 const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (props: ScenarioButtonProps) => {
+    const { t } = useTranslation(['transit', 'main']);
     const scenarioIsSelected =
         (props.selectedScenario && props.selectedScenario.getId() === props.scenario.getId()) || false;
 
@@ -48,7 +49,7 @@ const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (pro
 
         const newAttributes = props.scenario.getClonedAttributes(true);
         const duplicateScenario = new Scenario(newAttributes, true, serviceLocator.collectionManager);
-        duplicateScenario.set('name', `${props.scenario.attributes.name} (${props.t('main:copy')})`);
+        duplicateScenario.set('name', `${props.scenario.attributes.name} (${t('main:copy')})`);
 
         await duplicateScenario.save(serviceLocator.socketEventManager);
         serviceLocator.collectionManager.refresh('scenarios');
@@ -62,13 +63,13 @@ const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (pro
             isSelected={scenarioIsSelected}
             flushActionButtons={true}
             onSelect={{ handler: onSelect }}
-            onDuplicate={{ handler: onDuplicate, altText: props.t('transit:transitScenario:DuplicateScenario') }}
+            onDuplicate={{ handler: onDuplicate, altText: t('transit:transitScenario:DuplicateScenario') }}
             onDelete={
                 !isFrozen && !scenarioIsSelected
                     ? {
                         handler: onDelete,
-                        message: props.t('transit:transitScenario:ConfirmDelete'),
-                        altText: props.t('transit:transitScenario:Delete')
+                        message: t('transit:transitScenario:ConfirmDelete'),
+                        altText: t('transit:transitScenario:Delete')
                     }
                     : undefined
             }
@@ -81,7 +82,7 @@ const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (pro
                     <img
                         className="_icon-alone"
                         src={'/dist/images/icons/interface/lock_white.svg'}
-                        alt={props.t('main:Locked')}
+                        alt={t('main:Locked')}
                     />
                 </ButtonCell>
             )}
@@ -90,4 +91,4 @@ const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (pro
     );
 };
 
-export default withTranslation(['transit', 'main'])(TransitScenarioButton);
+export default TransitScenarioButton;

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioButton.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioButton.tsx
@@ -11,10 +11,13 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import Scenario from 'transition-common/lib/services/scenario/Scenario';
 import Button from '../../parts/Button';
 import ButtonCell from '../../parts/ButtonCell';
+import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
 
 interface ScenarioButtonProps {
     scenario: Scenario;
     selectedScenario?: Scenario;
+    isChecked: boolean;
+    setChecked: (scenarioId: string, isChecked: boolean) => void;
 }
 
 const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (props: ScenarioButtonProps) => {
@@ -74,6 +77,15 @@ const TransitScenarioButton: React.FunctionComponent<ScenarioButtonProps> = (pro
                     : undefined
             }
         >
+            <ButtonCell alignment="left">
+                <InputCheckboxBoolean
+                    disabled={isFrozen}
+                    id={`transitScenarioSelect${props.scenario.getId()}`}
+                    label=" "
+                    isChecked={props.isChecked}
+                    onValueChange={(e) => props.setChecked(props.scenario.getId(), e.target.value)}
+                />
+            </ButtonCell>
             <ButtonCell alignment="left">
                 <span className="_circle-button" style={{ backgroundColor: props.scenario.attributes.color }}></span>
             </ButtonCell>

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioImportForm.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import FileImportForm from '../../parts/FileImportForm';
@@ -14,9 +14,8 @@ interface ScenarioImportFormProps {
     setImporterSelected: (importerSelected: boolean) => void;
 }
 
-const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps & WithTranslation> = (
-    props: ScenarioImportFormProps & WithTranslation
-) => {
+const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps> = (props: ScenarioImportFormProps) => {
+    const { t } = useTranslation('main');
     const closeImporter = () => props.setImporterSelected(false);
 
     const onImported = async () => {
@@ -39,10 +38,10 @@ const ScenariosImportForm: React.FunctionComponent<ScenarioImportFormProps & Wit
         <FileImportForm
             pluralizedObjectsName={'scenarios'}
             fileNameWithExtension={'scenarios.json'}
-            label={props.t('main:JsonFile')}
+            label={t('main:JsonFile')}
             closeImporter={closeImporter}
         />
     );
 };
 
-export default withTranslation(['main', 'notifications'])(ScenariosImportForm);
+export default ScenariosImportForm;

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
@@ -4,10 +4,12 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
 
+import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import TransitScenario from 'transition-common/lib/services/scenario/Scenario';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
@@ -25,6 +27,9 @@ interface ScenarioListProps {
 
 const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: ScenarioListProps) => {
     const { t } = useTranslation('transit');
+    const [checkedScenarios, setCheckedScenarios] = useState<Record<string, boolean>>({});
+    const [showDeleteSelectedModal, setShowDeleteSelectedModal] = useState(false);
+
     const newScenario = function () {
         const defaultColor = Preferences.get('transit.scenarios.defaultColor', '#0086FF');
         const newScenario = new TransitScenario({ color: defaultColor }, true, serviceLocator.collectionManager);
@@ -32,6 +37,51 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
         serviceLocator.selectedObjectsManager.setSelection('scenario', [newScenario]);
     };
 
+    const setScenarioCheckedCallback = React.useCallback(
+        (scenarioId: string, isChecked: boolean) => {
+            setCheckedScenarios((prevCheckedScenarios) => {
+                if (isChecked) {
+                    return { ...prevCheckedScenarios, [scenarioId]: true };
+                } else {
+                    const newCheckedScenarios = { ...prevCheckedScenarios };
+                    delete newCheckedScenarios[scenarioId];
+                    return newCheckedScenarios;
+                }
+            });
+        },
+        [setCheckedScenarios]
+    );
+
+    const deleteSelected = async () => {
+        if (props.scenarioCollection) {
+            try {
+                serviceLocator.eventManager.emit('progress', {
+                    name: 'DeletingSelectedScenarios',
+                    progress: 0.0
+                });
+                await props.scenarioCollection.deleteByIds(
+                    Object.keys(checkedScenarios),
+                    serviceLocator.socketEventManager
+                );
+                await props.scenarioCollection.loadFromServer(
+                    serviceLocator.socketEventManager,
+                    serviceLocator.collectionManager
+                );
+                serviceLocator.collectionManager.refresh('scenarios');
+
+                setCheckedScenarios({});
+            } finally {
+                // Make sure to set progress to 1.0 even if there is an error, otherwise the progress bar will be stuck
+                serviceLocator.eventManager.emit('progress', {
+                    name: 'DeletingSelectedScenarios',
+                    progress: 1.0
+                });
+            }
+        }
+    };
+
+    const checkScenarioIds = Object.keys(checkedScenarios);
+    const hasChecked = checkScenarioIds.length > 0;
     return (
         <div className="tr__list-transit-scenarios-container">
             <div className="tr__section-header-container">
@@ -54,6 +104,8 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
                                 key={scenario.id}
                                 scenario={scenario}
                                 selectedScenario={props.selectedScenario}
+                                isChecked={checkedScenarios[scenario.id] ?? false}
+                                setChecked={setScenarioCheckedCallback}
                             />
                         ))}
             </ButtonList>
@@ -67,6 +119,27 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
                         label={t('transit:transitScenario:New')}
                         onClick={newScenario}
                     />
+                    {hasChecked && (
+                        <Button
+                            color="red"
+                            icon={faTrash}
+                            iconClass="_icon"
+                            label={t('transit:transitScenario:DeleteSelected')}
+                            onClick={() => setShowDeleteSelectedModal(true)}
+                        />
+                    )}
+                    {showDeleteSelectedModal && (
+                        <ConfirmModal
+                            isOpen={true}
+                            title={t('transit:transitScenario:ConfirmDeleteSelected', {
+                                count: checkScenarioIds.length
+                            })}
+                            confirmAction={deleteSelected}
+                            confirmButtonColor="red"
+                            confirmButtonLabel={t('main:Delete')}
+                            closeModal={() => setShowDeleteSelectedModal(false)}
+                        />
+                    )}
                 </div>
             )}
         </div>

--- a/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
+++ b/packages/transition-frontend/src/components/forms/scenario/TransitScenarioList.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 
 import TransitScenario from 'transition-common/lib/services/scenario/Scenario';
@@ -18,12 +18,13 @@ import TransitScenarioButton from './TransitScenarioButton';
 import ButtonList from '../../parts/ButtonList';
 import ToggleableHelp from 'chaire-lib-frontend/lib/components/pageParts/ToggleableHelp';
 
-interface ScenarioListProps extends WithTranslation {
+interface ScenarioListProps {
     scenarioCollection: ScenarioCollection;
     selectedScenario?: Scenario;
 }
 
 const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: ScenarioListProps) => {
+    const { t } = useTranslation('transit');
     const newScenario = function () {
         const defaultColor = Preferences.get('transit.scenarios.defaultColor', '#0086FF');
         const newScenario = new TransitScenario({ color: defaultColor }, true, serviceLocator.collectionManager);
@@ -38,9 +39,9 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
                     <img
                         src={'/dist/images/icons/transit/scenario_white.svg'}
                         className="_icon"
-                        alt={props.t('transit:transitScenario:Scenario')}
+                        alt={t('transit:transitScenario:Scenario')}
                     />{' '}
-                    {props.t('transit:transitScenario:List')}
+                    {t('transit:transitScenario:List')}
                 </h3>
                 <ToggleableHelp namespace="transit" section="transitScenario" />
             </div>
@@ -63,7 +64,7 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
                         color="blue"
                         icon={faPlus}
                         iconClass="_icon"
-                        label={props.t('transit:transitScenario:New')}
+                        label={t('transit:transitScenario:New')}
                         onClick={newScenario}
                     />
                 </div>
@@ -72,4 +73,4 @@ const TransitScenarioList: React.FunctionComponent<ScenarioListProps> = (props: 
     );
 };
 
-export default withTranslation('transit')(TransitScenarioList);
+export default TransitScenarioList;


### PR DESCRIPTION
part of #238

Add the `deleteByIds` function to `ScenarioCollection`, which receives
an array of ids and deletes each unfrozen scenario individually.

Add a checkbox to the `TransitScenarioButton` component, with a
callback when the selection status changes. When scenarios are selected,
a button at the bottom of the list allows to delete the selected
scenarios. A confirm modal requests confirmation to delete the scenarios
before executing the command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select scenarios with checkboxes and a bulk "Delete selected scenarios" action including confirmation and progress reporting.

* **Localization**
  * Added English and French UI strings for bulk deletion labels and confirmation prompts (with count interpolation).

* **Backend & API**
  * Added support for deleting multiple scenarios in one operation and emitting update/ cache notifications after deletions.

* **Tests**
  * Added unit tests covering bulk-delete success, partial success, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->