### PR TITLE
db: avoid deleting frozen records at the DB level

### DIFF
--- a/packages/chaire-lib-backend/src/models/db/__tests__/dataSources.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/dataSources.db.test.ts
@@ -271,8 +271,9 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
+        // One object is already deleted, only the second one should be deleted
         const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(ids).toEqual(1);
 
     });
 

--- a/packages/chaire-lib-backend/src/models/db/__tests__/zones.db.test.ts
+++ b/packages/chaire-lib-backend/src/models/db/__tests__/zones.db.test.ts
@@ -217,8 +217,9 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
+        // One object is already deleted, only the second one should be deleted
         const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(ids).toEqual(1);
 
     });
 

--- a/packages/chaire-lib-backend/src/models/db/dataSources.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/dataSources.db.queries.ts
@@ -133,7 +133,7 @@ export default {
         return updateMultiple(knex, tableName, undefined, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    deleteMultiple: deleteMultiple.bind(null, knex, tableName, false),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection,

--- a/packages/chaire-lib-backend/src/models/db/dataSources.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/dataSources.db.queries.ts
@@ -132,7 +132,7 @@ export default {
     updateMultiple: (updatedObjects: Partial<DataSourceAttributes>[], returning?: string) => {
         return updateMultiple(knex, tableName, undefined, updatedObjects, { returning });
     },
-    delete: deleteRecord.bind(null, knex, tableName),
+    delete: deleteRecord.bind(null, knex, tableName, false),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName, false),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),

--- a/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
@@ -408,28 +408,40 @@ export const deleteRecord = async (
  *
  * @param knex The database configuration object
  * @param tableName The name of the table on which to execute the operation
+ * @param hasFrozenField Whether the table has an `is_frozen` field that should
+ * prevent deletion of frozen records
  * @param {string[]|number[]} ids An array of record IDs to delete, numeric for
  * tables that have numeric primary keys, or uuid strings for tables that have
  * uuid primary keys
  * @param options Additional options parameter. `transaction` is an optional
  * transaction of which this delete is part of.
- * @returns The array of deleted IDs
+ * @returns The number of deleted records
  */
 export const deleteMultiple = async (
     knex: Knex,
     tableName: string,
+    hasFrozenField: boolean,
     ids: string[] | number[],
     options: {
         transaction?: Knex.Transaction;
     } = {}
-): Promise<string[] | number[]> => {
+): Promise<number> => {
     try {
-        const query = knex(tableName).whereIn('id', ids).del();
+        const query = knex(tableName).whereIn('id', ids);
+        // If the table has an `is_frozen` field, only delete records that are
+        // not frozen, by default the field may be null, so make sure the value
+        // is _not_ true
+        if (hasFrozenField) {
+            query.andWhere((builder) => {
+                builder.where('is_frozen', false).orWhereNull('is_frozen');
+            });
+        }
+        query.del();
         if (options.transaction) {
             query.transacting(options.transaction);
         }
-        await query;
-        return ids;
+        const deletedCount = await query;
+        return typeof deletedCount === 'number' ? deletedCount : ids.length;
     } catch (error) {
         throw new TrError(
             `Cannot delete objects with ids ${ids} from table ${tableName} (knex error: ${error})`,

--- a/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/default.db.queries.ts
@@ -365,21 +365,25 @@ export const updateMultiple = async <T extends Idable, U>(
  *
  * @param knex The database configuration object
  * @param tableName The name of the table on which to execute the operation
+ * @param hasFrozenField Whether the table has an `is_frozen` field that should
+ * prevent deletion of a frozen record
  * @param {string|number} id The ID of the record to delete, numeric for tables
  * that have numeric primary keys, or uuid strings for tables that have uuid
  * primary keys
  * @param options Additional options parameter. `transaction` is an optional
  * transaction of which this delete is part of.
- * @returns The ID of the deleted object
+ * @returns The ID of the deleted object, or undefined if the object was not
+ * deleted because it did not exist or was frozen
  */
 export const deleteRecord = async (
     knex: Knex,
     tableName: string,
+    hasFrozenField: boolean,
     id: string | number,
     options: {
         transaction?: Knex.Transaction;
     } = {}
-) => {
+): Promise<string | number | undefined> => {
     try {
         if (typeof id === 'string' && !uuidValidate(id)) {
             throw new TrError(
@@ -388,12 +392,21 @@ export const deleteRecord = async (
                 'ObjectCannotDeleteBecauseIdIsMissingOrInvalid'
             );
         }
-        const query = knex(tableName).where('id', id).del();
+        const query = knex(tableName).where('id', id);
+        // If the table has an `is_frozen` field, only delete records that are
+        // not frozen, by default the field may be null, so make sure the value
+        // is _not_ true
+        if (hasFrozenField) {
+            query.andWhere((builder) => {
+                builder.where('is_frozen', false).orWhereNull('is_frozen');
+            });
+        }
+        query.del();
         if (options.transaction) {
             query.transacting(options.transaction);
         }
-        await query;
-        return id;
+        const deletedCount = await query;
+        return typeof deletedCount === 'number' && deletedCount === 0 ? undefined : id;
     } catch (error) {
         throw new TrError(
             `Cannot delete object with id ${id} from table ${tableName} (knex error: ${error})`,

--- a/packages/chaire-lib-backend/src/models/db/tokens.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/tokens.db.queries.ts
@@ -145,7 +145,7 @@ export default {
     getById,
     getUserByToken,
     exists: exists.bind(null, knex, tableName),
-    delete: deleteRecord.bind(null, knex, tableName),
+    delete: deleteRecord.bind(null, knex, tableName, false),
     deleteToken,
     cleanExpiredApiTokens,
     defaultTokenLifespanDays

--- a/packages/chaire-lib-backend/src/models/db/zones.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/zones.db.queries.ts
@@ -277,7 +277,7 @@ export default {
     updateMultiple: (updatedObjects: Partial<ZoneAttributes>[], returning?: string) => {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
-    delete: deleteRecord.bind(null, knex, tableName),
+    delete: deleteRecord.bind(null, knex, tableName, false),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName, false),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),

--- a/packages/chaire-lib-backend/src/models/db/zones.db.queries.ts
+++ b/packages/chaire-lib-backend/src/models/db/zones.db.queries.ts
@@ -278,7 +278,7 @@ export default {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    deleteMultiple: deleteMultiple.bind(null, knex, tableName, false),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection,

--- a/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/transitObjects.socketRoutes.test.ts
@@ -92,10 +92,10 @@ describe('Object socket routes', () => {
         test('deleteMultiple when the route exists', (done) => {
             // Create ids to delete and set the mock to return those ids as deleted
             const objectIdsToDelete = [uuidV4(), uuidV4()];
-            (mockDataHandlerWithAllFunctions.deleteMultiple as jest.MockedFunction<Exclude<typeof mockDataHandlerWithAllFunctions.deleteMultiple, undefined>>).mockResolvedValueOnce(Status.createOk({ deletedIds: objectIdsToDelete }));
-            socketStub.emit('transitObjects.deleteMultiple', objectIdsToDelete, (status: Status.Status<{ deletedIds: string[] }>) => {
+            (mockDataHandlerWithAllFunctions.deleteMultiple as jest.MockedFunction<Exclude<typeof mockDataHandlerWithAllFunctions.deleteMultiple, undefined>>).mockResolvedValueOnce(Status.createOk({ deletedCount: objectIdsToDelete.length }));
+            socketStub.emit('transitObjects.deleteMultiple', objectIdsToDelete, (status: Status.Status<{ deletedCount: number }>) => {
                 expect(Status.isStatusOk(status)).toEqual(true);
-                expect(Status.unwrap(status)).toEqual({ deletedIds: objectIdsToDelete});
+                expect(Status.unwrap(status)).toEqual({ deletedCount: objectIdsToDelete.length });
                 expect(mockDataHandlerWithAllFunctions.deleteMultiple).toHaveBeenLastCalledWith(socketStub, objectIdsToDelete);
                 done();
             });

--- a/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
@@ -343,6 +343,9 @@ describe(`${objectName}`, function() {
 
         const collectionBefore = await dbQueries.collection();
 
+        const id = await dbQueries.delete(frozenObjectAttributes.id)
+        expect(id).toBeUndefined();
+
         const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
         expect(deletedCount).toEqual(0);
 

--- a/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/TransitPath.db.test.ts
@@ -316,9 +316,39 @@ describe(`${objectName}`, function() {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One is already deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
+    });
+
+    test('should not delete frozen objects from database', async() => {
+        // Create 2 new frozen objects
+        const frozenObjectAttributes = {
+            ...newObjectAttributes,
+            id: uuidV4(),
+            internal_id: 'Frozen path 1',
+            is_frozen: true
+        };
+        const frozenObjectAttributes2 = {
+            ...newObjectAttributes2,
+            id: uuidV4(),
+            internal_id: 'Frozen path 2',
+            is_frozen: true
+        };
+        const frozenObject1 = new ObjectClass(frozenObjectAttributes, true);
+        const frozenObject2 = new ObjectClass(frozenObjectAttributes2, true);
+        await dbQueries.create(frozenObject1.attributes);
+        await dbQueries.create(frozenObject2.attributes);
+
+        const collectionBefore = await dbQueries.collection();
+
+        const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
+        expect(deletedCount).toEqual(0);
+
+        // Make sure paths are still in database
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(collectionBefore.length);
     });
 
 });

--- a/packages/transition-backend/src/models/db/__tests__/odPairs.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/odPairs.db.test.ts
@@ -212,8 +212,9 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One is already deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
     });
 

--- a/packages/transition-backend/src/models/db/__tests__/places.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/places.db.test.ts
@@ -349,8 +349,16 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One has just been deleted, the other is frozen, so no object should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(0);
+
+        // Update the second object to not be frozen anymore, so it can be deleted in the next step
+        const idUpdated = await dbQueries.update(newObjectAttributes2.id, { is_frozen: false });
+        expect(idUpdated).toBe(newObjectAttributes2.id);
+        // Second object should be deleted this time
+        const deletedCountAfterUnfreeze = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCountAfterUnfreeze).toEqual(1);
 
     });
 

--- a/packages/transition-backend/src/models/db/__tests__/simulationRuns.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/simulationRuns.db.test.ts
@@ -252,8 +252,9 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One has just been deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
     });
 
@@ -417,8 +418,8 @@ describe(`${objectName}`, () => {
         await dbQueries.saveSimulationRunScenarios(newObjectAttributes2.id, [scenarioAttributes1.id]);
 
         // Delete multiple record, with cascade
-        const deletedIds = await dbQueries.deleteMultiple([newObjectAttributes2.id, newObjectAttributes.id], true)
-        expect(deletedIds).toEqual([newObjectAttributes2.id, newObjectAttributes.id]);
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes2.id, newObjectAttributes.id], true)
+        expect(deletedCount).toEqual(2);
 
         const scenarioForRun1 = await dbQueries.getScenarioIdsForRun(newObjectAttributes.id);
         expect(scenarioForRun1).toEqual([]);
@@ -447,8 +448,8 @@ describe(`${objectName}`, () => {
         await dbQueries.saveSimulationRunScenarios(newObjectAttributes2.id, [scenarioAttributes1.id]);
 
         // Delete multiple record, without cascade
-        const deletedIds = await dbQueries.deleteMultiple([newObjectAttributes2.id, newObjectAttributes.id], false)
-        expect(deletedIds).toEqual([newObjectAttributes2.id, newObjectAttributes.id]);
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes2.id, newObjectAttributes.id], false)
+        expect(deletedCount).toEqual(2);
 
         const scenarioForRun1 = await dbQueries.getScenarioIdsForRun(newObjectAttributes.id);
         expect(scenarioForRun1).toEqual([]);

--- a/packages/transition-backend/src/models/db/__tests__/simulations.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/simulations.db.test.ts
@@ -37,7 +37,7 @@ const newObjectAttributes2= {
     name: 'Simulation2',
     description: 'descS2',
     color: '#ff0000',
-    is_frozen: true
+    is_frozen: false
 };
 
 const updatedAttributes = {
@@ -197,8 +197,9 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One has just been deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
     });
 

--- a/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
@@ -272,6 +272,9 @@ describe(`${objectName}`, () => {
 
         const collectionBefore = await dbQueries.collection();
 
+        const id = await dbQueries.delete(frozenObjectAttributes.id)
+        expect(id).toBeUndefined();
+
         const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
         expect(deletedCount).toEqual(0);
 

--- a/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitAgencies.db.test.ts
@@ -212,8 +212,9 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One has just been deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
     });
 
@@ -246,6 +247,37 @@ describe(`${objectName}`, () => {
         const _collection = await dbQueries.collection();
         expect(_collection.length).toEqual(2);
 
+    });
+
+    test('should not delete frozen objects from database', async() => {
+        // Create 2 new frozen objects
+        const frozenObjectAttributes = {
+            ...newObjectAttributes,
+            id: uuidV4(),
+            acronym: 'FROZEN1',
+            internal_id: 'Frozen agency 1',
+            is_frozen: true
+        };
+        const frozenObjectAttributes2 = {
+            ...newObjectAttributes2,
+            id: uuidV4(),
+            acronym: 'FROZEN2',
+            internal_id: 'Frozen agency 2',
+            is_frozen: true
+        };
+        const frozenObject1 = new ObjectClass(frozenObjectAttributes, true);
+        const frozenObject2 = new ObjectClass(frozenObjectAttributes2, true);
+        await dbQueries.create(frozenObject1.attributes);
+        await dbQueries.create(frozenObject2.attributes);
+
+        const collectionBefore = await dbQueries.collection();
+
+        const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
+        expect(deletedCount).toEqual(0);
+
+        // Make sure agencies are still in database
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(collectionBefore.length);
     });
 
 });

--- a/packages/transition-backend/src/models/db/__tests__/transitLines.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitLines.db.test.ts
@@ -332,9 +332,39 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributesWithSchedule.id)
         expect(id).toBe(newObjectAttributesWithSchedule.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributesWithSchedule.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributesWithSchedule.id, newObjectAttributes2.id]);
+        // One is already deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributesWithSchedule.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
+    });
+
+    test('should not delete frozen objects from database', async() => {
+        // Create 2 new frozen objects
+        const frozenObjectAttributes = {
+            ...newObjectAttributesWithSchedule,
+            id: uuidV4(),
+            internal_id: 'Frozen line 1',
+            is_frozen: true
+        };
+        const frozenObjectAttributes2 = {
+            ...newObjectAttributes2,
+            id: uuidV4(),
+            internal_id: 'Frozen line 2',
+            is_frozen: true
+        };
+        const frozenObject1 = new ObjectClass(frozenObjectAttributes, true);
+        const frozenObject2 = new ObjectClass(frozenObjectAttributes2, true);
+        await dbQueries.create(frozenObject1.attributes);
+        await dbQueries.create(frozenObject2.attributes);
+
+        const collectionBefore = await dbQueries.collection();
+
+        const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
+        expect(deletedCount).toEqual(0);
+
+        // Make sure lines are still in database
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(collectionBefore.length);
     });
 
 });

--- a/packages/transition-backend/src/models/db/__tests__/transitLines.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitLines.db.test.ts
@@ -359,6 +359,9 @@ describe(`${objectName}`, () => {
 
         const collectionBefore = await dbQueries.collection();
 
+        const id = await dbQueries.delete(frozenObjectAttributes.id)
+        expect(id).toBeUndefined();
+
         const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
         expect(deletedCount).toEqual(0);
 

--- a/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
@@ -256,10 +256,11 @@ describe(`${objectName}`, () => {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One is already deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
-        // All services should still be there
+        // All services should still be there, as they are not recursively deleted with scenarios
         const serviceCollection = await servicesDbQueries.collection();
         expect(serviceCollection.length).toEqual(3);
 
@@ -325,10 +326,56 @@ describe(`${objectName}`, () => {
         expect(serviceCollection.length).toEqual(1);
         expect(serviceCollection[0].id).toEqual(serviceId2);
 
-        // Delete multiple with cascade
-        await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id], true);
+        // Delete multiple with cascade, only service 2 reamains
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id], true);
+        expect(deletedCount).toEqual(1);
         const serviceCollection2 = await servicesDbQueries.collection();
         expect(serviceCollection2.length).toEqual(0);
+    });
+
+    test('Do not delete frozen scenarios', async() => {
+        // Put services in the database
+        await servicesDbQueries.createMultiple([{
+            id: serviceId1,
+            name: 'Service test 1',
+            ...defaultServiceAttribs
+        }, {
+            id: serviceId2,
+            name: 'Service test 2',
+            ...defaultServiceAttribs
+        }, {
+            id: serviceId3,
+            name: 'Service test 3',
+            ...defaultServiceAttribs
+        }]);
+
+        // Create a frozen scenario and a non frozen one in the database, services should not be deleted for frozen scenarios
+        await dbQueries.createMultiple([{
+            ...newObjectAttributes,
+            services: [serviceId1, serviceId3],
+            is_frozen: true
+        }, {
+            ...newObjectAttributes2,
+            services: [serviceId2],
+            is_frozen: false
+        }])
+        
+        // Delete multiple with cascade, only the non frozen should be deleted
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id], true);
+        expect(deletedCount).toEqual(1);
+
+        // First scenario should not have been deleted
+        const scenarioCollection = await dbQueries.collection();
+        expect(scenarioCollection.length).toEqual(1);
+        expect(scenarioCollection[0].id).toEqual(newObjectAttributes.id);
+
+        // serviceId1 and serviceId3 should not have been deleted since they are used by the frozen scenario, but serviceId2 should have been deleted
+        const serviceCollection = await servicesDbQueries.collection();
+        expect(serviceCollection.length).toEqual(2);
+        const serviceIds = serviceCollection.map(service => service.id);
+        expect(serviceIds).toContain(serviceId1);
+        expect(serviceIds).toContain(serviceId3);
+        expect(serviceIds).not.toContain(serviceId2);
     });
 
 });

