### PR TITLE
Refactor generateGeographyAndSegments functions to use named params

### DIFF
--- a/packages/transition-backend/src/services/gtfsImport/PathImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/PathImporter.ts
@@ -242,14 +242,14 @@ const generatePathFromShape = (
 
     const coordinatesWithDistances = importData.shapeById[shapeGtfsId];
     // TODO Those 2 parameters were added to the call:  this.get('defaultLayoverRatioOverTotalTravelTime', null), this.get('defaultMinLayoverTimeSeconds', null));
-    const warnings = generateGeographyAndSegmentsFromGtfs(
-        newPath,
-        coordinatesWithDistances,
+    const warnings = generateGeographyAndSegmentsFromGtfs({
+        path: newPath,
+        shapeCoordinatesWithDistances: coordinatesWithDistances,
         nodeIds,
         allTripsStopTimes,
         shapeGtfsId,
-        importData.stopCoordinatesByStopId
-    );
+        stopCoordinatesByStopId: importData.stopCoordinatesByStopId
+    });
     newPath.convertAllCoordinatesToWaypoints(newPath.attributes.data.routingEngine !== 'engine'); // set all coordinates to waypoints if routingEngine is not engine
 
     return { newPath, warnings };
@@ -269,12 +269,12 @@ const generatePathWithoutShape = (
     const newPath = line.newPath({ direction, name: pathName });
 
     // TODO Those 2 parameters were added to the call: this.get('defaultLayoverRatioOverTotalTravelTime', null), this.get('defaultMinLayoverTimeSeconds', null)). See if we can/need to configure them
-    const warnings = generateGeographyAndSegmentsFromStopTimes(
-        newPath,
+    const warnings = generateGeographyAndSegmentsFromStopTimes({
+        path: newPath,
         nodeIds,
         allTripsStopTimes,
-        importData.stopCoordinatesByStopId
-    );
+        stopCoordinatesByStopId: importData.stopCoordinatesByStopId
+    });
 
     return { newPath, warnings };
 };

--- a/packages/transition-backend/src/services/gtfsImport/__tests__/PathImporter.test.ts
+++ b/packages/transition-backend/src/services/gtfsImport/__tests__/PathImporter.test.ts
@@ -32,12 +32,12 @@ const setPathGeography = (path: Path, nodeIds: string[], gtfsShapeId: string | u
     };
     path.setData('gtfs', { shape_id: gtfsShapeId });
 };
