### PR TITLE
ci: add the "pathSegmentByPeriod" branch to docker build

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,6 +7,7 @@ on:
       - "validationTrajets"
       - "evolutionaryTransitNetworkDesign"
       - "railCurveRadius"
+      - "pathSegmentByPeriod"
   workflow_dispatch:
   schedule:
     # Do a daily rebuild at 2:00 AM UTC


### PR DESCRIPTION
This branch is a development branch with a feature to edit transit path times by period and segments in a modal window. The experimental branch is backward compatible and can be tried by users to test the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated build pipeline configuration to trigger builds for an additional branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->