### PR TITLE
Warn user when a schedule fails to regenerate after a path edit

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -451,6 +451,8 @@
         "IncreaseRoutingRadiiToIncludeExistingPathShape": "Adapt nodes radii to fit current shape",
         "IncreaseRoutingRadiiToIncludeExistingPathShapeHelp": "Increase path nodes routing radii if the path shape is too far from some nodes (max 200m). Nodes routing radii will be ignored.",
         "ForceRecalculateFromRouting": "Recalculate all segment travel times",
+        "ScheduleGenerationFailuresTitle": "### Some schedules could not be regenerated",
+        "ScheduleGenerationFailuresIntro": "The following services have periods that could not be regenerated because the number of vehicles or the interval is not set. Go to the timetable section of this line to configure them so trips can be generated.",
         "Uuid": "UUID",
         "Line": "Line",
         "InternalId": "Internal ID",

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -449,6 +449,8 @@
         "IncreaseRoutingRadiiToIncludeExistingPathShape": "Adapter le rayon des noeuds au tracé actuel",
         "IncreaseRoutingRadiiToIncludeExistingPathShapeHelp": "Augmenter le rayon utilisé autour des noeuds pour le calcul de chemin si le tracé actuel est trop loin de certains noeuds (max 200m). Les rayons attribués aux noeuds seront ignorés.",
         "ForceRecalculateFromRouting": "Recalculer tous les temps de parcours des segments",
+        "ScheduleGenerationFailuresTitle": "### Certains horaires n'ont pas pu être régénérés",
+        "ScheduleGenerationFailuresIntro": "Les services suivants ont des périodes qui n'ont pas pu être régénérées parce que le nombre de véhicules ou l'intervalle n'est pas défini. Rendez-vous dans la section des horaires de cette ligne pour les configurer afin que les trajets puissent être générés.",
         "MinDwellTimeSeconds": "Temps d'arrêt minimum aux noeuds [sec.]",
         "MinMatchingTimestamp": "Intervalle minimum d'horodatage pour le calcul de chemin (en secondes), 500 par défaut",
         "MinMatchingTimestampHelp": "Intervalle d'horodatage utilisé entre les points de repères lors de la cartospondance (map matching) utilisée lors du calcul de chemin. Une plus petite valeur (moins de 500) réduira les détours imprévus, mais pourrait faire en sorte que le calcul de chemin ne réussisse pas si le parcours comporte de longs segments entre certaines paires de noeuds d'arrêts (l'ajout de points de repères pourrait alors être nécessaire). Une valeur plus élevée (plus de 500) permettra d'obtenir un parcours complet dans la majorité des cas, mais pourrait ajouter des détours imprévus.",

--- a/packages/transition-common/src/services/line/Line.ts
+++ b/packages/transition-common/src/services/line/Line.ts
@@ -392,12 +392,22 @@ export class Line extends ObjectWithHistory<LineAttributes> implements Saveable 
         delete this.attributes.scheduleByServiceId[serviceId];
     }
 
-    // update all schedules that uses the path id
-    async updateSchedulesForPathId(pathId: string, saveSchedules = false) {
+    /**
+     * Updates all schedules that use the given path id, regenerating their trips.
+     *
+     * @param pathId - The id of the path whose associated schedules must be updated
+     * @param saveSchedules - When true, persist each updated schedule via the socket
+     *                        event manager
+     * @returns The ids of the services whose schedule had generation problems
+     *          and should be raised to the user. See `updateForAllPeriods` in
+     *          `services/schedules/Schedule.ts` for the exact failure conditions.
+     */
+    async updateSchedulesForPathId(pathId: string, saveSchedules = false): Promise<string[]> {
         const associatedServiceIds = this.getScheduleServiceIdsForPathId(pathId);
         if (associatedServiceIds.length > 0) {
-            await this.updateSchedules(associatedServiceIds, saveSchedules);
+            return this.updateSchedules(associatedServiceIds, saveSchedules);
         }
+        return [];
     }
 
     // source: https://stackoverflow.com/a/41491220
@@ -427,17 +437,32 @@ export class Line extends ObjectWithHistory<LineAttributes> implements Saveable 
         return L > threshold ? darkColor : lightColor;
     }
 
