### PR TITLE
Fix null-safety in MapLayerManager and NodeLayerMapEvents

### DIFF
--- a/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
+++ b/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
@@ -283,7 +283,8 @@ class MapLibreLayerManager {
         this._layersByName[layerName].source.data = newGeojson;
 
         if (this._map && this.layerIsEnabled(layerName)) {
-            (this._map.getSource(layerName) as GeoJSONSource).setData(this._layersByName[layerName].source.data);
+            const source = this._map.getSource(layerName) as GeoJSONSource | undefined;
+            source?.setData(this._layersByName[layerName].source.data);
         }
         serviceLocator.eventManager.emit('map.updatedLayer', layerName);
     }
@@ -299,7 +300,8 @@ class MapLibreLayerManager {
                         : defaultGeojson;
             this._layersByName[layerName].source.data = newGeojson;
             if (this._map && this.layerIsEnabled(layerName)) {
-                (this._map.getSource(layerName) as GeoJSONSource).setData(this._layersByName[layerName].source.data);
+                const source = this._map.getSource(layerName) as GeoJSONSource | undefined;
+                source?.setData(this._layersByName[layerName].source.data);
             }
         }
         serviceLocator.eventManager.emit('map.updatedLayers', Object.keys(geojsonByLayerName));

--- a/packages/transition-frontend/src/services/map/events/NodeLayerMapEvents.ts
+++ b/packages/transition-frontend/src/services/map/events/NodeLayerMapEvents.ts
@@ -48,11 +48,12 @@ const onNodeMouseEnter = (e: MapLayerMouseEvent) => {
         const nodeGeojson = e.features[0];
         const hoverNodeIntegerId = nodeGeojson.id;
         const hoverNodeId = nodeGeojson.properties?.id;
-        const node = new Node(
-            serviceLocator.collectionManager.get('nodes').getById(hoverNodeId).properties,
-            false,
-            serviceLocator.collectionManager
-        );
+        const nodesCollection = serviceLocator.collectionManager?.get('nodes');
+        const nodeFeature = nodesCollection?.getById(hoverNodeId);
+        if (!nodeFeature) {
+            return; // collection or node not loaded yet
+        }
+        const node = new Node(nodeFeature.properties, false, serviceLocator.collectionManager);
 
         // unhover previous node:
         if (map._hoverNodeIntegerId && map._hoverNodeSource && map._hoverNodeId) {


### PR DESCRIPTION
Guard against undefined map sources in MapLayerManager when a layer is removed before its update completes. Guard against the nodes collection not being loaded yet when hovering a node on the map.

When hovering over a node on the map before the nodes collection has finished loading from the server, the app throws:

Uncaught TypeError: can't access property "getById", ServiceLocator_1.default.collectionManager.get(...) is undefined onNodeMouseEnter NodeLayerMapEvents.js:48

Similarly, MapLayerManager.updateLayer / updateLayers can crash if a map source is removed between the time an update is queued and when it executes, because getSource() returns undefined but is cast unconditionally to GeoJSONSource.

Both are race conditions where map events fire before the backing data is ready. The fix adds null guards so the operations are silently skipped instead of crashing.

This fixes a bug found during the implementation of PR #1892.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map layer updates with better handling of missing data sources to prevent application crashes.
  * Enhanced node feature retrieval to gracefully skip operations when node data is unavailable, improving overall application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->