### PR TITLE
Improve candidates

### DIFF
--- a/packages/transition-backend/src/models/db/networkDesignResults.db.queries.ts
+++ b/packages/transition-backend/src/models/db/networkDesignResults.db.queries.ts
@@ -33,7 +33,7 @@ const create = async (candidateResult: CandidateResultForDb): Promise<void> => {
                 generation_index: candidateResult.generationIndex,
                 candidate_index: candidateResult.candidateIndex,
                 total_fitness: candidateResult.resultData.result.totalFitness,
-                data: { scenarioName: candidateResult.scenarioName }
+                data: { scenarioName: candidateResult.scenarioName, source: candidateResult.resultData.source }
             })
             .returning('id');
         const candidateResultIdValue = candidateResultId[0].id;

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
@@ -129,8 +129,14 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
     //TODO: Add functionality to the _socket argument, or remove it.
     async prepareScenario(_socket: EventEmitter): Promise<Scenario> {
         const lines = this.prepareNetwork();
-        const services = this.assignServices(lines);
-        services.push(...(this.wrappedJob.parameters.transitNetworkDesignParameters.nonSimulatedServices || []));
+        let services: string[] = [];
+        // Create a scenario with the same services as the already defined scenario
+        if (this.scenario !== undefined) {
+            services = this.scenario.attributes.services;
+        } else {
+            services = this.assignServices(lines);
+            services.push(...(this.wrappedJob.parameters.transitNetworkDesignParameters.nonSimulatedServices || []));
+        }
         const maxNumberOfVehicles = this.wrappedJob.parameters.transitNetworkDesignParameters.nbOfVehicles;
         const scenario = new Scenario(
             {

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
@@ -13,7 +13,10 @@ import Scenario from 'transition-common/lib/services/scenario/Scenario';
 import * as AlgoTypes from '../internalTypes';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { randomFromDistribution } from 'chaire-lib-common/lib/utils/RandomUtils';
-import { EvolutionaryTransitNetworkDesignJobType } from '../../networkDesign/transitNetworkDesign/evolutionary/types';
+import {
+    CandidateSource,
+    EvolutionaryTransitNetworkDesignJobType
+} from '../../networkDesign/transitNetworkDesign/evolutionary/types';
 import { TransitNetworkDesignJobWrapper } from '../../networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper';
 import { SIMULATION_METHODS_FACTORY } from '../../simulation/methods/SimulationMethod';
 import { CandidateResult, ResultSerialization } from './types';
@@ -23,14 +26,16 @@ const USED_VEHICLES_THRESHOLD = 0.75;
 
 class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
     private scenario: Scenario | undefined;
+    private source: CandidateSource | undefined;
 
     constructor(
         chromosome: AlgoTypes.CandidateChromosome,
         wrappedJob: TransitNetworkDesignJobWrapper<EvolutionaryTransitNetworkDesignJobType>,
-        scenario?: Scenario
+        data: { scenario?: Scenario; source?: CandidateSource } = {}
     ) {
         super(chromosome, wrappedJob);
-        this.scenario = scenario;
+        this.scenario = data.scenario;
+        this.source = data.source;
     }
 
     private prepareNetwork(): Line[] {
@@ -224,7 +229,8 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
             numberOfLines: 0,
             numberOfVehicles: 0,
             maxNumberOfVehicles: this.wrappedJob.parameters.transitNetworkDesignParameters.nbOfVehicles,
-            result
+            result,
+            source: this.source
         };
         let totalNumberOfVehicles = 0;
         let numberOfLines = 0;
@@ -266,6 +272,15 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
         details.numberOfVehicles = totalNumberOfVehicles;
         details.numberOfLines = numberOfLines;
         return details;
+    }
+
+    /**
+     * Get this candidate's source information, which can be used to know how it
+     * was generated (randomly, from crossover or mutation, etc.)
+     * @returns The source information of the candidate
+     */
+    getSource(): CandidateSource | undefined {
+        return this.source;
     }
 }
 

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/types.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/types.ts
@@ -5,6 +5,8 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
+import { CandidateSource } from '../../networkDesign/transitNetworkDesign/evolutionary/types';
+
 /**
  * Results for a single candidate of the evolutionary algorithm
  */
@@ -39,4 +41,5 @@ export type ResultSerialization = {
     numberOfLines: number;
     numberOfVehicles: number;
     result: CandidateResult;
+    source?: CandidateSource;
 };

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/LineAndNumberOfVehiclesGeneration.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/LineAndNumberOfVehiclesGeneration.ts
@@ -158,7 +158,12 @@ export const reproduceCandidates = (
         const linesChromosome = _cloneDeep(previousGenSorted[i].getChromosome().lines);
         linesChromosomes.push(linesChromosome);
         candidates.push(
-            new NetworkCandidate({ lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` }, jobWrapper)
+            // Pass the scenario to the elite candidates to fix the number of vehicles and service level as well
+            new NetworkCandidate(
+                { lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` },
+                jobWrapper,
+                previousGenSorted[i].getScenario()
+            )
         );
     }
 

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/LineAndNumberOfVehiclesGeneration.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/LineAndNumberOfVehiclesGeneration.ts
@@ -17,10 +17,14 @@ import Mutation from '../reproduction/Mutation';
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import { sequentialArray } from 'chaire-lib-common/lib/utils/MathUtils';
 import LineAndNumberOfVehiclesGenerationLogger from './LineAndNumberOfVehiclesGenerationLogger';
-import { EvolutionaryTransitNetworkDesignJobType } from '../../networkDesign/transitNetworkDesign/evolutionary/types';
+import {
+    CandidateSource,
+    EvolutionaryTransitNetworkDesignJobType
+} from '../../networkDesign/transitNetworkDesign/evolutionary/types';
 import { TransitNetworkDesignJobWrapper } from '../../networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper';
 import ScenarioCollection from 'transition-common/lib/services/scenario/ScenarioCollection';
 import LineAndNumberOfVehiclesNetworkCandidate from '../candidate/LineAndNumberOfVehiclesNetworkCandidate';
+import _ from 'lodash';
 
 const chromosomeExists = (chrom: boolean[], linesChromosomes: boolean[][]) =>
     linesChromosomes.findIndex((chromosome) => _isEqual(chromosome, chrom)) !== -1;
@@ -83,7 +87,11 @@ export const generateFirstCandidates = (
         );
 
         linesChromosomes.push(linesChromosome);
-        candidates.push(new NetworkCandidate({ lines: linesChromosome, name: `GEN0_C${i}` }, jobWrapper));
+        candidates.push(
+            new NetworkCandidate({ lines: linesChromosome, name: `GEN0_C${i}` }, jobWrapper, {
+                source: { type: 'random' }
+            })
+        );
     }
     return candidates;
 };