-    async updateSchedules(serviceIds: string[] = [], saveSchedules = false) {
+    /**
+     * Regenerates trips for the given services' schedules. When no service id
+     * is provided, every schedule attached to the line is regenerated.
+     *
+     * @param serviceIds - The ids of the services to update. Pass an empty array
+     *                     (default) to update every schedule on the line.
+     * @param saveSchedules - When true, persist each updated schedule via the
+     *                        socket event manager
+     * @returns The ids of the services whose schedule had generation problems
+     *          and should be raised to the user. See `updateForAllPeriods` in
+     *          `services/schedules/Schedule.ts` for the exact failure conditions.
+     */
+    async updateSchedules(serviceIds: string[] = [], saveSchedules = false): Promise<string[]> {
         // update all services if serviceIds is empty
         const schedulesObjectsByServiceId = this.getSchedules();
         if (serviceIds.length === 0) {
             serviceIds = Object.keys(schedulesObjectsByServiceId);
         }
         const savePromises: Promise<unknown>[] = [];
+        const serviceIdsWithFailedScheduleGeneration: string[] = [];
         for (const serviceId in schedulesObjectsByServiceId) {
             if (serviceIds.includes(serviceId)) {
                 const schedule = schedulesObjectsByServiceId[serviceId];
-                schedule.updateForAllPeriods();
+                if (!schedule.updateForAllPeriods()) {
+                    serviceIdsWithFailedScheduleGeneration.push(serviceId);
+                }
                 if (saveSchedules) {
                     savePromises.push(schedule.save(serviceLocator.socketEventManager));
                 }
@@ -445,6 +470,7 @@ export class Line extends ObjectWithHistory<LineAttributes> implements Saveable 
             }
         }
         await Promise.all(savePromises);
+        return serviceIdsWithFailedScheduleGeneration;
     }
 
     // TODO This function does not seem to be called anywhere

--- a/packages/transition-common/src/services/schedules/Schedule.ts
+++ b/packages/transition-common/src/services/schedules/Schedule.ts
@@ -1065,7 +1065,19 @@ class Schedule extends ObjectWithHistory<ScheduleAttributes> implements Saveable
         const periods = this.attributes.periods;
         for (let i = 0, countI = periods.length; i < countI; i++) {
             const period = periods[i];
-            period.trips.forEach((trip) => (associatedPathIds[trip.path_id] = true));
+            // Include the paths the period is configured to use, even if no trips
+            // have been generated yet. Otherwise a service that has not produced
+            // any trips would be considered unrelated to its configured paths and
+            // would silently be skipped by callers like updateSchedulesForPathId.
+            if (period.outbound_path_id) {
+                associatedPathIds[period.outbound_path_id] = true;
+            }
+            if (period.inbound_path_id) {
+                associatedPathIds[period.inbound_path_id] = true;
+            }
+            // period.trips can be undefined when the period has never been generated
+            // (no interval/units configured).
+            period.trips?.forEach((trip) => (associatedPathIds[trip.path_id] = true));
         }
 
         return Object.keys(associatedPathIds);
@@ -1237,13 +1249,72 @@ class Schedule extends ObjectWithHistory<ScheduleAttributes> implements Saveable
 
         return Status.createOk(result.trips);
     }
