### PR TITLE
Remove unused params in CollectionCacheParams

### DIFF
--- a/packages/transition-backend/src/models/capnpCache/default.cache.queries.ts
+++ b/packages/transition-backend/src/models/capnpCache/default.cache.queries.ts
@@ -40,14 +40,11 @@ export interface CollectionCacheParams {
     collection: GenericCollection<any>;
     cachePathDirectory?: string;
     parser?: any;
-    dataSourceId?: string;
     pluralizedCollectionName: string;
-    cachePath?: string;
     CacheCollection: any;
     CollectionClass: any;
     capnpParser: any;
     maxNumberOfObjectsPerFile?: number;
-    emptyDirectory?: boolean;
 }
 
 // TODO: Type the promise
@@ -72,9 +69,6 @@ const collectionToCache = async (params: CollectionCacheParams): Promise<any> =>
             `${prefix}cache/${config.projectShortname}/${cachePathDirectory}`
         );
         bodyData.cache_directory_path = cachePathDirectory;
-    }
-    if (params.emptyDirectory) {
-        fileManager.directoryManager.emptyDirectory(`${prefix}cache/${config.projectShortname}/${cachePathDirectory}`);
     }
 
     // TODO: Callers should send the right type, the first 'if' can totally change the collection type! But make sure all callers are fixed first
@@ -101,9 +95,7 @@ const collectionToCache = async (params: CollectionCacheParams): Promise<any> =>
             cacheName: collectionName,
             bodyData,
             parser,
