### PR TITLE
tests: change 'Routing' section ui test to 'Stop nodes'

### DIFF
--- a/packages/transition-frontend/ui-tests/test-left-menu.spec.ts
+++ b/packages/transition-frontend/ui-tests/test-left-menu.spec.ts
@@ -23,9 +23,16 @@ test.beforeAll(async ({ browser }) => {
 
 loginTestHelpers.startAndLoginAnonymously({ context, title: 'Transition' });
 
-// Click on a few sections of the left menu to check that the panel switching works properly.
-testHelpers.clickLeftMenuTest({ context, section: 'routing' });
-testHelpers.clickLeftMenuTest({ context, section: 'preferences' });
-testHelpers.clickLeftMenuTest({ context, section: 'agencies' });
+// Click on a few sections of the left menu to check that the panel switching
+// works properly.
+//
+// FIXME Some sections like Routing and Accessibility map have a full loading
+// panel until all data is loaded, so we cannot check the title.  Despite a 30
+// seconds timeout, the tests were still timing out with a loading panel in the
+// CI, so we are skipping the title check for those sections for now. Anyway, we
+// are not really testing anything here.
+testHelpers.clickLeftMenuTest({ context, section: 'nodes', expectedRightPanelTitle: 'Stop nodes' });
+testHelpers.clickLeftMenuTest({ context, section: 'preferences', expectedRightPanelTitle: 'Preferences' });
+testHelpers.clickLeftMenuTest({ context, section: 'agencies', expectedRightPanelTitle: 'Agencies' });
 
 testHelpers.logoutTest({ context });

--- a/packages/transition-frontend/ui-tests/testHelpers.ts
+++ b/packages/transition-frontend/ui-tests/testHelpers.ts
@@ -27,7 +27,7 @@ type SwitchLanguageTest = (params: { languageToSwitch: AvailableLanguages } & Co
 type HasUrlTest = (params: { expectedUrl: Url } & CommonTestParameters) => void;
 type LoginTest = (params: { loginMethod: LoginMethods } & CommonTestParameters) => void;
 type LogoutTest = (params: CommonTestParameters) => void;
-type LeftMenuTest = (params: { section: LeftMenuSections } & CommonTestParameters) => void;
+type LeftMenuTest = (params: { section: LeftMenuSections; expectedRightPanelTitle: string } & CommonTestParameters) => void;
 
 const testUsername = process.env.PLAYWRIGHT_TEST_USER || 'testUser';
 const testPassword = process.env.PLAYWRIGHT_TEST_PASSWORD || 'testPassword';
@@ -177,31 +177,15 @@ export const logoutTest: LogoutTest = ({ context }) => {
  * Click on one of the sections on the left menu, and check that the right panel is the correct one.
  * @param {Object} options - The options for the test.
  * @param {string} options.section - The section we click.
+ * @param {string} options.expectedRightPanelTitle - The expected title of the right panel.
  */
-export const clickLeftMenuTest: LeftMenuTest = ({ context, section }) => {
+export const clickLeftMenuTest: LeftMenuTest = ({ context, section, expectedRightPanelTitle }) => {
     test(`Click the ${section} section of the left menu - ${getTestCounter(context, `${section}`)}`, async () => {
         const leftMenu = context.page.locator('//nav[@id="tr__left-menu"]/ul[@class="tr__left-menu-container"]');
         const sectionButton = leftMenu.locator(`//li/button[@data-section='${section}']/span/img`);
         await sectionButton.click();
         const rightPanel = context.page.locator('//section[@id="tr__right-panel"]/div[@class="tr__right-panel-inner"]');
         const rightPanelTitle = rightPanel.getByRole('heading').nth(0);
-        let expectedRightPanelTitle;
-        // To avoid making this function hard to maintain, we only leave the options that are clicked on during the "Test left menu" test, which are commonly used options whose title is unlikely to change
-        // The expectedRightPanelTitle is the english title of each panel, taken directly from the translation files
-        switch(section) {
-        case 'agencies':
-            expectedRightPanelTitle = 'Agencies';
-            break;
-        case 'routing':
-            expectedRightPanelTitle = 'Routing';
-            break;
-        case 'preferences':
-            expectedRightPanelTitle = 'Preferences';
-            break;
-        }
-        // The routing section keeps a full-panel LoadingPage until the scenario collection is ready, so the first
-        // real heading appears later than for agencies/preferences. Playwright retries this assert until match or
-        // expect.timeout (aligned with test timeout in playwright.config—not a fixed sleep).
         await expect(rightPanelTitle).toContainText(expectedRightPanelTitle);
     });
 };


### PR DESCRIPTION
Pass the expected panel title to the `clickLeftMenuTest` helper, as it is each caller's responsibility to know what to expect instead of having an exhaustive switch case in the helper, english only.

The UI tests are now often failing in the CI. The `Routing` section displays a full loading panel until all data is loaded, so the title is not available yet. And despite a 30 seconds timeout, it still shows the panel as loading.

The real fix would imply
1- Refactor the form with complete loading page so the title and any other part not depending on the data can be shown while it is loading 2- Let the UI tests wait for the data to be loaded before testing anything (and load less data at startup anyway)

The current approach is acceptable for now, as the UI tests for Transition do not yet claim to do any actual testing, but just change to a few sections