### PR TITLE
network design: save best candidates' simulation results in the main job

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -1210,12 +1210,11 @@
             }
         },
         "evolutionaryTransitNetworkDesign": {
-            "files": {
-                "transitDemand": "Demand file: {{filename}}",
-                "nodeWeight": "Node weights file: {{filename}}",
-                "simulationResults": "Simulation results for candidates",
-                "linesResult": "Candidate lines"
-            }
+            "files_linesResult": "Candidate lines",
+            "files_simulationResults": "Simulation results for candidates",
+            "files_transitDemand": "Demand file: {{filename}}",
+            "files_nodeWeight": "Node weights file: {{filename}}",
+            "files": "Simulation result file: {{filename}}"
         }
     },
     "batchCalculation": {

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -1221,12 +1221,11 @@
             }
         },
         "evolutionaryTransitNetworkDesign": {
-            "files": {
-                "transitDemand": "Fichier de demande: {{filename}}",
-                "nodeWeight": "Fichier de poids des nœuds: {{filename}}",
-                "simulationResults": "Résultats de simulation par candidats",
-                "linesResult": "Lignes candidates"
-            }
+            "files_linesResult": "Lignes candidates",
+            "files_simulationResults": "Résultats de simulation par candidats",
+            "files_transitDemand": "Fichier de demande: {{filename}}",
+            "files_nodeWeight": "Fichier de poids des nœuds: {{filename}}",
+            "files": "Fichier de résultat de simulation: {{filename}}"
         }
     },
     "batchCalculation": {

--- a/packages/transition-backend/src/api/__tests__/jobs.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/jobs.socketRoutes.test.ts
@@ -122,12 +122,12 @@ describe('Job files', () => {
                 testFile: { 
                     url: `/job/${jobAttributes.id}/file.csv`, 
                     downloadName: `file_20220808_132134.csv`,
-                    title: { text: `transit:jobs:test:files:testFile`, fileName: `file.csv` }
+                    title: { text: `transit:jobs:test:files`, params: { filename: `file.csv`, context: 'testFile' } }
                 }, 
                 testFile2: { 
                     url: `/job/${jobAttributes.id}/noExtension`, 
                     downloadName: `noExtension_20220808_132134`,
-                    title: { text: `transit:jobs:test:files:testFile2`, fileName: `noExtension` }
+                    title: { text: `transit:jobs:test:files`, params: { filename: `noExtension`, context: 'testFile2' } }
                 } 
             });
             expect(mockedRead).toHaveBeenCalledTimes(1);

--- a/packages/transition-backend/src/api/jobs.socketRoutes.ts
+++ b/packages/transition-backend/src/api/jobs.socketRoutes.ts
@@ -12,6 +12,7 @@ import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { JobAttributes, JobDataType } from 'transition-common/lib/services/jobs/Job';
 import { ExecutableJob } from '../services/executableJob/ExecutableJob';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 /**
  * Add routes specific to the executable jobs
@@ -74,22 +75,25 @@ export default function (socket: EventEmitter, userId: number) {
                     [fileName: string]: {
                         url: string;
                         downloadName: string;
-                        title: string | { text: string; fileName: string };
+                        title: TranslatableMessage;
                     };
                 } = {};
                 Object.keys(jobResourceFiles).forEach((file) => {
                     if (jobResourceFiles[file] && files?.includes(jobResourceFiles[file] as string)) {
-                        const fileName = jobResourceFiles[file] as string;
-                        const match = fileName.match(/([^/]+)\.([^/]+)$/);
+                        const filename = jobResourceFiles[file] as string;
+                        const match = filename.match(/([^/]+)\.([^/]+)$/);
                         const formattedTime = moment(job.attributes.created_at || '').format('YYYYMMDD_HHmmss');
                         const downloadName =
                             match === null
-                                ? `${fileName}_${formattedTime}`
+                                ? `${filename}_${formattedTime}`
                                 : `${match[1]}_${formattedTime}.${match[2]}`;
                         jobFiles[file] = {
-                            url: `/job/${id}/${fileName}`,
+                            url: `/job/${id}/${filename}`,
                             downloadName: downloadName,
-                            title: { text: `transit:jobs:${job.attributes.name}:files:${file}`, fileName }
+                            title: {
+                                text: `transit:jobs:${job.attributes.name}:files`,
+                                params: { filename, context: file }
+                            }
                         };
                     }
                 });

--- a/packages/transition-backend/src/services/capnpCache/dbToCache.ts
+++ b/packages/transition-backend/src/services/capnpCache/dbToCache.ts
@@ -144,9 +144,9 @@ const saveLineObjectsToCache = async (lines: LineCollection, cachePathDirectory?
         await linesDbQueries.collectionWithSchedules(chunk);
         await lineObjectsToCache(chunk, cachePathDirectory);
         // Reset the line's schedules, to not load the memory
-        chunk.forEach(line => {
-            line.attributes.scheduleByServiceId = {}
-        })
+        chunk.forEach((line) => {
+            line.attributes.scheduleByServiceId = {};
+        });
         const memoryAfter = process.memoryUsage();
         console.log('saving a chunk of lines: after');
         console.log(`- RSS: ${Math.round(memoryAfter.rss / 1024 / 1024)} MB`); // Convert bytes to MB

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/Candidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/Candidate.ts
@@ -47,6 +47,8 @@ abstract class Candidate {
     abstract simulate(): Promise<CandidateResult>;
 
     abstract getScenario(): Scenario | undefined;
+
+    abstract cleanup(): Promise<void>;
 }
 
 export default Candidate;

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/Candidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/Candidate.ts
@@ -49,6 +49,8 @@ abstract class Candidate {
     abstract getScenario(): Scenario | undefined;
 
     abstract cleanup(): Promise<void>;
+
+    abstract saveResultsFile(): Promise<void>;
 }
 
 export default Candidate;

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
@@ -18,7 +18,7 @@ import {
     EvolutionaryTransitNetworkDesignJobType
 } from '../../networkDesign/transitNetworkDesign/evolutionary/types';
 import { TransitNetworkDesignJobWrapper } from '../../networkDesign/transitNetworkDesign/TransitNetworkDesignJobWrapper';
-import { SIMULATION_METHODS_FACTORY } from '../../simulation/methods/SimulationMethod';
+import { SIMULATION_METHODS_FACTORY, SimulationMethod } from '../../simulation/methods/SimulationMethod';
 import { CandidateResult, ResultSerialization } from './types';
 
 // Proportion between the number of vehicles used and the available number under which this candidate is considered invalid
@@ -27,6 +27,7 @@ const USED_VEHICLES_THRESHOLD = 0.75;
 class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
     private scenario: Scenario | undefined;
     private source: CandidateSource | undefined;
+    private simulationMethod: undefined | SimulationMethod;
 
     constructor(
         chromosome: AlgoTypes.CandidateChromosome,
@@ -177,6 +178,7 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
         // FIXME Type properly when the methods are typed better (see issues #1533, #1560 and #1553)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const simulationMethod = factory.create(methodOptions as any, this.wrappedJob);
+        this.simulationMethod = simulationMethod;
         const results = await simulationMethod.simulate(scenario.getId());
         allResults[simulationMethodType] = results;
 
@@ -281,6 +283,14 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
      */
     getSource(): CandidateSource | undefined {
         return this.source;
+    }
+
+    cleanup(): Promise<void> {
+        // Call the cleanup method of the simulation method if it exists, to clean up any resources used for the simulation (e.g. tasks, results, etc.)
+        if (this.simulationMethod !== undefined) {
+            return this.simulationMethod.cleanup();
+        }
+        return Promise.resolve();
     }
 }
 

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/candidate/LineAndNumberOfVehiclesNetworkCandidate.ts
@@ -285,6 +285,16 @@ class LineAndNumberOfVehiclesNetworkCandidate extends Candidate {
         return this.source;
     }
 