-            dataSourceId: params.dataSourceId,
-            cachePathDirectory,
-            cachePath
+            cachePathDirectory
         });
     } else {
         const features =
@@ -198,9 +190,6 @@ const collectionFromCache = async (params: CollectionCacheParams): Promise<any> 
     if (cachePathDirectory) {
         bodyData.cache_directory_path = cachePathDirectory;
     }
-    if (params.dataSourceId) {
-        bodyData.data_source_uuid = params.dataSourceId;
-    }
 
     if (Preferences.get('json2Capnp.enabled', false)) {
         if (!collection) {
@@ -217,8 +206,7 @@ const collectionFromCache = async (params: CollectionCacheParams): Promise<any> 
             cacheName: collectionName,
             bodyData,
             parser,
-            cachePathDirectory,
-            cachePath
+            cachePathDirectory
         });
     } else {
         const countFiles = fileManager.fileExists(`${cachePath}.count`)
@@ -288,8 +276,6 @@ export interface ObjectCacheParams {
     cacheName: string;
     cachePathDirectory: string;
     parser?: any;
-    dataSourceId?: string;
-    cachePath?: string;
     CacheObjectClass: any;
     ObjectClass: any;
     capnpParser: any;
@@ -318,9 +304,6 @@ const objectToCache = async (params: ObjectToCacheParams) => {
             `${prefix}cache/${config.projectShortname}/${cachePathDirectory}`
         );
         bodyData.cache_directory_path = cachePathDirectory;
-    }
-    if (params.dataSourceId) {
-        bodyData.data_source_uuid = params.dataSourceId;
     }
 
     if (Preferences.get('json2Capnp.enabled', false)) {
@@ -391,9 +374,6 @@ const objectFromCache = async (params: ObjectFromCacheParams) => {
 
     if (cachePathDirectory) {
         bodyData.cache_directory_path = cachePathDirectory;
-    }
-    if (params.dataSourceId) {
-        bodyData.data_source_uuid = params.dataSourceId;
     }
 
     if (Preferences.get('json2Capnp.enabled', false)) {

--- a/packages/transition-backend/src/services/json2capnp/Json2CapnpBase.ts
+++ b/packages/transition-backend/src/services/json2capnp/Json2CapnpBase.ts
@@ -16,16 +16,13 @@ export interface baseCacheParams {
 export interface collectionCacheParams extends baseCacheParams {
     collection: GenericCollection<any>;
     parser?: any;
-    dataSourceId?: string;
     cachePathDirectory?: string;
-    cachePath?: string;
 }
 
 export interface objectCacheParams extends baseCacheParams {
     object: GenericObject<any>;
     parser?: any;
     cachePathDirectory?: string;
-    cachePath?: string;
 }
 
 export interface objectFromCacheParams extends baseCacheParams {

--- a/packages/transition-backend/src/services/json2capnp/Json2CapnpRust.ts
+++ b/packages/transition-backend/src/services/json2capnp/Json2CapnpRust.ts
@@ -30,10 +30,6 @@ class Json2CapnpRust implements Json2CapnpBase {
             );
         }
 
-        if (args.dataSourceId) {
-            args.bodyData.data_source_uuid = args.dataSourceId;
-        }
-
         return await json2CapnpService.writeCache(args.cacheName, args.bodyData, args.cachePathDirectory);
     }
 

--- a/services/json2capnp/src/main.rs
+++ b/services/json2capnp/src/main.rs
@@ -84,21 +84,12 @@ fn main() {
             "project_cache_directory_path": project_cache_directory_path.to_str().unwrap(),
             "custom_subdirectory_path"    : json!(null),
             "project_shortname"           : json!(project_shortname),
-            "data_source_uuid"            : json!(null)
         });
 
         match &request.get_param("cache_directory_path") {
             Some(cache_directory_path) => {
                 println!("request cache_directory_path {}", cache_directory_path);
                 config["custom_subdirectory_path"] = json!(format!("{}", cache_directory_path));
-            },
-            _ => {}
-        }
-
-        match &request.get_param("data_source_uuid") {
-            Some(data_source_uuid) => {
-                println!("request data_source_uuid {}", data_source_uuid);
-                config["data_source_uuid"] = json!(format!("{}", data_source_uuid));
             },
             _ => {}
         }

--- a/services/json2capnp/src/routers.rs
+++ b/services/json2capnp/src/routers.rs
@@ -69,32 +69,17 @@ pub fn write_collection_route(collection_name: &str, cache_file_name: &str, conf
 
     let json : serde_json::Value   = try_or_400!(rouille::input::json_input(request));
     let json_cache_directory_path  = json.get("cache_directory_path").unwrap_or(&serde_json::Value::Null);
-    let json_data_source_uuid      = json.get("data_source_uuid").unwrap_or(&serde_json::Value::Null);
 
     let cache_directory_path;
 
     if json_cache_directory_path.is_null() // no custom path
     {
-        if !json_data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}", config["project_cache_directory_path"].as_str().unwrap(), json_data_source_uuid.as_str().unwrap());
-        }
-        else
-        {
-            cache_directory_path = format!("{}", config["project_cache_directory_path"].as_str().unwrap());
-        }
+        cache_directory_path = format!("{}", config["project_cache_directory_path"].as_str().unwrap());
         println!("cache_directory_path: {}", cache_directory_path);
     }
     else
     {
-        if !json_data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_data_source_uuid.as_str().unwrap(), json_cache_directory_path.as_str().unwrap(), );
-        }
-        else
-        {
-            cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_cache_directory_path.as_str().unwrap());
-        }
+        cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_cache_directory_path.as_str().unwrap());
         println!("cache_directory_path_custom: {}", cache_directory_path);
     }
 
@@ -138,32 +123,17 @@ pub fn write_collection_route(collection_name: &str, cache_file_name: &str, conf
 pub fn read_collection_route(collection_name: &str, cache_file_name: &str, config: &serde_json::Value, read_fn: &dyn Fn(&mut std::fs::File) -> ::std::result::Result<serde_json::Value, capnp::Error>) -> rouille::Response {
 
     let custom_subdirectory_path  = config.get("custom_subdirectory_path").unwrap_or(&serde_json::Value::Null);
-    let data_source_uuid          = config.get("data_source_uuid").unwrap_or(&serde_json::Value::Null);
 
     let cache_directory_path;
 
     if custom_subdirectory_path.is_null() // no custom path
     {
-        if !data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}", config["project_cache_directory_path"].as_str().unwrap(), data_source_uuid.as_str().unwrap());
-        }
-        else
-        {
-            cache_directory_path = format!("{}", config["project_cache_directory_path"].as_str().unwrap());
-        }
+        cache_directory_path = format!("{}", config["project_cache_directory_path"].as_str().unwrap());
         //println!("cache_directory_path: {}", cache_directory_path);
     }
     else
     {
-        if !data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}/{}", config["project_cache_directory_path"].as_str().unwrap(), data_source_uuid.as_str().unwrap(), custom_subdirectory_path.as_str().unwrap());
-        }
-        else
-        {
-            cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), custom_subdirectory_path.as_str().unwrap());
-        }
+        cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), custom_subdirectory_path.as_str().unwrap());
         //println!("cache_directory_path_custom: {}", cache_directory_path);
     }
 