--- a/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitScenarios.db.test.ts
@@ -358,7 +358,11 @@ describe(`${objectName}`, () => {
             ...newObjectAttributes2,
             services: [serviceId2],
             is_frozen: false
-        }])
+        }]);
+
+        // Try to delete frozen scenario, it should not be deleted
+        const id = await dbQueries.delete(newObjectAttributes.id, true);
+        expect(id).toBeUndefined();
         
         // Delete multiple with cascade, only the non frozen should be deleted
         const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id], true);

--- a/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
@@ -389,6 +389,9 @@ describe(`${objectName}`, function() {
 
         const collectionBefore = await dbQueries.collection();
 
+        const id = await dbQueries.delete(frozenObjectAttributes.id);
+        expect(id).toBeUndefined();
+
         const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
         expect(deletedCount).toEqual(0);
 

--- a/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
+++ b/packages/transition-backend/src/models/db/__tests__/transitServices.db.test.ts
@@ -307,8 +307,9 @@ describe(`${objectName}`, function() {
         const id = await dbQueries.delete(newObjectAttributes.id)
         expect(id).toBe(newObjectAttributes.id);
 
-        const ids = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
-        expect(ids).toEqual([newObjectAttributes.id, newObjectAttributes2.id]);
+        // One is already deleted, only one should be deleted here
+        const deletedCount = await dbQueries.deleteMultiple([newObjectAttributes.id, newObjectAttributes2.id]);
+        expect(deletedCount).toEqual(1);
 
     });
 
@@ -365,6 +366,35 @@ describe(`${objectName}`, function() {
         const prefix = 'Service ';
         const result = await dbQueries.getServiceNamesStartingWith(prefix);
         expect(result).toEqual(['Service test', 'Service test 2']);
+    });
+
+    test('should not delete frozen objects from database', async() => {
+        // Create 2 new frozen objects
+        const frozenObjectAttributes = {
+            ...newObjectAttributes,
+            id: uuidV4(),
+            internal_id: 'Frozen service 1',
+            is_frozen: true
+        };
+        const frozenObjectAttributes2 = {
+            ...newObjectAttributes2,
+            id: uuidV4(),
+            internal_id: 'Frozen service 2',
+            is_frozen: true
+        };
+        const frozenObject1 = new ObjectClass(frozenObjectAttributes, true);
+        const frozenObject2 = new ObjectClass(frozenObjectAttributes2, true);
+        await dbQueries.create(frozenObject1.attributes);
+        await dbQueries.create(frozenObject2.attributes);
+
+        const collectionBefore = await dbQueries.collection();
+
+        const deletedCount = await dbQueries.deleteMultiple([frozenObjectAttributes.id, frozenObjectAttributes2.id]);
+        expect(deletedCount).toEqual(0);
+
+        // Make sure lines are still in database
+        const collection = await dbQueries.collection();
+        expect(collection.length).toEqual(collectionBefore.length);
     });
 
 });