+    saveResultsFile(): Promise<void> {
+        const simulationMethod = this.simulationMethod;
+        if (simulationMethod !== undefined) {
+            if (typeof (simulationMethod as any).saveResultsFile === 'function') {
+                return (simulationMethod as any).saveResultsFile(this.chromosome.name);
+            }
+        }
+        return Promise.resolve();
+    }
+
     cleanup(): Promise<void> {
         // Call the cleanup method of the simulation method if it exists, to clean up any resources used for the simulation (e.g. tasks, results, etc.)
         if (this.simulationMethod !== undefined) {

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/Generation.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/Generation.ts
@@ -171,16 +171,9 @@ abstract class Generation {
      * @param top The number of top scenarios to return
      * @returns An array of the top scenarios
      */
-    getBestScenarios(top = 1): Scenario[] {
-        const bestScenarios: Scenario[] = [];
-        for (let i = 0; i < Math.min(top, this.candidates.length); i++) {
-            const bestCandidate = this.candidates[i];
-            const scenario = bestCandidate.getScenario();
-            if (scenario !== undefined) {
-                bestScenarios.push(scenario);
-            }
-        }
-        return bestScenarios;
+    getBestCandidates(top = 1): NetworkCandidate[] {
+        this.sortCandidates();
+        return this.candidates.slice(0, top);
     }
 
     abstract sortCandidates(): void;

--- a/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/Generation.ts
+++ b/packages/transition-backend/src/services/evolutionaryAlgorithm/generation/Generation.ts
@@ -184,6 +184,16 @@ abstract class Generation {
     }
 
     abstract sortCandidates(): void;
+
+    async cleanupCandidates(): Promise<void> {
+        const promiseQueue = new pQueue({ concurrency: 1 });
+
+        for (const candidate of this.candidates) {
+            promiseQueue.add(async () => {
+                await candidate.cleanup();
+            });
+        }
+    }
 }
 
 export default Generation;

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
@@ -383,68 +383,73 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
             do {
                 previousGeneration = await this._prepareOrResumeGeneration(previousGeneration);
 
-                // FIXME Handle checkpointing with simulations that can be long
-                // Simulate the generation
-                await previousGeneration.simulate();
+                try {
+                    // FIXME Handle checkpointing with simulations that can be long
+                    // Simulate the generation
+                    await previousGeneration.simulate();
 
-                // TODO For now, we keep the best of each generation, but we
-                // should be smarter about it, knowing that the end of the
-                // simulation can follow various rules, like a number of
-                // generation or convergence of results. edit: Now that we save
-                // results to db at each generation, we may not even need this.
-                // See if runtime messages are useful or not.
-                algorithmResults.generations.push(previousGeneration.serializeBestResult());
-                await this.addMessages({
-                    infos: [
-                        `Completed generation ${this.currentIteration} with best results: ${JSON.stringify(previousGeneration.serializeBestResult())}.`
-                    ]
-                });
-                this.job.attributes.data.results = algorithmResults;
-                // Await saving simulation to avoid race condition if next generation is very fast
-                await this.job.save(this.executorOptions.progressEmitter);
-
-                // Save best scenarios if necessary
-                // FIXME Refactor this so we can map a candidate with the scenario it generated and save it in the result's data for output in files
-                // FIXME2 Extract this block to a function when we clean up this class
-                if (this.options.numberOfGenerations - this.currentIteration < this.options.keepGenerations) {
-                    const bestScenarios = previousGeneration.getBestScenarios(this.options.keepCandidates);
-                    const scenarioSavePromises = bestScenarios?.map((scenario) =>
-                        saveSimulationScenario(scenario, this)
-                    );
-                    const scenarioSaveResults = (await Promise.all(scenarioSavePromises)).filter(
-                        (scenarioSaveResult) => scenarioSaveResult !== undefined
-                    );
-                    algorithmResults.scenarioIds.push(...scenarioSaveResults.map((result) => result!.scenarioId));
+                    // TODO For now, we keep the best of each generation, but we
+                    // should be smarter about it, knowing that the end of the
+                    // simulation can follow various rules, like a number of
+                    // generation or convergence of results. edit: Now that we save
+                    // results to db at each generation, we may not even need this.
+                    // See if runtime messages are useful or not.
+                    algorithmResults.generations.push(previousGeneration.serializeBestResult());
+                    await this.addMessages({
+                        infos: [
+                            `Completed generation ${this.currentIteration} with best results: ${JSON.stringify(previousGeneration.serializeBestResult())}.`
+                        ]
+                    });
                     this.job.attributes.data.results = algorithmResults;
+                    // Await saving simulation to avoid race condition if next generation is very fast
                     await this.job.save(this.executorOptions.progressEmitter);
 
-                    // Update the main cache with the saved scenarios to allow analyzing them from Transition UI
-                    await loadAndSaveScenariosToCache();
-                    await loadAndSaveServicesToCache();
-                    await loadAndSaveLinesByIdsToCache({
-                        lineIds: scenarioSaveResults.flatMap((result) => result!.lineIds)
-                    });
-                    // FIXME Should signal the main thread to restart trRouting. Or maybe it works directly?
+                    // Save best scenarios if necessary
+                    // FIXME Refactor this so we can map a candidate with the scenario it generated and save it in the result's data for output in files
+                    // FIXME2 Extract this block to a function when we clean up this class
+                    if (this.options.numberOfGenerations - this.currentIteration < this.options.keepGenerations) {
+                        const bestScenarios = previousGeneration.getBestScenarios(this.options.keepCandidates);
+                        const scenarioSavePromises = bestScenarios?.map((scenario) =>
+                            saveSimulationScenario(scenario, this)
+                        );
+                        const scenarioSaveResults = (await Promise.all(scenarioSavePromises)).filter(
+                            (scenarioSaveResult) => scenarioSaveResult !== undefined
+                        );
+                        algorithmResults.scenarioIds.push(...scenarioSaveResults.map((result) => result!.scenarioId));
+                        this.job.attributes.data.results = algorithmResults;
+                        await this.job.save(this.executorOptions.progressEmitter);
+
+                        // Update the main cache with the saved scenarios to allow analyzing them from Transition UI
+                        await loadAndSaveScenariosToCache();
+                        await loadAndSaveServicesToCache();
+                        await loadAndSaveLinesByIdsToCache({
+                            lineIds: scenarioSaveResults.flatMap((result) => result!.lineIds)
+                        });
+                        // FIXME Should signal the main thread to restart trRouting. Or maybe it works directly?
+                    }
+
+                    // Save the results of this generation to the database
+
+                    // FIXME Consider doing it somewhere else, and maybe in multiple
+                    // steps (save candidate at the beginning and simulation results
+                    // at the end), to help with checkpoint recovery. It could avoid
+                    // saving the big blog of current generation in the job's
+                    // checkpointing, as well as re-run already completed candidate
+                    // simulations.
+                    const candidateResultsPromises = previousGeneration.getCandidates().map((candidate, index) =>
+                        resultsDbQueries.create({
+                            jobId: this.job.id,
+                            generationIndex: this.currentIteration,
+                            candidateIndex: index,
+                            scenarioName: candidate.getScenario()?.attributes.name || '',
+                            resultData: candidate.serialize()
+                        })
+                    );
+                    await Promise.all(candidateResultsPromises);
+                } finally {
+                    // Make sure the generation is cleaned up even if it throws an exception.
+                    await previousGeneration.cleanupCandidates();
                 }
-
-                // Save the results of this generation to the database
-
-                // FIXME Consider doing it somewhere else, and maybe in multiple
-                // steps (save candidate at the beginning and simulation results
-                // at the end), to help with checkpoint recovery. It could avoid
-                // saving the big blog of current generation in the job's
-                // checkpointing, as well as re-run already completed candidate
-                // simulations.
-                const candidateResultsPromises = previousGeneration.getCandidates().map((candidate, index) =>
-                    resultsDbQueries.create({
-                        jobId: this.job.id,
-                        generationIndex: this.currentIteration,
-                        candidateIndex: index,
-                        scenarioName: candidate.getScenario()?.attributes.name || '',
-                        resultData: candidate.serialize()
-                    })
-                );
-                await Promise.all(candidateResultsPromises);
 
                 // Increment generation number
                 this.currentIteration++;

--- a/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
+++ b/packages/transition-backend/src/services/networkDesign/transitNetworkDesign/evolutionary/EvolutionaryTransitNetworkDesignJob.ts
@@ -408,10 +408,14 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
                     // FIXME Refactor this so we can map a candidate with the scenario it generated and save it in the result's data for output in files
                     // FIXME2 Extract this block to a function when we clean up this class
                     if (this.options.numberOfGenerations - this.currentIteration < this.options.keepGenerations) {
-                        const bestScenarios = previousGeneration.getBestScenarios(this.options.keepCandidates);
-                        const scenarioSavePromises = bestScenarios?.map((scenario) =>
-                            saveSimulationScenario(scenario, this)
-                        );
+                        const bestCandidates = previousGeneration.getBestCandidates(this.options.keepCandidates);
+                        const saveFilePromises = bestCandidates.map((candidate) => candidate.saveResultsFile());
+                        const scenarioSavePromises = bestCandidates.map((candidate) => {
+                            const scenario = candidate.getScenario();
+                            if (scenario) {
+                                return saveSimulationScenario(scenario, this);
+                            }
+                        });
                         const scenarioSaveResults = (await Promise.all(scenarioSavePromises)).filter(
                             (scenarioSaveResult) => scenarioSaveResult !== undefined
                         );
@@ -425,6 +429,8 @@ class EvolutionaryTransitNetworkDesignJobExecutor extends TransitNetworkDesignJo
                         await loadAndSaveLinesByIdsToCache({
                             lineIds: scenarioSaveResults.flatMap((result) => result!.lineIds)
                         });
+                        // Make sure all files are saved for the candidates
+                        await Promise.all(saveFilePromises);
                         // FIXME Should signal the main thread to restart trRouting. Or maybe it works directly?
                     }
 

--- a/packages/transition-backend/src/services/simulation/methods/AccessibilityMapSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/AccessibilityMapSimulation.ts
@@ -197,4 +197,9 @@ export default class AccessibilityMapSimulation implements SimulationMethod {
         return { fitness: currentTotalAverage, results: { placesCost: placesAvgCosts } }; */
         return { fitness: 0, results: { placesCost: [] } };
     }
+
+    async cleanup(): Promise<void> {
+        // Nothing to clean up for now, but if we keep results during simulation, we may want to clean them up here
+        return Promise.resolve();
+    }
 }

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
@@ -246,6 +246,7 @@ export default class OdTripSimulation implements SimulationMethod {
     private fitnessFunction: FitnessFunction;
     private odTripFitnessFunction: OdTripFitnessFunction;
     private nonRoutableOdTripFitnessFunction: NonRoutableTripFitnessFunction;
+    private routingJob: ExecutableJob<BatchRouteJobType> | undefined;
 
     constructor(
         private options: OdTripSimulationOptions,
@@ -352,51 +353,56 @@ export default class OdTripSimulation implements SimulationMethod {
                 files: { input: `sampled_transit_demand_${scenarioId}.csv` }
             }
         });
+        // Keep the job until the cleanup function is called, in case we still need the results after simulations
+        this.routingJob = routingJob;
 
-        try {
-            // Create the input file for the batch routing job as a random sample of the original demand file (from the currently running job)
-            await this.sampleOdTripFileForJob(routingJob);
+        // Create the input file for the batch routing job as a random sample of the original demand file (from the currently running job)
+        await this.sampleOdTripFileForJob(routingJob);
 
-            //TODO Normally we would yeild the execution here. To let the child run. For now run it directly.
-            // I would normally do routingJob.run() here, but it was not implemented like that :P
+        //TODO Normally we would yeild the execution here. To let the child run. For now run it directly.
+        // I would normally do routingJob.run() here, but it was not implemented like that :P
 
-            // This is copied from wrapBatchRoute in `TransitionWorkerPool.ts`
+        // This is copied from wrapBatchRoute in `TransitionWorkerPool.ts`
 
-            // Child job needs its own progress emitter to avoid conflicts with the parent's
-            const childProgressEmitter = new EventEmitter();
+        // Child job needs its own progress emitter to avoid conflicts with the parent's
+        const childProgressEmitter = new EventEmitter();
 
-            const batchJobExecutor = new TrRoutingBatchExecutor(
-                routingJob,
-                {
-                    progressEmitter: childProgressEmitter,
-                    isCancelled: this.jobWrapper.privexecutorOptions.isCancelled,
-                    suppressExpectedRouteErrors: true
-                },
-                this.jobWrapper.getFakeTrRoutingBatchManager(childProgressEmitter)
+        const batchJobExecutor = new TrRoutingBatchExecutor(
+            routingJob,
+            {
+                progressEmitter: childProgressEmitter,
+                isCancelled: this.jobWrapper.privexecutorOptions.isCancelled,
+                suppressExpectedRouteErrors: true
+            },
+            this.jobWrapper.getFakeTrRoutingBatchManager(childProgressEmitter)
+        );
+        const execResults = await batchJobExecutor.run();
+        if (execResults.completed === true) {
+            const facPerField = this.options.demandAttributes.fileAndMapping.fieldMappings.expansionFactor;
+            // Handle results using the visitor pattern
+            const fitnessVisitor = new OdTripFitnessVisitor(routingJob, {
+                odTripFitnessFunction: this.odTripFitnessFunction,
+                nonRoutableOdTripFitnessFunction: this.nonRoutableOdTripFitnessFunction,
+                expansionFactorField: facPerField,
+                getOriginalFitness: this.jobWrapper.getOriginalFitness
+            });
+            const results = await batchJobExecutor.handleResults(fitnessVisitor);
+            const fitness = this.fitnessFunction(results);
+            console.log(
+                `OdTripSimulation: scenario=${scenarioId} fitness=${fitness.toFixed(2)} routed=${results.routedCount} nonRouted=${results.nonRoutedCount} total=${results.totalCount}`
             );
-            const execResults = await batchJobExecutor.run();
-            if (execResults.completed === true) {
-                const facPerField = this.options.demandAttributes.fileAndMapping.fieldMappings.expansionFactor;
-                // Handle results using the visitor pattern
-                const fitnessVisitor = new OdTripFitnessVisitor(routingJob, {
-                    odTripFitnessFunction: this.odTripFitnessFunction,
-                    nonRoutableOdTripFitnessFunction: this.nonRoutableOdTripFitnessFunction,
-                    expansionFactorField: facPerField,
-                    getOriginalFitness: this.jobWrapper.getOriginalFitness
-                });
-                const results = await batchJobExecutor.handleResults(fitnessVisitor);
-                const fitness = this.fitnessFunction(results);
-                console.log(
-                    `OdTripSimulation: scenario=${scenarioId} fitness=${fitness.toFixed(2)} routed=${results.routedCount} nonRouted=${results.nonRoutedCount} total=${results.totalCount}`
-                );
 
-                return { fitness, results };
-            } else {
-                throw new Error('Batch routing job did not complete successfully');
-            }
-        } finally {
-            // Delete the child job to avoid clutter, no need to await
-            routingJob.delete();
+            return { fitness, results };
+        } else {
+            throw new Error('Batch routing job did not complete successfully');
+        }
+    }
+
+    async cleanup(): Promise<void> {
+        if (this.routingJob) {
+            return this.routingJob.delete().then(() => {
+                this.routingJob = undefined;
+            });
         }
     }
 }

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
@@ -34,6 +34,7 @@ import {
 } from './OdTripSimulationFitnessFunctions';
 import { TransitDemandFromCsvRoutingAttributes } from 'transition-common/lib/services/transitDemand/types';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
+import { BatchRouteFileResultVisitor } from '../../transitRouting/batchRouteCalculation/BatchRouteFileResultVisitor';
 
 export const OdTripSimulationTitle = 'OdTripSimulation';
 const timeCsvColumnHeader = 'time';
@@ -246,7 +247,7 @@ export default class OdTripSimulation implements SimulationMethod {
     private fitnessFunction: FitnessFunction;
     private odTripFitnessFunction: OdTripFitnessFunction;
     private nonRoutableOdTripFitnessFunction: NonRoutableTripFitnessFunction;
-    private routingJob: ExecutableJob<BatchRouteJobType> | undefined;
+    private routingJobExecutor: TrRoutingBatchExecutor | undefined;
 
     constructor(
         private options: OdTripSimulationOptions,
@@ -331,7 +332,7 @@ export default class OdTripSimulation implements SimulationMethod {
             routingModes: ['transit'],
             withAlternatives: false,
             withGeometries: false,
-            detailed: false,
+            detailed: true,
             scenarioId: scenarioId
         };
 
@@ -353,8 +354,6 @@ export default class OdTripSimulation implements SimulationMethod {
                 files: { input: `sampled_transit_demand_${scenarioId}.csv` }
             }
         });
-        // Keep the job until the cleanup function is called, in case we still need the results after simulations
-        this.routingJob = routingJob;
 
         // Create the input file for the batch routing job as a random sample of the original demand file (from the currently running job)
         await this.sampleOdTripFileForJob(routingJob);
@@ -376,6 +375,9 @@ export default class OdTripSimulation implements SimulationMethod {
             },
             this.jobWrapper.getFakeTrRoutingBatchManager(childProgressEmitter)
         );
+        // Keep the job until the cleanup function is called, in case we still need the results after simulations
+        this.routingJobExecutor = batchJobExecutor;
+
         const execResults = await batchJobExecutor.run();
         if (execResults.completed === true) {
             const facPerField = this.options.demandAttributes.fileAndMapping.fieldMappings.expansionFactor;
@@ -398,11 +400,27 @@ export default class OdTripSimulation implements SimulationMethod {
         }
     }
 
+    async saveResultsFile(fileSuffix: string): Promise<void> {
+        const routingJobExecutor = this.routingJobExecutor;
+        if (routingJobExecutor !== undefined) {
+            // Run the file result visitor to generate the files and save them into the main jobs storage
+            const resultVisitor = new BatchRouteFileResultVisitor(
+                this.jobWrapper.job,
+                routingJobExecutor.getJob().attributes.data.parameters.transitRoutingAttributes,
+                fileSuffix
+            );
+            await routingJobExecutor.handleResults(resultVisitor);
+        }
+    }
+
     async cleanup(): Promise<void> {
-        if (this.routingJob) {
-            return this.routingJob.delete().then(() => {
-                this.routingJob = undefined;
-            });
+        if (this.routingJobExecutor) {
+            return this.routingJobExecutor
+                .getJob()
+                .delete()
+                .then(() => {
+                    this.routingJobExecutor = undefined;
+                });
         }
     }
 }

--- a/packages/transition-backend/src/services/simulation/methods/SimulationMethod.ts
+++ b/packages/transition-backend/src/services/simulation/methods/SimulationMethod.ts
@@ -23,6 +23,7 @@ import { AccessibilityMapSimulationFactory } from './AccessibilityMapSimulation'
  */
 export interface SimulationMethod {
     simulate: (scenarioId: string) => Promise<{ fitness: number; results: unknown }>;
+    cleanup: () => Promise<void>;
 }
 
 /**

--- a/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
+++ b/packages/transition-backend/src/services/transitRouting/TrRoutingBatch.ts
@@ -61,13 +61,19 @@ export const batchRoute = async (
         options.progressEmitter.emit('progress', { name: 'GeneratingBatchRoutingResults', progress: 0.0 });
         // FIXME We hardcode the result visitor to file output for now, but we could have other implementations (like calculating statistics, or nothing at all)
         // FIXME2 Also, since we do not have any way of handling the results after the job is done yet, the visitor handler is now part of the job, but later, handling results could be done on completed jobs, and not as part of the job
-        const resultVisitor = new BatchRouteFileResultVisitor(job);
+        const resultVisitor = new BatchRouteFileResultVisitor(
+            job,
+            job.attributes.data.parameters.transitRoutingAttributes
+        );
         const { files } = await batchRoutingExecutor.handleResults(resultVisitor);
         options.progressEmitter.emit('progress', { name: 'GeneratingBatchRoutingResults', progress: 1.0 });
 
         const routingResult = {
             ...execResults,
-            files
+            files: {
+                input: job.getInputFileName(),
+                ...files
+            }
         };
         return routingResult;
     } else {
@@ -358,4 +364,6 @@ export class TrRoutingBatchExecutor {
             console.error(`Error getting od trip result for ${odTripIndex}: ${error}`);
         }
     };
+
+    public getJob = (): ExecutableJob<BatchRouteJobType> => this.job;
 }

--- a/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/BatchRouteFileResultVisitor.ts
+++ b/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/BatchRouteFileResultVisitor.ts
@@ -5,30 +5,37 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { ExecutableJob } from '../../executableJob/ExecutableJob';
-import { BatchRouteJobType, BatchRouteResultVisitor } from '../BatchRoutingJob';
+import { BatchRouteResultVisitor } from '../BatchRoutingJob';
 import { OdTripRouteResult } from '../types';
 import { createRoutingFileResultProcessor, generateFileOutputResults } from './TrRoutingBatchResult';
 import PathCollection from 'transition-common/lib/services/path/PathCollection';
 import pathDbQueries from '../../../models/db/transitPaths.db.queries';
+import { BatchCalculationParameters } from 'transition-common/lib/services/batchCalculation/types';
+import { BatchRoutingResultProcessor } from './TrRoutingBatchResult';
+import { JobDataType } from 'transition-common/lib/services/jobs/Job';
 
 // Example concrete visitor for file generation
 export class BatchRouteFileResultVisitor
-implements
-        BatchRouteResultVisitor<{ files: { input: string; csv?: string; detailedCsv?: string; geojson?: string } }> {
-    private resultHandler = createRoutingFileResultProcessor(this.job);
-    private pathCollection: PathCollection | undefined | false = false;
+implements BatchRouteResultVisitor<{ files: { csv?: string; detailedCsv?: string; geojson?: string } }> {
+    private resultHandler: BatchRoutingResultProcessor;
+    // Cache for path collection, to avoid loading it multiple times if geometries are included in the results, if no geometry asked, set to `false`
+    private pathCollection: PathCollection | undefined | false = undefined;
 
-    constructor(private job: ExecutableJob<BatchRouteJobType>) {
-        // Nothing to do
+    constructor(
+        private job: ExecutableJob<JobDataType>,
+        private batchParameters: BatchCalculationParameters,
+        fileSuffix?: string
+    ) {
+        this.resultHandler = createRoutingFileResultProcessor(this.job, this.batchParameters, fileSuffix);
     }
 
     private prepareResultData = async (): Promise<void> => {
         let pathCollection: PathCollection | undefined = undefined;
-        if (this.job.attributes.data.parameters.transitRoutingAttributes.withGeometries) {
+        if (this.batchParameters.withGeometries) {
             pathCollection = new PathCollection([], {});
-            if (this.job.attributes.data.parameters.transitRoutingAttributes.scenarioId) {
+            if (this.batchParameters.scenarioId) {
                 const pathGeojson = await pathDbQueries.geojsonCollection({
-                    scenarioId: this.job.attributes.data.parameters.transitRoutingAttributes.scenarioId
+                    scenarioId: this.batchParameters.scenarioId
                 });
                 pathCollection.loadFromCollection(pathGeojson.features);
             }
@@ -39,13 +46,13 @@ implements
     };
 
     visitTripResult = async (routingResult: OdTripRouteResult) => {
-        if (this.pathCollection === false) {
+        if (this.pathCollection === undefined) {
             await this.prepareResultData();
         }
         const processedResults = await generateFileOutputResults(routingResult, {
             exportCsv: true,
-            exportDetailed: this.job.attributes.data.parameters.transitRoutingAttributes.detailed === true,
-            withGeometries: this.job.attributes.data.parameters.transitRoutingAttributes.withGeometries === true,
+            exportDetailed: this.batchParameters.detailed === true,
+            withGeometries: this.batchParameters.withGeometries === true,
             pathCollection: this.pathCollection as PathCollection | undefined
         });
         this.resultHandler.processResult(processedResults);
@@ -55,7 +62,7 @@ implements
         this.resultHandler.end();
     };
 
-    getResult(): { files: { input: string; csv?: string; detailedCsv?: string; geojson?: string } } {
+    getResult(): { files: { csv?: string; detailedCsv?: string; geojson?: string } } {
         return { files: this.resultHandler.getFiles() };
     }
 }

--- a/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/TrRoutingBatchResult.ts
+++ b/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/TrRoutingBatchResult.ts
@@ -24,17 +24,18 @@ import { BatchCalculationParameters } from 'transition-common/lib/services/batch
 import { pathIsRoute } from 'chaire-lib-common/lib/services/routing/RoutingResult';
 import { RoutingResultsByMode } from 'chaire-lib-common/lib/services/routing/types';
 import { resultToObject } from 'chaire-lib-common/lib/services/routing/RoutingResultUtils';
+import { JobDataType } from 'transition-common/lib/services/jobs/Job';
 import { ExecutableJob } from '../../executableJob/ExecutableJob';
 import { BatchRouteJobType } from '../BatchRoutingJob';
 
-const CSV_FILE_NAME = 'batchRoutingResults.csv';
-const DETAILED_CSV_FILE_NAME = 'batchRoutingDetailedResults.csv';
-const GEOMETRY_FILE_NAME = 'batchRoutingGeometryResults.geojson';
+const getCsvFileName = (suffix: string) => `batchRoutingResults${suffix}.csv`;
+const getDetailedCsvFileName = (suffix: string) => `batchRoutingDetailedResults${suffix}.csv`;
+const getGeometryFileName = (suffix: string) => `batchRoutingGeometryResults${suffix}.geojson`;
 
 export interface BatchRoutingResultProcessor {
     processResult: (routingResult: OdTripRouteOutput) => void;
     end: () => void;
-    getFiles: () => { input: string; csv?: string; detailedCsv?: string; geojson?: string };
+    getFiles: () => { csv?: string; detailedCsv?: string; geojson?: string };
 }
 
 /**
@@ -42,19 +43,49 @@ export interface BatchRoutingResultProcessor {
  *
  */
 export const createRoutingFileResultProcessor = (
-    job: ExecutableJob<BatchRouteJobType>
+    job: ExecutableJob<JobDataType>,
+    batchParameters?: BatchCalculationParameters,
+    fileSuffix?: string
 ): BatchRoutingResultProcessor => {
-    return new BatchRoutingResultProcessorFile(job);
+    return new BatchRoutingResultProcessorFile(job, batchParameters, fileSuffix);
 };
 
 class BatchRoutingResultProcessorFile implements BatchRoutingResultProcessor {
-    private batchParameters: BatchCalculationParameters = this.job.attributes.data.parameters.transitRoutingAttributes;
+    private batchParameters: BatchCalculationParameters;
     private csvStream: fs.WriteStream | undefined;
     private csvDetailedStream: fs.WriteStream | undefined;
     private geometryStream: fs.WriteStream | undefined;
     private geometryStreamHasData = false;
 
-    constructor(private job: ExecutableJob<BatchRouteJobType>) {
+    /**
+     * Constructor
+     *
+     * @param job The job under which the files will be saved (doesn't have to
+     * be the job the results are from)
+     * @param [batchParameters] The batch calculation parameters, used to know
+     * which files to generate and which attributes to include in the csv, if
+     * not provided it will be extracted from the job's data. Defaults to the
+     * job's data parameters if the job is a BatchRoute job
+     * @param [fileSuffix] Optional suffix to add to the registered files.
+     * Defaults to empty string (no suffix)
+     */
+    constructor(
+        private job: ExecutableJob<JobDataType>,
+        batchParameters: BatchCalculationParameters | undefined = undefined,
+        private fileSuffix = ''
+    ) {
+        if (batchParameters !== undefined) {
+            this.batchParameters = batchParameters;
+        } else {
+            if (this.job.attributes.name === 'batchRoute') {
+                this.batchParameters = (
+                    this.job.attributes.data as BatchRouteJobType['data']
+                ).parameters.transitRoutingAttributes;
+            } else {
+                throw new Error('Missing batch parameter information and the job is not a batch route job');
+            }
+        }
+
         this.initResultFiles();
     }
 
@@ -62,21 +93,21 @@ class BatchRoutingResultProcessorFile implements BatchRoutingResultProcessor {
         const csvAttributes = getDefaultCsvAttributes(this.batchParameters.routingModes || []);
 
         // Register CSV output file
-        this.job.registerOutputFile('csv', CSV_FILE_NAME);
-        this.csvStream = this.job.getWriteStream('csv');
+        this.job.registerOutputFile('csv' + this.fileSuffix, getCsvFileName(this.fileSuffix));
+        this.csvStream = this.job.getWriteStream('csv' + this.fileSuffix);
         this.csvStream.on('error', console.error);
         this.csvStream.write(Object.keys(csvAttributes).join(',') + '\n');
 
         if (this.batchParameters.detailed) {
-            this.job.registerOutputFile('detailedCsv', DETAILED_CSV_FILE_NAME);
-            this.csvDetailedStream = this.job.getWriteStream('detailedCsv');
+            this.job.registerOutputFile('detailedCsv' + this.fileSuffix, getDetailedCsvFileName(this.fileSuffix));
+            this.csvDetailedStream = this.job.getWriteStream('detailedCsv' + this.fileSuffix);
             this.csvDetailedStream.on('error', console.error);
             this.csvDetailedStream.write(Object.keys(getDefaultStepsAttributes()).join(',') + '\n');
         }
 
         if (this.batchParameters.withGeometries) {
-            this.job.registerOutputFile('geojson', GEOMETRY_FILE_NAME);
-            this.geometryStream = this.job.getWriteStream('geojson');
+            this.job.registerOutputFile('geojson' + this.fileSuffix, getGeometryFileName(this.fileSuffix));
+            this.geometryStream = this.job.getWriteStream('geojson' + this.fileSuffix);
             this.geometryStream.on('error', console.error);
             this.geometryStream.write('{ "type": "FeatureCollection", "features": [');
         }
@@ -113,10 +144,9 @@ class BatchRoutingResultProcessorFile implements BatchRoutingResultProcessor {
     };
 
     getFiles = () => ({
-        input: this.job.getInputFileName(),
-        csv: CSV_FILE_NAME,
-        detailedCsv: this.batchParameters.detailed ? DETAILED_CSV_FILE_NAME : undefined,
-        geojson: this.batchParameters.withGeometries ? GEOMETRY_FILE_NAME : undefined
+        csv: getCsvFileName(this.fileSuffix),
+        detailedCsv: this.batchParameters.detailed ? getDetailedCsvFileName(this.fileSuffix) : undefined,
+        geojson: this.batchParameters.withGeometries ? getGeometryFileName(this.fileSuffix) : undefined
     });
 }
 

--- a/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/__tests__/TrRoutingBatchResult.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/batchRouteCalculation/__tests__/TrRoutingBatchResult.test.ts
@@ -153,7 +153,7 @@ describe('File generator: Only CSV results', () => {
     });
 
     test('get files', () => {
-        expect(resultProcessor.getFiles()).toEqual({ input: inputFileName, csv: CSV_FILE_NAME, detailed: undefined, geojson: undefined });
+        expect(resultProcessor.getFiles()).toEqual({ csv: CSV_FILE_NAME, detailed: undefined, geojson: undefined });
     });
 
     test('Process results', () => {
@@ -180,7 +180,7 @@ describe('File generator: Only CSV results', () => {
 
         resultProcessor.end();
         expect(csvStream.writableEnded).toBeTruthy();
-        expect(resultProcessor.getFiles()).toEqual({ input: inputFileName, csv: CSV_FILE_NAME, detailed: undefined, geojson: undefined });
+        expect(resultProcessor.getFiles()).toEqual({ csv: CSV_FILE_NAME, detailed: undefined, geojson: undefined });
     })
 });
 
@@ -212,7 +212,7 @@ describe('File generator: CSV and detailed results', () => {
     });
 
     test('get files', () => {
-        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: DETAILED_CSV_FILE_NAME, geojson: undefined });
+        expect(resultProcessor.getFiles()).toEqual({ csv: CSV_FILE_NAME, detailedCsv: DETAILED_CSV_FILE_NAME, geojson: undefined });
     });
 
     test('Process results', () => {
@@ -248,7 +248,7 @@ describe('File generator: CSV and detailed results', () => {
         resultProcessor.end();
         expect(csvStream.writableEnded).toBeTruthy();
         expect(detailedStream.writableEnded).toBeTruthy();
-        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: DETAILED_CSV_FILE_NAME, geojson: undefined });
+        expect(resultProcessor.getFiles()).toEqual({ csv: CSV_FILE_NAME, detailedCsv: DETAILED_CSV_FILE_NAME, geojson: undefined });
     })
 });
 
@@ -281,7 +281,7 @@ describe('File generator: CSV and geojson results', () => {
     });
 
     test('get files', () => {
-        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: undefined, geojson: GEOMETRY_FILE_NAME });
+        expect(resultProcessor.getFiles()).toEqual({ csv: CSV_FILE_NAME, detailedCsv: undefined, geojson: GEOMETRY_FILE_NAME });
     });
 
     test('Process results', () => {
@@ -323,7 +323,7 @@ describe('File generator: CSV and geojson results', () => {
         resultProcessor.end();
         expect(csvStream.writableEnded).toBeTruthy();
         expect(geojsonStream.writableEnded).toBeTruthy();
-        expect(resultProcessor.getFiles()).toEqual({ input: expect.anything(), csv: CSV_FILE_NAME, detailedCsv: undefined, geojson: GEOMETRY_FILE_NAME });
+        expect(resultProcessor.getFiles()).toEqual({ csv: CSV_FILE_NAME, detailedCsv: undefined, geojson: GEOMETRY_FILE_NAME });
 
         // make sure the geojson content is valid geojson
         const geojsonString = geojsonStream.data.join('');

--- a/packages/transition-frontend/src/components/parts/executableJob/ExpandableFileWidget.tsx
+++ b/packages/transition-frontend/src/components/parts/executableJob/ExpandableFileWidget.tsx
@@ -7,6 +7,7 @@ import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { JobsConstants } from 'transition-common/lib/api/jobs';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 export interface ExpandableFileProps {
     jobId: number;
@@ -14,7 +15,7 @@ export interface ExpandableFileProps {
 }
 
 type JobFileType = {
-    [fileName: string]: { url: string; downloadName: string; title: string | { text: string; fileName: string } };
+    [fileName: string]: { url: string; downloadName: string; title: TranslatableMessage };
 };
 
 const getFilesFromSocket = (id: number): Promise<Status.Status<JobFileType>> => {
@@ -64,11 +65,9 @@ const ExpandableFileWidget: React.FunctionComponent<ExpandableFileProps & WithTr
                 Object.keys(files).map((fileName, fileIdx) => (
                     <p key={`jobFile${props.jobId}_${fileIdx}`}>
                         <a href={files[fileName].url} download={files[fileName].downloadName}>
-                            {typeof files[fileName].title === 'string'
-                                ? props.t(files[fileName].title as string)
-                                : props.t((files[fileName].title as any).text, {
-                                    filename: (files[fileName].title as any).fileName
-                                })}
+                            {typeof files[fileName].title === 'object'
+                                ? props.t(files[fileName].title.text, files[fileName].title.params)
+                                : props.t(files[fileName].title)}
                         </a>
                     </p>
                 ))}


### PR DESCRIPTION
See individual commits for details

- Add a cleanup step to generations and candidates, so the job used by the candidates can be kept until the end of the generation instead of being deleted right away. This will allow to save its result at the end.
- Update the batch route file result visitor to accept a job that may not be a batch route job, but a job in which to save the files. It receives also the batch routing parameters necessary to know what results should be generated, as well as an optional suffix to append to the file names.
- The X best candidates of the Y last generation now have their results saved in the main job, and they are listed under the job's files list.