@@ -159,11 +167,10 @@ export const reproduceCandidates = (
         linesChromosomes.push(linesChromosome);
         candidates.push(
             // Pass the scenario to the elite candidates to fix the number of vehicles and service level as well
-            new NetworkCandidate(
-                { lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` },
-                jobWrapper,
-                previousGenSorted[i].getScenario()
-            )
+            new NetworkCandidate({ lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` }, jobWrapper, {
+                scenario: previousGenSorted[i].getScenario(),
+                source: { type: 'elite' }
+            })
         );
     }
 
@@ -183,13 +190,16 @@ export const reproduceCandidates = (
 
         linesChromosomes.push(linesChromosome);
         candidates.push(
-            new NetworkCandidate({ lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` }, jobWrapper)
+            new NetworkCandidate({ lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` }, jobWrapper, {
+                source: { type: 'random' }
+            })
         );
     }
 
     for (let i = elitesToKeep + randomToCreate; i < jobWrapper.job.attributes.internal_data.populationSize!; i++) {
         let linesChromosome: boolean[] = [];
         let activeLineCount = 0;
+        let source: CandidateSource | undefined = undefined;
 
         do {
             const firstParentIndex = selection.selectCandidateIdx();
@@ -197,6 +207,7 @@ export const reproduceCandidates = (
             if (random.float(0.0, 1.0) > evolutionaryAlgorithmConfig.crossoverProbability) {
                 // No crossover, take the parent as is
                 linesChromosome = _cloneDeep(firstParent.getChromosome().lines);
+                source = { type: 'selected' as const, parent: firstParent.getChromosome().name, mutated: false };
             } else {
                 const secondParentIdx = selection.selectCandidateIdx([firstParentIndex]);
                 const secondParent = previousGenSorted[secondParentIdx];
@@ -207,16 +218,28 @@ export const reproduceCandidates = (
                     linesToKeepSize
                 );
                 linesChromosome = crossover.getChildChromosomes();
+                source = {
+                    type: 'crossover' as const,
+                    parents: [firstParent.getChromosome().name, secondParent.getChromosome().name],
+                    mutated: false
+                };
             }
 
-            linesChromosome = lineMutation.getMutatedChromosome(linesChromosome);
+            const mutatedChromosome = lineMutation.getMutatedChromosome(linesChromosome);
+            // Add whether the chromosome was mutated from the original one
+            if (_isEqual(mutatedChromosome, linesChromosome) === false) {
+                source.mutated = true;
+            }
+            linesChromosome = mutatedChromosome;
 
             activeLineCount = linesChromosome.filter((gene) => gene === true).length;
         } while (chromosomeExists(linesChromosome, linesChromosomes) || !linesNumInRange(activeLineCount));
 
         linesChromosomes.push(linesChromosome);
         candidates.push(
-            new NetworkCandidate({ lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` }, jobWrapper)
+            new NetworkCandidate({ lines: linesChromosome, name: `GEN${currentGeneration}_C${i}` }, jobWrapper, {
+                source
+            })
         );
     }
     if (shuffledGeneOrder !== undefined) {
@@ -236,11 +259,10 @@ export const resumeCandidatesFromChromosomes = (
 ): NetworkCandidate[] => {
     return currentGeneration.candidates.map(
         (candidateData) =>
-            new NetworkCandidate(
-                candidateData.chromosome,
-                jobWrapper,
-                scenarioCollection.getById(candidateData.scenarioId!)
-            )
+            new NetworkCandidate(candidateData.chromosome, jobWrapper, {
+                scenario: scenarioCollection.getById(candidateData.scenarioId!),
+                source: candidateData.source
+            })
     );
 };
 

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
@@ -351,7 +351,8 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
         this.job.attributes.internal_data.currentGeneration = {
             candidates: candidates.map((candidate) => ({
                 chromosome: candidate.getChromosome(),
-                scenarioId: candidate.getScenario()?.id
+                scenarioId: candidate.getScenario()?.id,
+                source: candidate.getSource()
             }))
         };
         await this.job.save(this.executorOptions.progressEmitter);
@@ -534,7 +535,8 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
             nonRoutedCount: undefined,
             usersHourlyCost: undefined,
             normalizedUserCost: undefined,
-            differentialUsersHourlyCost: undefined
+            differentialUsersHourlyCost: undefined,
+            candidateSource: undefined
         };
 
         // Register the output files and create streams
@@ -597,7 +599,8 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
                 differentialUsersHourlyCost:
                     typeof row.data?.differentialUsersHourlyCost === 'number'
                         ? row.data.differentialUsersHourlyCost
-                        : undefined
+                        : undefined,
+                candidateSource: row.candidate_data?.source ? JSON.stringify(row.candidate_data.source) : undefined
             };
             simulationsCsvStream.write(unparse([csvAttributes], { header: false }) + '\n');
         }

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/types.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/types.ts
@@ -19,6 +19,12 @@ export type EvolutionaryTransitNetworkDesignJobParameters = {
     simulationMethod: SimulationMethodConfiguration;
 };
 
+export type CandidateSource =
+    | { type: 'elite' }
+    | { type: 'random' }
+    | { type: 'crossover'; parents: [string, string]; mutated: boolean }
+    | { type: 'selected'; parent: string; mutated: boolean };
+
 export type EvolutionaryTransitNetworkDesignJobType = {
     name: 'evolutionaryTransitNetworkDesign';
     data: {
@@ -38,6 +44,7 @@ export type EvolutionaryTransitNetworkDesignJobType = {
                 chromosome: CandidateChromosome;
                 scenarioId?: string;
                 fitness?: number;
+                source?: CandidateSource;
             }[];
         };
     };


### PR DESCRIPTION
* This keeps as is the scenario services from the elite, to avoid them having very different levels of services at the next generation
* Also add a source for each candidate. The source explains where each candidate comes from: either and `elite`, `random`, `selected` from a single parent, the result of a `crossover` between multiple parents. The 2 latter can also be mutated.
* The source information is exported in the result files.