### PR TITLE
Do all capnp file write operation in parallel in RecreateCache()

### DIFF
--- a/packages/transition-backend/src/services/capnpCache/dbToCache.ts
+++ b/packages/transition-backend/src/services/capnpCache/dbToCache.ts
@@ -232,18 +232,31 @@ export const recreateCache = async (
         saveLines: true
     }
 ) => {
-    await loadAndSaveDataSourcesToCache({ cachePathDirectory: options.cachePathDirectory });
-    await loadAndSaveAgenciesToCache({ cachePathDirectory: options.cachePathDirectory });
-    await loadAndSaveServicesToCache({ cachePathDirectory: options.cachePathDirectory });
-    await loadAndSaveScenariosToCache({ cachePathDirectory: options.cachePathDirectory });
-    await loadAndSaveLinesToCache({
-        saveIndividualLines: options.saveLines,
-        cachePathDirectory: options.cachePathDirectory
-    });
-    await loadAndSaveNodesToCache({
-        refreshTransferrableNodes: options.refreshTransferrableNodes,
-        cachePathDirectory: options.cachePathDirectory
-    });
-    await loadAndSavePathsToCache({ cachePathDirectory: options.cachePathDirectory });
-    console.log('all cache save complete');
+    console.time('all cache save complete');
+    try {
+        // Write all section of the cache in parallel with Promise.all
+        // If only one of them fail, the promise.all will fail and return, while
+        // the others might complete. This should be fine, but we might have partial cache on disk
+        await Promise.all([
+            loadAndSaveDataSourcesToCache({ cachePathDirectory: options.cachePathDirectory }),
+            loadAndSaveAgenciesToCache({ cachePathDirectory: options.cachePathDirectory }),
+            loadAndSaveServicesToCache({ cachePathDirectory: options.cachePathDirectory }),
+            loadAndSaveScenariosToCache({ cachePathDirectory: options.cachePathDirectory }),
+            loadAndSaveLinesToCache({
+                saveIndividualLines: options.saveLines,
+                cachePathDirectory: options.cachePathDirectory
+            }),
+            loadAndSaveNodesToCache({
+                refreshTransferrableNodes: options.refreshTransferrableNodes,
+                cachePathDirectory: options.cachePathDirectory
+            }),
+            loadAndSavePathsToCache({ cachePathDirectory: options.cachePathDirectory })
+        ]);
+    } catch (error) {
+        // Log and rethrow error
+        console.error('Failed to recreate all cache', error);
+        throw error;
+    } finally {
+        console.timeEnd('all cache save complete');
+    }
 };


### PR DESCRIPTION
We use a Promise.all() on all the loadAndSave operation instead of awaiting each one by one.

This make the operation to go from
all cache save complete: 2:07.002 (m:ss.mmm)
to
all cache save complete: 1:19.832 (m:ss.mmm)
saving about 45 seconds in this example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache rebuild now runs multiple cache tasks in parallel, reducing total update time and improving responsiveness.
  * Added timing instrumentation to measure cache operation duration for better performance visibility.

* **Bug Fixes**
  * Improved error handling during cache reconstruction to ensure failures are logged and surfaced for reliable recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->