@@ -208,32 +178,17 @@ pub fn write_object_route(collection_name: &str, subdirectory: &str, config: &se
 
     let json : serde_json::Value   = try_or_400!(rouille::input::json_input(request));
     let json_cache_directory_path  = json.get("cache_directory_path").unwrap_or(&serde_json::Value::Null);
-    let json_data_source_uuid      = json.get("data_source_uuid").unwrap_or(&serde_json::Value::Null);
 
     let cache_directory_path;
 
     if json_cache_directory_path.is_null() // no custom path
     {
-        if !json_data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_data_source_uuid.as_str().unwrap(), subdirectory);
-        }
-        else
-        {
-            cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), subdirectory);
-        }
+        cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), subdirectory);
         //println!("cache_directory_path: {}", cache_directory_path);
     }
     else
     {
-        if !json_data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_data_source_uuid.as_str().unwrap(), json_cache_directory_path.as_str().unwrap(), );
-        }
-        else
-        {
-            cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_cache_directory_path.as_str().unwrap());
-        }
+        cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), json_cache_directory_path.as_str().unwrap());
         //println!("cache_directory_path_custom: {}", cache_directory_path);
     }
 
@@ -257,33 +212,18 @@ pub fn write_object_route(collection_name: &str, subdirectory: &str, config: &se
 pub fn read_object_route(object_name: &str, object_uuid: &String, subdirectory: &str, config: &serde_json::Value, read_fn: &dyn Fn(&String, &str) -> ::std::result::Result<serde_json::Value, capnp::Error>) -> rouille::Response {
 
     let custom_subdirectory_path  = config.get("custom_subdirectory_path").unwrap_or(&serde_json::Value::Null);
-    let data_source_uuid          = config.get("data_source_uuid").unwrap_or(&serde_json::Value::Null);
 
     let cache_directory_path;
 
 
     if custom_subdirectory_path.is_null() // no custom path
     {
-        if !data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}/{}", config["project_cache_directory_path"].as_str().unwrap(), data_source_uuid.as_str().unwrap(), subdirectory);
-        }
-        else
-        {
-            cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), subdirectory);
-        }
+        cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), subdirectory);
         //println!("cache_directory_path: {}", cache_directory_path);
     }
     else
     {
-        if !data_source_uuid.is_null()
-        {
-            cache_directory_path = format!("{}/dataSources/{}/{}", config["project_cache_directory_path"].as_str().unwrap(), data_source_uuid.as_str().unwrap(), custom_subdirectory_path.as_str().unwrap());
-        }
-        else
-        {
-            cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), custom_subdirectory_path.as_str().unwrap());
-        }
+        cache_directory_path = format!("{}/{}", config["project_cache_directory_path"].as_str().unwrap(), custom_subdirectory_path.as_str().unwrap());
         //println!("cache_directory_path_custom: {}", cache_directory_path);
     }
 


### PR DESCRIPTION
cachePath was not used, it was already overriden.
emptyDirectory was not used and it would be better to call the emptyCacheDirectory function. dataSource was not used. Also removed the code from the Json2Capnp daemon side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified cache handling by removing unused data source and cache path configuration options
  * Streamlined cache directory path construction logic across cache operations
  * Reduced parameter complexity in caching service interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->