-mockedPathGenerationFromGTFS.mockImplementation((path, _coords, nodeIds, _allStopTimes, gtfsShapeId) => {
-    setPathGeography(path, nodeIds, gtfsShapeId);
+mockedPathGenerationFromGTFS.mockImplementation((params) => {
+    setPathGeography(params.path, params.nodeIds, params.shapeGtfsId);
     return [];
 });
-mockedPathGenerationFromStopTimes.mockImplementation((path, nodeIds, _allStopTimes, _stopCoords) => {
-    setPathGeography(path, nodeIds, undefined);
+mockedPathGenerationFromStopTimes.mockImplementation((params) => {
+    setPathGeography(params.path, params.nodeIds, undefined);
     return [];
 });
 
@@ -112,15 +112,15 @@ describe('One line, 2 identical simple trips', () => {
         expect(pathsDbQueries.createMultiple).toHaveBeenCalledTimes(1);
         // verify that the generator receives stop times from both trips
         expect(mockedPathGenerationFromGTFS).toHaveBeenCalledTimes(1);
-        const callArgs = mockedPathGenerationFromGTFS.mock.calls[0];
-        expect(callArgs[2]).toEqual([nodeId1, nodeId2, nodeId3, nodeId4]);
-        expect(callArgs[3]).toEqual([baseTripAndStopTimes.stopTimes, offsetStopTimesForTrip2]);
+        const callArgs = mockedPathGenerationFromGTFS.mock.calls[0][0];
+        expect(callArgs.nodeIds).toEqual([nodeId1, nodeId2, nodeId3, nodeId4]);
+        expect(callArgs.allTripsStopTimes).toEqual([baseTripAndStopTimes.stopTimes, offsetStopTimesForTrip2]);
     });
 
     test('Generate path with warnings', async () => {
         const warnings = ['warning1', 'warning2'];
-        mockedPathGenerationFromGTFS.mockImplementationOnce((path, _coords, nodeIds, _allStopTimes, gtfsShapeId) => {
-            setPathGeography(path, nodeIds, gtfsShapeId);
+        mockedPathGenerationFromGTFS.mockImplementationOnce((params) => {
+            setPathGeography(params.path, params.nodeIds, params.shapeGtfsId);
             return warnings;
         });
         const result = await PathImporter.generateAndImportPaths(tripsByRouteId, importData, collectionManager) as any;
@@ -213,9 +213,9 @@ describe('One line, 2 different trip IDs with same shape', () => {
         expect(pathsDbQueries.createMultiple).toHaveBeenCalledTimes(1);
         // verify that the generator receives stop times from both trips
         expect(mockedPathGenerationFromGTFS).toHaveBeenCalledTimes(1);
-        const callArgs = mockedPathGenerationFromGTFS.mock.calls[0];
-        expect(callArgs[2]).toEqual([nodeId1, nodeId2, nodeId3, nodeId4]);
-        expect(callArgs[3]).toEqual([baseTripAndStopTimes.stopTimes, trip2StopTimes]);
+        const callArgs = mockedPathGenerationFromGTFS.mock.calls[0][0];
+        expect(callArgs.nodeIds).toEqual([nodeId1, nodeId2, nodeId3, nodeId4]);
+        expect(callArgs.allTripsStopTimes).toEqual([baseTripAndStopTimes.stopTimes, trip2StopTimes]);
     });
 
 });
@@ -296,8 +296,8 @@ describe('One line, multiple trips resulting in 2 paths', () => {
 
     test('Generate path with warnings', async () => {
         const warnings = ['warning1', 'warning2'];
-        mockedPathGenerationFromGTFS.mockImplementationOnce((path, _coords, nodeIds, _allStopTimes, gtfsShapeId) => {
-            setPathGeography(path, nodeIds, gtfsShapeId);
+        mockedPathGenerationFromGTFS.mockImplementationOnce((params) => {
+            setPathGeography(params.path, params.nodeIds, params.shapeGtfsId);
             return warnings;
         });
         const result = await PathImporter.generateAndImportPaths(tripsByRouteId, importData, collectionManager) as any;
@@ -330,7 +330,7 @@ describe('One line, multiple trips resulting in 2 paths', () => {
 
     test('Throw an error during generation', async () => {
         const error = 'error';
-        mockedPathGenerationFromGTFS.mockImplementationOnce((path) => {
+        mockedPathGenerationFromGTFS.mockImplementationOnce(() => {
             throw error;
         });
         const result = await PathImporter.generateAndImportPaths(tripsByRouteId, importData, collectionManager) as any;
@@ -447,12 +447,12 @@ describe('Multiple lines, with 2 paths each', () => {
     test('Generate path with warnings', async () => {
         const warningsLine1 = ['warning1', 'warning2'];
         const warningsLine2 = ['warning3'];
-        mockedPathGenerationFromGTFS.mockImplementationOnce((path, _coords, nodeIds, _allStopTimes, gtfsShapeId) => {
-            setPathGeography(path, nodeIds, gtfsShapeId);
+        mockedPathGenerationFromGTFS.mockImplementationOnce((params) => {
+            setPathGeography(params.path, params.nodeIds, params.shapeGtfsId);
             return warningsLine1;
         });
-        mockedPathGenerationFromGTFS.mockImplementationOnce((path, _coords, nodeIds, _allStopTimes, gtfsShapeId) => {
-            setPathGeography(path, nodeIds, gtfsShapeId);
+        mockedPathGenerationFromGTFS.mockImplementationOnce((params) => {
+            setPathGeography(params.path, params.nodeIds, params.shapeGtfsId);
             return warningsLine2;
         });
         const result = await PathImporter.generateAndImportPaths(tripsByRouteId, importData, collectionManager) as any;
@@ -466,7 +466,7 @@ describe('Multiple lines, with 2 paths each', () => {
 
     test('Throw an error during generation', async () => {
         const error = 'error';
-        mockedPathGenerationFromGTFS.mockImplementationOnce((path) => {
+        mockedPathGenerationFromGTFS.mockImplementationOnce(() => {
             throw error;
         });
         const result = await PathImporter.generateAndImportPaths(tripsByRouteId, importData, collectionManager) as any;
@@ -530,13 +530,13 @@ describe('One line, 3 trips with no shape', () => {
         expect(pathsDbQueries.createMultiple).toHaveBeenCalledTimes(1);
         expect(mockedPathGenerationFromStopTimes).toHaveBeenCalledTimes(2);
         // forward path should receive stop times from both trips
-        const forwardCallArgs = mockedPathGenerationFromStopTimes.mock.calls[0];
-        expect(forwardCallArgs[1]).toEqual([nodeId1, nodeId2, nodeId3, nodeId4]);
-        expect(forwardCallArgs[2]).toEqual([baseTripAndStopTimes.stopTimes, offsetStopTimesForTrip2]);
+        const forwardCallArgs = mockedPathGenerationFromStopTimes.mock.calls[0][0];
+        expect(forwardCallArgs.nodeIds).toEqual([nodeId1, nodeId2, nodeId3, nodeId4]);
+        expect(forwardCallArgs.allTripsStopTimes).toEqual([baseTripAndStopTimes.stopTimes, offsetStopTimesForTrip2]);
         // return path should receive stop times from the single return trip
-        const returnCallArgs = mockedPathGenerationFromStopTimes.mock.calls[1];
-        expect(returnCallArgs[1]).toEqual([nodeId4, nodeId3, nodeId2, nodeId1]);
-        expect(returnCallArgs[2]).toEqual([tripsByRouteId[routeId][2].stopTimes]);
+        const returnCallArgs = mockedPathGenerationFromStopTimes.mock.calls[1][0];
+        expect(returnCallArgs.nodeIds).toEqual([nodeId4, nodeId3, nodeId2, nodeId1]);
+        expect(returnCallArgs.allTripsStopTimes).toEqual([tripsByRouteId[routeId][2].stopTimes]);
     });
 
 });

--- a/packages/transition-backend/src/services/path/PathGtfsGeographyGenerator.ts
+++ b/packages/transition-backend/src/services/path/PathGtfsGeographyGenerator.ts
@@ -411,16 +411,26 @@ const calculateDistances = (
     return result.status === 'success' ? result : calculateDistancesBySegments(params);
 };
 
-export const generateGeographyAndSegmentsFromGtfs = (
-    path: Path,
-    shapeCoordinatesWithDistances: GtfsTypes.Shapes[],
-    nodeIds: string[],
-    allTripsStopTimes: StopTime[][],
-    shapeGtfsId: string,
-    stopCoordinatesByStopId: { [key: string]: [number, number] },
-    defaultLayoverRatioOverTotalTravelTime = 0.1,
-    defaultMinLayoverTimeSeconds = 180
-): TranslatableMessage[] => {
+export const generateGeographyAndSegmentsFromGtfs = (params: {
+    path: Path;
+    shapeCoordinatesWithDistances: GtfsTypes.Shapes[];
+    nodeIds: string[];
+    allTripsStopTimes: StopTime[][];
+    shapeGtfsId: string;
+    stopCoordinatesByStopId: { [key: string]: [number, number] };
+    defaultLayoverRatioOverTotalTravelTime?: number;
+    defaultMinLayoverTimeSeconds?: number;
+}): TranslatableMessage[] => {
+    const {
+        path,
+        shapeCoordinatesWithDistances,
+        nodeIds,
+        allTripsStopTimes,
+        shapeGtfsId,
+        stopCoordinatesByStopId,
+        defaultLayoverRatioOverTotalTravelTime = 0.1,
+        defaultMinLayoverTimeSeconds = 180
+    } = params;
     path.attributes.nodes = nodeIds; // reset nodes, they will be regenerated from stop times
 
     // Use first trip's stopTimes for distance calculations (geometry is same for all trips)
@@ -557,14 +567,22 @@ export const generateGeographyAndSegmentsFromGtfs = (
     return errors;
 };
 
-export const generateGeographyAndSegmentsFromStopTimes = (
-    path: Path,
-    nodeIds: string[],
-    allTripsStopTimes: StopTime[][],
-    stopCoordinatesByStopId: { [key: string]: [number, number] },
-    defaultLayoverRatioOverTotalTravelTime = 0.1,
-    defaultMinLayoverTimeSeconds = 180
-): TranslatableMessage[] => {
+export const generateGeographyAndSegmentsFromStopTimes = (params: {
+    path: Path;
+    nodeIds: string[];
+    allTripsStopTimes: StopTime[][];
+    stopCoordinatesByStopId: { [key: string]: [number, number] };
+    defaultLayoverRatioOverTotalTravelTime?: number;
+    defaultMinLayoverTimeSeconds?: number;
+}): TranslatableMessage[] => {
+    const {
+        path,
+        nodeIds,
+        allTripsStopTimes,
+        stopCoordinatesByStopId,
+        defaultLayoverRatioOverTotalTravelTime = 0.1,
+        defaultMinLayoverTimeSeconds = 180
+    } = params;
     path.attributes.nodes = nodeIds; // reset nodes, they will be regenerated from stop times
 
     // Use first trip's stopTimes for distance calculations (geometry is same for all trips)

--- a/packages/transition-backend/src/services/path/__tests__/PathGtfsGeographyGenerator.test.ts
+++ b/packages/transition-backend/src/services/path/__tests__/PathGtfsGeographyGenerator.test.ts
@@ -148,9 +148,9 @@ const createPath = (nodeCoordinates: { [nodeId: string]: [number, number] } = no
 const simpleNodeIds = ['node1', 'node2', 'node3', 'node4'];
 
 const runSimpleGtfs = (path: Path, nodeIds = simpleNodeIds) =>
-    generateGeographyAndSegmentsFromGtfs(
-        path, simpleShapeCoordinates, nodeIds, [simpleStopTimes], 'shape1', simpleStopCoordinates
-    );
+    generateGeographyAndSegmentsFromGtfs({
+        path, shapeCoordinatesWithDistances: simpleShapeCoordinates, nodeIds, allTripsStopTimes: [simpleStopTimes], shapeGtfsId: 'shape1', stopCoordinatesByStopId: simpleStopCoordinates
+    });
 
 describe('generateGeographyAndSegmentsFromGtfs', () => {
     describe('with valid shape and stops near shape', () => {
@@ -192,17 +192,17 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
 
     test('should set geography to null for empty or undefined shape', () => {
         const path1 = createPath();
-        const errors1 = generateGeographyAndSegmentsFromGtfs(
-            path1, [], ['node1', 'node2'], [simpleStopTimes], 'emptyShape', simpleStopCoordinates
-        );
+        const errors1 = generateGeographyAndSegmentsFromGtfs({
+            path: path1, shapeCoordinatesWithDistances: [], nodeIds: ['node1', 'node2'], allTripsStopTimes: [simpleStopTimes], shapeGtfsId: 'emptyShape', stopCoordinatesByStopId: simpleStopCoordinates
+        });
         expect(errors1).toHaveLength(0);
         expect(path1.attributes.geography).toBeNull();
         expect(path1.attributes.data.gtfs).toEqual({ shape_id: 'emptyShape' });
 
         const path2 = createPath();
-        const errors2 = generateGeographyAndSegmentsFromGtfs(
-            path2, undefined as any, ['node1'], [simpleStopTimes], 'noShape', simpleStopCoordinates
-        );
+        const errors2 = generateGeographyAndSegmentsFromGtfs({
+            path: path2, shapeCoordinatesWithDistances: undefined as any, nodeIds: ['node1'], allTripsStopTimes: [simpleStopTimes], shapeGtfsId: 'noShape', stopCoordinatesByStopId: simpleStopCoordinates
+        });
         expect(errors2).toHaveLength(0);
         expect(path2.attributes.geography).toBeNull();
     });
@@ -217,9 +217,9 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
             stop4: simpleStopCoordinates.stop4
         };
         const path = createPath(nodeCoordinatesFromStops(stopCoordinatesWithFarStop));
-        const errors = generateGeographyAndSegmentsFromGtfs(
-            path, simpleShapeCoordinates, simpleNodeIds, [simpleStopTimes], 'shape1', stopCoordinatesWithFarStop
-        );
+        const errors = generateGeographyAndSegmentsFromGtfs({
+            path, shapeCoordinatesWithDistances: simpleShapeCoordinates, nodeIds: simpleNodeIds, allTripsStopTimes: [simpleStopTimes], shapeGtfsId: 'shape1', stopCoordinatesByStopId: stopCoordinatesWithFarStop
+        });
 
         expect(errors).toHaveLength(1);
         const error = errors[0] as TranslatableMessageWithParams;
@@ -240,9 +240,9 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
     test('should handle loop shape without errors', () => {
         const path = createPath(nodeCoordinatesFromStops(loopStopCoordinates));
         const nodeIds = ['node1', 'node2', 'node3', 'node4', 'node5', 'node6'];
-        const errors = generateGeographyAndSegmentsFromGtfs(
-            path, loopShapeCoordinates, nodeIds, [loopStopTimes], 'loopShape', loopStopCoordinates
-        );
+        const errors = generateGeographyAndSegmentsFromGtfs({
+            path, shapeCoordinatesWithDistances: loopShapeCoordinates, nodeIds, allTripsStopTimes: [loopStopTimes], shapeGtfsId: 'loopShape', stopCoordinatesByStopId: loopStopCoordinates
+        });
 
         expect(errors).toHaveLength(0);
         expect(path.attributes.geography).toBeDefined();
@@ -267,9 +267,9 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
         }));
 
         const path = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
-        const errors = generateGeographyAndSegmentsFromGtfs(
-            path, shapesWithDist, simpleNodeIds, [stopTimesWithDist], 'shape1', simpleStopCoordinates
-        );
+        const errors = generateGeographyAndSegmentsFromGtfs({
+            path, shapeCoordinatesWithDistances: shapesWithDist, nodeIds: simpleNodeIds, allTripsStopTimes: [stopTimesWithDist], shapeGtfsId: 'shape1', stopCoordinatesByStopId: simpleStopCoordinates
+        });
 
         expect(errors).toHaveLength(0);
         expect(path.attributes.segments).toHaveLength(3);
@@ -296,9 +296,9 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
                 ['stop1', 'stop2', 'stop3', 'stop4'],
                 [[36000, 36000], [36700, 36710], [37400, 37420], [38100, 38100]]
             );
-            generateGeographyAndSegmentsFromGtfs(
-                path, simpleShapeCoordinates, simpleNodeIds, [longStopTimes], 'shape1', simpleStopCoordinates
-            );
+            generateGeographyAndSegmentsFromGtfs({
+                path, shapeCoordinatesWithDistances: simpleShapeCoordinates, nodeIds: simpleNodeIds, allTripsStopTimes: [longStopTimes], shapeGtfsId: 'shape1', stopCoordinatesByStopId: simpleStopCoordinates
+            });
             // totalTravelTimeWithDwellTimes = (0+700) + (10+690) + (20+680) = 2100s
             // layover = ceil(max(0.1 * 2100, 180)) = 210
             expect(getData(path, 'layoverTimeSeconds')).toEqual(210);
@@ -306,18 +306,18 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
 
         test('should respect custom ratio and minimum parameters', () => {
             const path1 = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
-            generateGeographyAndSegmentsFromGtfs(
-                path1, simpleShapeCoordinates, simpleNodeIds,
-                [simpleStopTimes], 'shape1', simpleStopCoordinates, 0.5, 60
-            );
+            generateGeographyAndSegmentsFromGtfs({
+                path: path1, shapeCoordinatesWithDistances: simpleShapeCoordinates, nodeIds: simpleNodeIds,
+                allTripsStopTimes: [simpleStopTimes], shapeGtfsId: 'shape1', stopCoordinatesByStopId: simpleStopCoordinates, defaultLayoverRatioOverTotalTravelTime: 0.5, defaultMinLayoverTimeSeconds: 60
+            });
             // totalTravelTimeWithDwellTimes = 300s; layover = ceil(max(0.5 * 300, 60)) = 150
             expect(getData(path1, 'layoverTimeSeconds')).toEqual(150);
 
             const path2 = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
-            generateGeographyAndSegmentsFromGtfs(
-                path2, simpleShapeCoordinates, simpleNodeIds,
-                [simpleStopTimes], 'shape1', simpleStopCoordinates, 0.01, 120
-            );
+            generateGeographyAndSegmentsFromGtfs({
+                path: path2, shapeCoordinatesWithDistances: simpleShapeCoordinates, nodeIds: simpleNodeIds,
+                allTripsStopTimes: [simpleStopTimes], shapeGtfsId: 'shape1', stopCoordinatesByStopId: simpleStopCoordinates, defaultLayoverRatioOverTotalTravelTime: 0.01, defaultMinLayoverTimeSeconds: 120
+            });
             // layover = ceil(max(0.01 * 300, 120)) = 120 (minimum wins)
             expect(getData(path2, 'layoverTimeSeconds')).toEqual(120);
         });
@@ -342,9 +342,9 @@ describe('generateGeographyAndSegmentsFromGtfs', () => {
     test('should produce a single segment for 2-stop path', () => {
         const path = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
         const twoStopTimes = makeStopTimes('trip1', ['stop1', 'stop4'], [[36000, 36000], [36300, 36300]]);
-        const errors = generateGeographyAndSegmentsFromGtfs(
-            path, simpleShapeCoordinates, ['node1', 'node4'], [twoStopTimes], 'shape1', simpleStopCoordinates
-        );
+        const errors = generateGeographyAndSegmentsFromGtfs({
+            path, shapeCoordinatesWithDistances: simpleShapeCoordinates, nodeIds: ['node1', 'node4'], allTripsStopTimes: [twoStopTimes], shapeGtfsId: 'shape1', stopCoordinatesByStopId: simpleStopCoordinates
+        });
 
         expect(errors).toHaveLength(0);
         expect(path.attributes.segments).toHaveLength(1);
@@ -359,9 +359,9 @@ describe('generateGeographyAndSegmentsFromStopTimes', () => {
 
         beforeEach(() => {
             path = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
-            errors = generateGeographyAndSegmentsFromStopTimes(
-                path, simpleNodeIds, [simpleStopTimes], simpleStopCoordinates
-            );
+            errors = generateGeographyAndSegmentsFromStopTimes({
+                path, nodeIds: simpleNodeIds, allTripsStopTimes: [simpleStopTimes], stopCoordinatesByStopId: simpleStopCoordinates
+            });
         });
 
         test('should set path geography and metadata', () => {
@@ -405,14 +405,14 @@ describe('generateGeographyAndSegmentsFromStopTimes', () => {
 
     test('should return error and null geography on missing stop coordinates', () => {
         const path = createPath();
-        const errors = generateGeographyAndSegmentsFromStopTimes(
-            path, simpleNodeIds, [simpleStopTimes], {
+        const errors = generateGeographyAndSegmentsFromStopTimes({
+            path, nodeIds: simpleNodeIds, allTripsStopTimes: [simpleStopTimes], stopCoordinatesByStopId: {
                 stop1: simpleStopCoordinates.stop1,
                 stop2: simpleStopCoordinates.stop2,
                 // stop3 is missing
                 stop4: simpleStopCoordinates.stop4
             }
-        );
+        });
 
         expect(errors).toHaveLength(1);
         const error = errors[0] as TranslatableMessageWithParams;
@@ -425,16 +425,16 @@ describe('generateGeographyAndSegmentsFromStopTimes', () => {
     test('should use customLayoverMinutes when set', () => {
         const path = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
         path.attributes.data.customLayoverMinutes = 3;
-        generateGeographyAndSegmentsFromStopTimes(path, simpleNodeIds, [simpleStopTimes], simpleStopCoordinates);
+        generateGeographyAndSegmentsFromStopTimes({ path, nodeIds: simpleNodeIds, allTripsStopTimes: [simpleStopTimes], stopCoordinatesByStopId: simpleStopCoordinates });
         expect(getData(path, 'layoverTimeSeconds')).toEqual(180);
     });
 
     test('should produce a single segment for 2-stop path', () => {
         const path = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
         const twoStopTimes = makeStopTimes('trip1', ['stop1', 'stop4'], [[36000, 36000], [36300, 36300]]);
-        const errors = generateGeographyAndSegmentsFromStopTimes(
-            path, ['node1', 'node4'], [twoStopTimes], simpleStopCoordinates
-        );
+        const errors = generateGeographyAndSegmentsFromStopTimes({
+            path, nodeIds: ['node1', 'node4'], allTripsStopTimes: [twoStopTimes], stopCoordinatesByStopId: simpleStopCoordinates
+        });
 
         expect(errors).toHaveLength(0);
         expect(path.attributes.segments).toEqual([0]);
@@ -444,7 +444,7 @@ describe('generateGeographyAndSegmentsFromStopTimes', () => {
 
     test('timing consistency: layover equation and dwell time sum', () => {
         const path = createPath(nodeCoordinatesFromStops(simpleStopCoordinates));
-        generateGeographyAndSegmentsFromStopTimes(path, simpleNodeIds, [simpleStopTimes], simpleStopCoordinates);
+        generateGeographyAndSegmentsFromStopTimes({ path, nodeIds: simpleNodeIds, allTripsStopTimes: [simpleStopTimes], stopCoordinatesByStopId: simpleStopCoordinates });
 
         expect(path.attributes.data.operatingTimeWithLayoverTimeSeconds).toEqual(
             path.attributes.data.operatingTimeWithoutLayoverTimeSeconds! +


### PR DESCRIPTION
Converts generateGeographyAndSegmentsFromGtfs and generateGeographyAndSegmentsFromStopTimes in PathGtfsGeographyGenerator.ts from positional parameters to a single named params object, consistent with other functions in the same file. This makes it easier to add new optional parameters without positional ambiguity or undefined holes.

This PR was made to address the growth of these functions in PR #1892 and related comments to their growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated path import service functions to use clearer code patterns, improving code maintainability and readability.

* **Tests**
  * Updated corresponding tests to align with refactored service functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->