-    updateForAllPeriods() {
-        // re-generate (after modifying path by instance)
+
+    /**
+     * Checks whether a period has been configured by the user to generate trips.
+     * A period is considered configured when at least one of its interval or unit
+     * count fields has a value. A fully blank period is treated as intentionally
+     * empty (the line is not meant to run during this period).
+     *
+     * @param period - The schedule period to inspect
+     * @returns True if the period has interval(s) or number of units set, false otherwise
+     */
+    private isPeriodConfigured(period: SchedulePeriod): boolean {
+        return !(
+            _isBlank(period.interval_seconds) &&
+            _isBlank(period.inbound_interval_seconds) &&
+            _isBlank(period.number_of_units)
+        );
+    }
+
+    /**
+     * Generates trips for every period of the schedule. Periods that are
+     * intentionally empty (no configuration and no existing trips) are skipped
+     * silently and do not affect the result.
+     *
+     * @returns True when the schedule generated successfully (no flag for the user).
+     *          False when the schedule should be flagged for these reasons:
+     *          - the schedule has no period at all, or no period is configured
+     *            (nothing will ever be generated)
+     *          - at least one period that was meant to produce trips (configured,
+     *            or already had trips before generation) failed to generate
+     *          - the schedule ended up with zero trips across all periods
+     */
+    updateForAllPeriods(): boolean {
         const periods = this.attributes.periods;
-        for (let i = 0, countI = periods.length; i < countI; i++) {
-            // TODO period_shortname can be undefined, fix typing to avoid this or add check
-            this.generateForPeriodFunction(periods[i].period_shortname as string);
+        if (periods.length === 0 || periods.every((period) => !this.isPeriodConfigured(period))) {
+            return false;
         }
+        let success = true;
+        let totalTripsCount = 0;
+        for (let i = 0, countI = periods.length; i < countI; i++) {
+            const period = periods[i];
+            const periodHadTrips = (period.trips?.length ?? 0) > 0;
+            if (!this.isPeriodConfigured(period) && !periodHadTrips) {
+                continue;
+            }
+            // TODO period_shortname can be undefined, fix typing to avoid this or add check
+            try {
+                const result = this.generateForPeriodFunction(period.period_shortname as string);
+                if (Status.isStatusError(result)) {
+                    success = false;
+                }
+            } catch (error) {
+                console.error('Error generating trips for schedule period', {
+                    scheduleId: this.attributes.id,
+                    serviceId: this.attributes.service_id,
+                    periodShortname: period.period_shortname,
+                    error
+                });
+                success = false;
+            }
+            totalTripsCount += period.trips?.length ?? 0;
+        }
+        // A schedule that succeeded on every call but still produced zero trips must also be flagged.
+        if (totalTripsCount === 0) {
+            success = false;
+        }
+        return success;
     }
 
     //TODO update test . (probably it's better to test generateForPeriodfunction instead. if the other test works, this one probably works too)

--- a/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
+++ b/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
@@ -105,10 +105,23 @@ describe('getAssociatedPathIds', () => {
         expect(schedule.getAssociatedPathIds()).toEqual([]);
     });
 
-    test('Periods with no trips', () => {
+    test('Periods with no trips but with configured paths', () => {
+        // A period that has outbound_path_id/inbound_path_id set is associated
+        // with those paths even if no trips have been generated yet.
         const testAttributes = _cloneDeep(scheduleAttributes);
         testAttributes.periods.forEach(period => {
             period.trips = [];
+        })
+        const schedule = new Schedule(testAttributes, true);
+        expect(schedule.getAssociatedPathIds()).toEqual([pathId]);
+    });
+
+    test('Periods with no trips and no configured paths', () => {
+        const testAttributes = _cloneDeep(scheduleAttributes);
+        testAttributes.periods.forEach(period => {
+            period.trips = [];
+            period.outbound_path_id = undefined;
+            period.inbound_path_id = undefined;
         })
         const schedule = new Schedule(testAttributes, true);
         expect(schedule.getAssociatedPathIds()).toEqual([]);
@@ -221,6 +234,120 @@ describe('updateForAllPeriods', () => {
             const periodEnd = period.custom_end_at_str ? timeStrToSecondsSinceMidnight(period.custom_end_at_str) as number : period.end_at_hour * 60 * 60;
             expect(period.trips.length).toEqual(Math.ceil((periodEnd - periodStart)/ interval));
         }
+    });
+
+    describe('return value (flag for the user)', () => {
+        test('returns false when the schedule has no period at all', () => {
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods = [];
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            expect(schedule.updateForAllPeriods()).toBe(false);
+        });
+
+        test('returns false when no period is configured (all interval/units blank)', () => {
+            // Every period has neither interval nor number_of_units set: nothing
+            // will ever be generated for this schedule, the user should be flagged.
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods.forEach(period => {
+                period.interval_seconds = undefined;
+                period.inbound_interval_seconds = undefined;
+                period.number_of_units = undefined;
+                period.trips = [];
+            });
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            expect(schedule.updateForAllPeriods()).toBe(false);
+        });
+
+        test('returns true when at least one configured period generates trips', () => {
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods.forEach(period => {
+                period.interval_seconds = 30 * 60;
+                period.number_of_units = undefined;
+                period.trips = [];
+            });
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            expect(schedule.updateForAllPeriods()).toBe(true);
+        });
+
+        test('returns true when configured periods succeed and unconfigured ones are skipped', () => {
+            // Mix: first period is configured and should produce trips, the rest
+            // are intentionally empty (no config and no existing trips) and must
+            // be skipped silently.
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods.forEach((period, idx) => {
+                if (idx === 0) {
+                    period.interval_seconds = 30 * 60;
+                    period.number_of_units = undefined;
+                    period.trips = [];
+                } else {
+                    period.interval_seconds = undefined;
+                    period.inbound_interval_seconds = undefined;
+                    period.number_of_units = undefined;
+                    period.trips = [];
+                }
+            });
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            expect(schedule.updateForAllPeriods()).toBe(true);
+        });
+
+        test('returns false when a configured period fails to generate (missing outbound path)', () => {
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods.forEach(period => {
+                period.interval_seconds = 30 * 60;
+                period.number_of_units = undefined;
+                (period as any).outbound_path_id = undefined;
+                period.trips = [];
+            });
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            expect(schedule.updateForAllPeriods()).toBe(false);
+        });
+
+        test('returns false when every period generation succeeds but produces zero trips overall', () => {
+            // Stub generateForPeriodFunction so every period returns Status.OK
+            // with an empty trip list. This simulates the case where generation
+            // does not error out but still produces no trips at all.
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods.forEach(period => {
+                period.interval_seconds = 30 * 60;
+                period.number_of_units = undefined;
+                period.trips = [];
+            });
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            const generateSpy = jest
+                .spyOn(schedule as any, 'generateForPeriodFunction')
+                .mockImplementation(() => Status.createOk([]));
+            try {
+                expect(schedule.updateForAllPeriods()).toBe(false);
+                expect(generateSpy).toHaveBeenCalled();
+                schedule.attributes.periods.forEach(period => {
+                    expect(period.trips?.length ?? 0).toBe(0);
+                });
+            } finally {
+                generateSpy.mockRestore();
+            }
+        });
+
+        test('returns false when an unconfigured period still has existing trips that fail to regenerate', () => {
+            // Period had trips before but lost its interval/units configuration:
+            // we must try to regenerate it (because trips existed) and fail since
+            // it is no longer configured, so the schedule should be flagged.
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            testAttributes.periods.forEach((period, idx) => {
+                if (idx === 0) {
+                    period.interval_seconds = undefined;
+                    period.inbound_interval_seconds = undefined;
+                    period.number_of_units = undefined;
+                    // keep existing trips so periodHadTrips is true
+                } else {
+                    period.interval_seconds = undefined;
+                    period.inbound_interval_seconds = undefined;
+                    period.number_of_units = undefined;
+                    period.trips = [];
+                }
+            });
+            const schedule = new Schedule(testAttributes, true, collectionManager);
+            expect(schedule.updateForAllPeriods()).toBe(false);
+        });
     });
 });
 

--- a/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/path/TransitPathEdit.tsx
@@ -5,7 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-import { withTranslation, WithTranslation } from 'react-i18next';
+import { useTranslation, withTranslation, WithTranslation } from 'react-i18next';
 import Collapsible from 'react-collapsible';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
 import { faUndoAlt } from '@fortawesome/free-solid-svg-icons/faUndoAlt';
@@ -46,6 +46,37 @@ for (let i = 0, countI = lineModesConfig.length; i < countI; i++) {
     lineModesConfigByMode[lineMode.value] = lineMode;
 }
 
+type ScheduleGenerationFailuresModalProps = {
+    serviceIds: string[];
+    onClose: () => void;
+};
+
+const ScheduleGenerationFailuresModal: React.FunctionComponent<ScheduleGenerationFailuresModalProps> = ({
+    serviceIds,
+    onClose
+}) => {
+    const { t } = useTranslation('transit');
+    const servicesCollection = serviceLocator.collectionManager?.get('services');
+    return (
+        <ConfirmModal
+            isOpen={true}
+            title={t('transit:transitPath:ScheduleGenerationFailuresTitle')}
+            showCancelButton={false}
+            confirmButtonColor="blue"
+            confirmAction={onClose}
+            closeModal={onClose}
+        >
+            <p style={{ textAlign: 'center' }}>{t('transit:transitPath:ScheduleGenerationFailuresIntro')}</p>
+            <ul style={{ marginLeft: '1.5rem', marginTop: '4rem' }}>
+                {serviceIds.map((serviceId) => {
+                    const service = servicesCollection?.getById?.(serviceId);
+                    return <li key={serviceId}>{service?.toString?.(false) || serviceId}</li>;
+                })}
+            </ul>
+        </ConfirmModal>
+    );
+};
+
 interface PathFormProps extends WithTranslation {
     path: Path;
     line: Line;
@@ -58,6 +89,7 @@ interface PathFormState extends SaveableObjectState<Path> {
     waypointDraggingAfterNodeIndex?: number;
     waypointDraggingIndex?: number;
     forceRecalculate: boolean;
+    serviceIdsWithFailedScheduleGeneration: string[];
 }
 
 class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormState> {
@@ -76,7 +108,8 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
             collectionName: 'paths',
             pathErrors: [],
             confirmModalSchedulesAffectedlIsOpen: false,
-            forceRecalculate: false
+            forceRecalculate: false,
+            serviceIdsWithFailedScheduleGeneration: []
         };
     }
 
@@ -209,13 +242,22 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
         line.attributes.data._pathsChangeTimestamp = Date.now();
         serviceLocator.eventManager.emit('progress', { name: 'SavingPath', progress: 0.0 });
         await path.save(serviceLocator.socketEventManager);
-        serviceLocator.selectedObjectsManager.deselect('path');
         serviceLocator.eventManager.emit('progress', { name: 'SavingPath', progress: 1.0 });
         serviceLocator.eventManager.emit('progress', { name: 'SavingLine', progress: 0.0 });
-        await line.updateSchedulesForPathId(path.getId(), true);
+        const failedServiceIds = await line.updateSchedulesForPathId(path.getId(), true);
         line.refreshPaths();
         serviceLocator.eventManager.emit('progress', { name: 'SavingLine', progress: 1.0 });
         this.closeSchedulesAffectedConfirmModal(e);
+        if (failedServiceIds.length > 0) {
+            this.setState({ serviceIdsWithFailedScheduleGeneration: failedServiceIds });
+        } else {
+            serviceLocator.selectedObjectsManager.deselect('path');
+        }
+    };
+
+    closeScheduleGenerationFailuresModal = () => {
+        this.setState({ serviceIdsWithFailedScheduleGeneration: [] });
+        serviceLocator.selectedObjectsManager.deselect('path');
     };
 
     onDeselect = () => {
@@ -838,6 +880,12 @@ class TransitPathEdit extends SaveableObjectForm<Path, PathFormProps, PathFormSt
                                 confirmButtonColor="red"
                                 confirmButtonLabel={this.props.t('transit:transitPath:Delete')}
                                 closeModal={this.closeDeleteConfirmModal}
+                            />
+                        )}
+                        {this.state.serviceIdsWithFailedScheduleGeneration.length > 0 && (
+                            <ScheduleGenerationFailuresModal
+                                serviceIds={this.state.serviceIdsWithFailedScheduleGeneration}
+                                onClose={this.closeScheduleGenerationFailuresModal}
                             />
                         )}
                         {this.state.confirmModalSchedulesAffectedlIsOpen && (

--- a/packages/transition-frontend/src/components/forms/schedules/TransitSchedulePeriod.tsx
+++ b/packages/transition-frontend/src/components/forms/schedules/TransitSchedulePeriod.tsx
@@ -84,6 +84,22 @@ const TransitSchedulePeriod: React.FC<TransitSchedulePeriodProps> = (props) => {
     const inboundPathId =
         actualInboundPathId || (inboundPathsChoices.length === 1 ? inboundPathsChoices[0].value : undefined);
 
+    // When only one path is available, sync the auto-selected default into form state
+    // so it gets saved even if the user never interacts with the dropdown.
+    React.useEffect(() => {
+        if (isFrozen) return;
+        if (outboundPathId && outboundPathId !== actualOutboundPathId) {
+            onValueChange(`periods[${periodIndex}].outbound_path_id`, { value: outboundPathId });
+        }
+    }, [outboundPathId, actualOutboundPathId, periodIndex, isFrozen]);
+
+    React.useEffect(() => {
+        if (isFrozen) return;
+        if (inboundPathId && inboundPathId !== actualInboundPathId) {
+            onValueChange(`periods[${periodIndex}].inbound_path_id`, { value: inboundPathId });
+        }
+    }, [inboundPathId, actualInboundPathId, periodIndex, isFrozen]);
+
     const outboundTripsCells: React.ReactNode[] = [];
     const inboundTripsCells: React.ReactNode[] = [];
     const tripRows: React.ReactNode[] = [];


### PR DESCRIPTION
Fixes #852 

When a path is edited and the user chooses to update affected schedules, Schedule.updateForAllPeriods used to swallow the errors returned by generateForPeriodFunction, leaving the user with no feedback that some periods (e.g. those without number of vehicles or interval set) did not actually get any trips generated.

Propagate per-service regeneration counts up through Line.updateSchedules and surface a warning modal listing every service whose schedule could not be regenerated at all. The modal points the user to the timetable section of the line to set the missing configuration.

We can see the pop up here:
<img width="1050" height="832" alt="Screenshot 2026-04-14 at 4 45 04 PM" src="https://github.com/user-attachments/assets/34c107a9-f838-4e48-82af-20e299444694" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English and French UI text explaining schedule-generation failures.
  * UI now shows a modal listing services whose schedules failed to regenerate.
  * Schedule period form auto-applies sensible inbound/outbound path choices.

* **Behavior Changes**
  * Regeneration process reports which services failed; UI retains path selection on failures and clears it when none.

* **Tests**
  * Expanded tests covering path association and schedule regeneration outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/transition/pull/1905)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->