### PR TITLE
Revert "fix missing translation in checkbox label"

### DIFF
--- a/packages/chaire-lib-frontend/src/components/input/InputCheckbox.tsx
+++ b/packages/chaire-lib-frontend/src/components/input/InputCheckbox.tsx
@@ -238,7 +238,7 @@ class InputCheckboxBooleanInner extends React.Component<InputCheckboxBoolProps> 
     render(): React.ReactNode {
         return (
             <InputCheckbox
-                choices={[{ value: 'true', label: this.props.t(`${this.props.localePrefix}:${this.props.label}`) }]}
+                choices={[{ value: 'true', label: this.props.label }]}
                 localePrefix={this.props.localePrefix}
                 disabled={this.props.disabled}
                 id={this.props.id}


### PR DESCRIPTION
This reverts commit b8af814af070bbc041834cbc066b6fcefaf2ec24.

The label received as props is often already translated by the calling components, translating it once again just puts a translation string in the main locale prefix. It breaks the previous behavior. The label received in params should already be translated. If not set, then we should fallback to a translated "Yes".