--- a/packages/transition-backend/src/models/db/odPairs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/odPairs.db.queries.ts
@@ -162,7 +162,7 @@ export default {
     updateMultiple: (updatedObjects: Partial<BaseOdTripAttributes>[], returning?: string) => {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
-    delete: deleteRecord.bind(null, knex, tableName),
+    delete: deleteRecord.bind(null, knex, tableName, false),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName, false),
     deleteForDataSourceId: deleteForDataSourceId.bind(null, knex, tableName),
     truncate: truncate.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/odPairs.db.queries.ts
+++ b/packages/transition-backend/src/models/db/odPairs.db.queries.ts
@@ -163,7 +163,7 @@ export default {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    deleteMultiple: deleteMultiple.bind(null, knex, tableName, false),
     deleteForDataSourceId: deleteForDataSourceId.bind(null, knex, tableName),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),

--- a/packages/transition-backend/src/models/db/places.db.queries.ts
+++ b/packages/transition-backend/src/models/db/places.db.queries.ts
@@ -275,7 +275,7 @@ export default {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    deleteMultiple: deleteMultiple.bind(null, knex, tableName, true),
     deleteForDataSourceId: deleteForDataSourceId.bind(null, knex, tableName),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),

--- a/packages/transition-backend/src/models/db/places.db.queries.ts
+++ b/packages/transition-backend/src/models/db/places.db.queries.ts
@@ -274,7 +274,7 @@ export default {
     updateMultiple: (updatedObjects: Partial<PlaceAttributes>[], returning?: string) => {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
-    delete: deleteRecord.bind(null, knex, tableName),
+    delete: deleteRecord.bind(null, knex, tableName, true),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName, true),
     deleteForDataSourceId: deleteForDataSourceId.bind(null, knex, tableName),
     truncate: truncate.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
@@ -243,7 +243,7 @@ const deleteRun = async (id: string, cascade = false) => {
     if (cascade) {
         await cascadeDeleteScenario(id);
     }
-    return deleteRecord(knex, tableName, id);
+    return deleteRecord(knex, tableName, false, id);
 };
 
 const deleteMultipleRun = async (ids: string[], cascade = false) => {

--- a/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulationRuns.db.queries.ts
@@ -253,7 +253,7 @@ const deleteMultipleRun = async (ids: string[], cascade = false) => {
             await cascadeDeleteScenario(ids[i]);
         }
     }
-    return deleteMultiple(knex, tableName, ids);
+    return deleteMultiple(knex, tableName, false, ids);
 };
 
 export default {

--- a/packages/transition-backend/src/models/db/simulations.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulations.db.queries.ts
@@ -129,7 +129,7 @@ export default {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
     delete: deleteRecord.bind(null, knex, tableName),
-    deleteMultiple: deleteMultiple.bind(null, knex, tableName),
+    deleteMultiple: deleteMultiple.bind(null, knex, tableName, true),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection

--- a/packages/transition-backend/src/models/db/simulations.db.queries.ts
+++ b/packages/transition-backend/src/models/db/simulations.db.queries.ts
@@ -128,7 +128,7 @@ export default {
     updateMultiple: (updatedObjects: Partial<SimulationAttributes>[], returning?: string) => {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, { returning });
     },
-    delete: deleteRecord.bind(null, knex, tableName),
+    delete: deleteRecord.bind(null, knex, tableName, true),
     deleteMultiple: deleteMultiple.bind(null, knex, tableName, true),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),

--- a/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
@@ -86,8 +86,8 @@ export default {
     ) => updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
     delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
         deleteRecord(knex, tableName, id, options),
-    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
-        deleteMultiple(knex, tableName, ids, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
+        deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection

--- a/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitAgencies.db.queries.ts
@@ -84,8 +84,8 @@ export default {
         updatedObjects: Partial<AgencyAttributes>[],
         options?: Parameters<typeof updateMultiple>[4]
     ) => updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
-    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
-        deleteRecord(knex, tableName, id, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[4]) =>
+        deleteRecord(knex, tableName, true, id, options),
     deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
         deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitLines.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitLines.db.queries.ts
@@ -179,8 +179,8 @@ export default {
     // TODO Update multiple will have to handle schedules too or do we suppose it's only the line attributes?
     updateMultiple: async (updatedObjects: Partial<LineAttributes>[], options?: Parameters<typeof updateMultiple>[4]) =>
         updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
-    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
-        deleteRecord(knex, tableName, id, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[4]) =>
+        deleteRecord(knex, tableName, true, id, options),
     deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
         deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitLines.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitLines.db.queries.ts
@@ -181,8 +181,8 @@ export default {
         updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
     delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
         deleteRecord(knex, tableName, id, options),
-    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
-        deleteMultiple(knex, tableName, ids, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
+        deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     // TODO Should collection also return the schedules?

--- a/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
@@ -244,8 +244,8 @@ export default {
         updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
     delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
         deleteRecord(knex, tableName, id, options),
-    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
-        deleteMultiple(knex, tableName, ids, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
+        deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection,

--- a/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitPaths.db.queries.ts
@@ -242,8 +242,8 @@ export default {
         update(knex, tableName, attributesCleaner, id, updatedObject, options),
     updateMultiple: async (updatedObjects: Partial<PathAttributes>[], options?: Parameters<typeof updateMultiple>[4]) =>
         updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options),
-    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
-        deleteRecord(knex, tableName, id, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[4]) =>
+        deleteRecord(knex, tableName, true, id, options),
     deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
         deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitScenarios.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitScenarios.db.queries.ts
@@ -273,7 +273,10 @@ const _cascadeDeleteServices = async (scenarioId: string, { transaction }: { tra
     const innerScenarioServiceQuery = knex
         .select('service_id')
         .from(`${scenarioServiceTableName}`)
-        .where('scenario_id', scenarioId);
+        // Avoid deleting services if the scenario is frozen
+        .innerJoin(`${tableName} as sc`, 'sc.id', `${scenarioServiceTableName}.scenario_id`)
+        .where('scenario_id', scenarioId)
+        .andWhereNot('sc.is_frozen', true);
     const countServiceQuery = knex
         .select('service_id')
         .from(`${scenarioServiceTableName}`)
@@ -312,7 +315,7 @@ const deleteScenario = async (
 const deleteMultipleScenarios = async (
     ids: string[],
     cascade = false,
-    { transaction, ...options }: Parameters<typeof deleteMultiple>[3] = {}
+    { transaction, ...options }: Parameters<typeof deleteMultiple>[4] = {}
 ) => {
     try {
         // Nested function to require a transaction around the deletes
@@ -323,7 +326,7 @@ const deleteMultipleScenarios = async (
                     await _cascadeDeleteServices(ids[i], { transaction: trx });
                 }
             }
-            return deleteMultiple(knex, tableName, ids, { transaction: trx, ...options });
+            return deleteMultiple(knex, tableName, true, ids, { transaction: trx, ...options });
         };
         // Make sure the deletes are done in a transaction, use the one in the options if available
         return await (transaction ? deleteWithTransaction(transaction) : knex.transaction(deleteWithTransaction));

--- a/packages/transition-backend/src/models/db/transitScenarios.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitScenarios.db.queries.ts
@@ -291,7 +291,7 @@ const _cascadeDeleteServices = async (scenarioId: string, { transaction }: { tra
 const deleteScenario = async (
     id: string,
     cascade = false,
-    { transaction, ...options }: Parameters<typeof deleteRecord>[3] = {}
+    { transaction, ...options }: Parameters<typeof deleteRecord>[4] = {}
 ) => {
     try {
         // Nested function to require a transaction around the delete
@@ -299,7 +299,7 @@ const deleteScenario = async (
             if (cascade) {
                 await _cascadeDeleteServices(id, { transaction: trx });
             }
-            return deleteRecord(knex, tableName, id, { transaction: trx, ...options });
+            return deleteRecord(knex, tableName, true, id, { transaction: trx, ...options });
         };
         // Make sure the delete is done in a transaction, use the one in the options if available
         return await (transaction ? deleteWithTransaction(transaction) : knex.transaction(deleteWithTransaction));

--- a/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
@@ -508,7 +508,7 @@ const _deleteSchedulePeriodTrips = async function (ids: number[], options: { tra
     return await deleteMultiple(knex, tripTable, false, ids, options);
 };
 
-const deleteScheduleData = async function (id: number | string, options: Parameters<typeof deleteRecord>[3] = {}) {
+const deleteScheduleData = async function (id: number | string, options: Parameters<typeof deleteRecord>[4] = {}) {
     // FIXME The main workflow still receives the uuid of the schedule to delete instead of the numeric id, so have to handle both
     if (typeof id === 'string') {
         const query = knex(scheduleTable).where('uuid', id).del();
@@ -517,7 +517,7 @@ const deleteScheduleData = async function (id: number | string, options: Paramet
         }
         return await query;
     }
-    return await deleteRecord(knex, scheduleTable, id, options);
+    return await deleteRecord(knex, scheduleTable, false, id, options);
 };
 
 const getCollectionSubquery = (lineIds: string[] = []) => {

--- a/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitSchedules.db.queries.ts
@@ -500,12 +500,12 @@ const readForLine = async function (lineId: string) {
 
 // Private function to delete periods by ids, within a transaction
 const _deleteSchedulePeriods = async function (ids: number[], options: { transaction: Knex.Transaction }) {
-    return await deleteMultiple(knex, periodTable, ids, options);
+    return await deleteMultiple(knex, periodTable, false, ids, options);
 };
 
 // Private function to delete trips by id, within a transaction
 const _deleteSchedulePeriodTrips = async function (ids: number[], options: { transaction: Knex.Transaction }) {
-    return await deleteMultiple(knex, tripTable, ids, options);
+    return await deleteMultiple(knex, tripTable, false, ids, options);
 };
 
 const deleteScheduleData = async function (id: number | string, options: Parameters<typeof deleteRecord>[3] = {}) {

--- a/packages/transition-backend/src/models/db/transitServices.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitServices.db.queries.ts
@@ -158,8 +158,8 @@ export default {
     updateMultiple: (updatedObjects: Partial<ServiceAttributes>[], options?: Parameters<typeof updateMultiple>[4]) => {
         return updateMultiple(knex, tableName, attributesCleaner, updatedObjects, options);
     },
-    delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
-        deleteRecord(knex, tableName, id, options),
+    delete: async (id: string, options?: Parameters<typeof deleteRecord>[4]) =>
+        deleteRecord(knex, tableName, true, id, options),
     deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
         deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),

--- a/packages/transition-backend/src/models/db/transitServices.db.queries.ts
+++ b/packages/transition-backend/src/models/db/transitServices.db.queries.ts
@@ -160,8 +160,8 @@ export default {
     },
     delete: async (id: string, options?: Parameters<typeof deleteRecord>[3]) =>
         deleteRecord(knex, tableName, id, options),
-    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[3]) =>
-        deleteMultiple(knex, tableName, ids, options),
+    deleteMultiple: async (ids: string[], options?: Parameters<typeof deleteMultiple>[4]) =>
+        deleteMultiple(knex, tableName, true, ids, options),
     truncate: truncate.bind(null, knex, tableName),
     destroy: destroy.bind(null, knex),
     collection,

--- a/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
+++ b/packages/transition-backend/src/services/transitObjects/TransitObjectsDataHandler.ts
@@ -46,7 +46,7 @@ export interface TransitObjectDataHandler {
     update: (socket: EventEmitter, id: string, attributes: GenericAttributes) => Promise<Record<string, any>>;
     delete: (socket: EventEmitter, id: string, customCachePath: string | undefined) => Promise<Record<string, any>>;
     // Optional function to delete multiple objects. Only objects supporting it will have this function
-    deleteMultiple?: (socket: EventEmitter, ids: string[]) => Promise<Status.Status<{ deletedIds: string[] }>>;
+    deleteMultiple?: (socket: EventEmitter, ids: string[]) => Promise<Status.Status<{ deletedCount: number }>>;
     geojsonCollection?: (
         params?
     ) => Promise<
@@ -300,13 +300,13 @@ function createDataHandlers(): Record<string, TransitObjectDataHandler> {
                             'DeleteMultipleWithObjectCacheNotSupported'
                         );
                     }
-                    const deletedIds = await transitClassConfig.deleteMultiple(ids);
-                    if (deletedIds.length > 0 && isSocketIo(socket)) {
+                    const deletedCount = await transitClassConfig.deleteMultiple(ids);
+                    if (deletedCount > 0 && isSocketIo(socket)) {
                         // Objects were deleted, notify clients
                         socket.broadcast.emit('data.updated');
                         socket.emit('cache.dirty');
                     }
-                    return Status.createOk({ deletedIds });
+                    return Status.createOk({ deletedCount });
                 } catch (error) {
                     console.error('Error deleting multiple objects: ', error);
                     return Status.createError(

--- a/packages/transition-backend/src/services/transitObjects/__tests__/TransitObjectDataHandler.test.ts
+++ b/packages/transition-backend/src/services/transitObjects/__tests__/TransitObjectDataHandler.test.ts
@@ -68,40 +68,40 @@ describe('TransitObjectDataHandler scenarios', () => {
 
         test('returns ok and emits socket notifications when some objects were deleted', async () => {
             const idsToDelete = ['scenario-1', 'scenario-2'];
-            mockedScenariosDeleteMultiple.mockResolvedValueOnce(idsToDelete);
+            mockedScenariosDeleteMultiple.mockResolvedValueOnce(idsToDelete.length);
             mockedIsSocketIo.mockReturnValue(true);
 
             const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, idsToDelete);
 
             expect(mockedScenariosDeleteMultiple).toHaveBeenCalledWith(idsToDelete);
             expect(Status.isStatusOk(status)).toEqual(true);
-            expect(Status.unwrap(status)).toEqual({ deletedIds: idsToDelete });
+            expect(Status.unwrap(status)).toEqual({ deletedCount: idsToDelete.length });
             expect((socketStub as any).broadcast.emit).toHaveBeenCalledWith('data.updated');
             expect((socketStub as any).emit).toHaveBeenCalledWith('cache.dirty');
         });
 
         test('returns ok and does not emit when socket is not Socket.IO', async () => {
             const idsToDelete = ['scenario-1', 'scenario-2'];
-            mockedScenariosDeleteMultiple.mockResolvedValueOnce(idsToDelete);
+            mockedScenariosDeleteMultiple.mockResolvedValueOnce(idsToDelete.length);
             mockedIsSocketIo.mockReturnValue(false);
 
             const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, idsToDelete);
 
             expect(mockedScenariosDeleteMultiple).toHaveBeenCalledWith(idsToDelete);
             expect(Status.isStatusOk(status)).toEqual(true);
-            expect(Status.unwrap(status)).toEqual({ deletedIds: idsToDelete });
+            expect(Status.unwrap(status)).toEqual({ deletedCount: idsToDelete.length });
             expect((socketStub as any).broadcast.emit).not.toHaveBeenCalled();
             expect((socketStub as any).emit).not.toHaveBeenCalled();
         });
 
         test('does not emit notifications when no object was deleted', async () => {
-            mockedScenariosDeleteMultiple.mockResolvedValueOnce([]);
+            mockedScenariosDeleteMultiple.mockResolvedValueOnce(0);
             mockedIsSocketIo.mockReturnValue(true);
 
             const status = await transitObjectDataHandlers.scenarios.deleteMultiple!(socketStub, ['scenario-1']);
 
             expect(Status.isStatusOk(status)).toEqual(true);
-            expect(Status.unwrap(status)).toEqual({ deletedIds: [] });
+            expect(Status.unwrap(status)).toEqual({ deletedCount: 0 });
             expect((socketStub as any).broadcast.emit).not.toHaveBeenCalled();
             expect((socketStub as any).emit).not.toHaveBeenCalled();
         });

--- a/packages/transition-common/src/services/scenario/ScenarioCollection.ts
+++ b/packages/transition-common/src/services/scenario/ScenarioCollection.ts
@@ -55,16 +55,16 @@ class ScenarioCollection extends GenericObjectCollection<Scenario> implements Pr
         });
     }
 
-    async deleteByIds(ids: string[], socket): Promise<string[]> {
+    async deleteByIds(ids: string[], socket): Promise<number> {
         // FIXME This should only be called by the frontend as it calls the
         // socket route. Our collections currently all use methods that call the
         // backend through socket routes (saves and loads), so it makes sense to
         // keep it here for now, but eventually, they should all be moved
         // elsewhere, in frontend.
         return new Promise((resolve, reject) => {
-            socket.emit('transitScenarios.deleteMultiple', ids, (response: Status.Status<{ deletedIds: string[] }>) => {
+            socket.emit('transitScenarios.deleteMultiple', ids, (response: Status.Status<{ deletedCount: number }>) => {
                 if (Status.isStatusOk(response)) {
-                    resolve(Status.unwrap(response).deletedIds);
+                    resolve(Status.unwrap(response).deletedCount);
                 } else {
                     reject(response.error);
                 }

--- a/packages/transition-common/src/services/scenario/__tests__/ScenarioCollection.test.ts
+++ b/packages/transition-common/src/services/scenario/__tests__/ScenarioCollection.test.ts
@@ -129,7 +129,7 @@ test('should construct scenario collection with or without features', function()
 });
 
 describe('deleteByIds', () => {
-    const deleteMultipleSocketMock = jest.fn().mockImplementation(async (deletedIds, callback) => callback(Status.createOk({ deletedIds })));
+    const deleteMultipleSocketMock = jest.fn().mockImplementation(async (deletedIds, callback) => callback(Status.createOk({ deletedCount: deletedIds.length })));
 
     beforeAll(() => {
         socketMock.on('transitScenarios.deleteMultiple', deleteMultipleSocketMock);
@@ -148,9 +148,9 @@ describe('deleteByIds', () => {
         const collection = new ScenarioCollection([], {}, eventManager);
         
         const serviceIds = [uuidV4(), uuidV4(), uuidV4()];
-        const deletedIds = await collection.deleteByIds(serviceIds, socketMock);
+        const deletedCount = await collection.deleteByIds(serviceIds, socketMock);
 
-        expect(deletedIds).toEqual(serviceIds);
+        expect(deletedCount).toEqual(serviceIds.length);
         expect(deleteMultipleSocketMock).toHaveBeenCalledTimes(1);
         expect(deleteMultipleSocketMock).toHaveBeenCalledWith(serviceIds, expect.any(Function));
     });
@@ -160,12 +160,12 @@ describe('deleteByIds', () => {
         const collection = new ScenarioCollection([], {}, eventManager);
 
         // Return a successful response with only the first service id deleted
-        deleteMultipleSocketMock.mockImplementationOnce(async (ids, callback) => callback(Status.createOk({ deletedIds: [ids[0]] })));
+        deleteMultipleSocketMock.mockImplementationOnce(async (ids, callback) => callback(Status.createOk({ deletedCount: 1 })));
         
         const serviceIds = [uuidV4(), uuidV4(), uuidV4()];
-        const deletedIds = await collection.deleteByIds(serviceIds, socketMock);
+        const deletedCount = await collection.deleteByIds(serviceIds, socketMock);
 
-        expect(deletedIds).toEqual([serviceIds[0]]);
+        expect(deletedCount).toEqual(1);
         expect(deleteMultipleSocketMock).toHaveBeenCalledTimes(1);
         expect(deleteMultipleSocketMock).toHaveBeenCalledWith(serviceIds, expect.any(Function));
     });


### PR DESCRIPTION
Theses commits are for the `deleteMultiple` and `delete` default DB functions respectively. It adds a parameter `hasFrozenField` to the delete queries, that are bound by the queries that extend it to either `true` or `false` depending if the corresponding table has a field named `is_frozen`. This will result in frozen records to be impossible to delete from the database. The objects can be unfrozen, then deleted though.

There is currently no parameter to override this (ie to delete frozen records). If we need/want that eventually, we can add an option parameter to the queries, or use different queries, to make sure the intent is correct.

Note that, currently, the frontend already prevents from deleting frozen records: the delete button of frozen objects is disabled and the services and scenarios list, that can be multi-selected and deleted do not allow to select the frozen objects.

But this could change if/when we add other possibilities than delete for mult-selects, in which case we'll want to select frozen records and handle them according to the task, or just for failsafe since many code paths may eventually lead to requesting a deletion. We cannot trust that all UI actions will handle this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frozen items are protected from deletion in the system.
  * Bulk delete operations now report the number of items deleted (deletedCount).

* **Bug Fixes**
  * Deletion flows and notifications updated to respect frozen protection and accurately reflect deletion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->