### PR TITLE
Add min waypoint zoom

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -396,6 +396,9 @@
         "CustomLayover": "Custom layover time (minutes)",
         "ShowPaths": "Show paths",
         "HidePaths": "Hide paths",
+        "WaypointMinZoom": "Minimum map zoom for path waypoints",
+        "WaypointMinZoomHelp": "Waypoints are drawn and can be added or removed from this zoom level upward (allowed range: 1–15). Lower values allow editing at a wider map view.",
+        "WaypointMinZoomRefreshHint": "You need to refresh the page for this change to apply on the map.",
         "true": "Yes",
         "false": "No",
         "Generate": "Generate path",
@@ -519,7 +522,8 @@
             "DefaultDecelerationIsRequired": "Deceleration is required.",
             "DefaultDecelerationIsInvalid": "Deceleration is invalid.",
             "DefaultDecelerationIsTooLow": "Deceleration is too low.",
-            "DefaultDecelerationIsTooHigh": "Deceleration is too high (uncomfortable)."
+            "DefaultDecelerationIsTooHigh": "Deceleration is too high (uncomfortable).",
+            "WaypointMinZoomOutOfRange": "Waypoint minimum zoom must be a whole number from 1 to 15."
         }
     },
     "transitRouting": {

--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -397,7 +397,7 @@
         "ShowPaths": "Show paths",
         "HidePaths": "Hide paths",
         "WaypointMinZoom": "Minimum map zoom for path waypoints",
-        "WaypointMinZoomHelp": "Waypoints are drawn and can be added or removed from this zoom level upward (allowed range: 1–15). Lower values allow editing at a wider map view.",
+        "WaypointMinZoomHelp": "Waypoints are drawn and can be added or removed from this zoom level upward (allowed range: 1–15, where 1 is the whole-world view and 15 is street-level). Lower values allow editing at a wider map view.",
         "WaypointMinZoomRefreshHint": "You need to refresh the page for this change to apply on the map.",
         "true": "Yes",
         "false": "No",
@@ -523,7 +523,7 @@
             "DefaultDecelerationIsInvalid": "Deceleration is invalid.",
             "DefaultDecelerationIsTooLow": "Deceleration is too low.",
             "DefaultDecelerationIsTooHigh": "Deceleration is too high (uncomfortable).",
-            "WaypointMinZoomOutOfRange": "Waypoint minimum zoom must be a whole number from 1 to 15."
+            "WaypointMinZoomOutOfRange": "Waypoint minimum zoom must be an integer from 1 to 15."
         }
     },
     "transitRouting": {

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -397,6 +397,9 @@
         "CustomLayover": "Battement personnalisé (minutes)",
         "ShowPaths": "Montrer les lignes et parcours",
         "HidePaths": "Cacher les lignes et parcours",
+        "WaypointMinZoom": "Zoom minimal de la carte pour les points de repère de parcours",
+        "WaypointMinZoomHelp": "Les points de repère s'affichent et peuvent être ajoutés ou retirés à partir de ce niveau de zoom (plage permise : 1 à 15). Une valeur plus basse permet d'éditer à une vue plus large.",
+        "WaypointMinZoomRefreshHint": "Il faut actualiser la page pour que ce réglage s'applique sur la carte.",
         "true": "Oui",
         "false": "Non",
         "Generate": "Générer le parcours",
@@ -519,7 +522,8 @@
             "DefaultDecelerationIsRequired": "La décélération st requise.",
             "DefaultDecelerationIsInvalid": "La décélération est invalide.",
             "DefaultDecelerationIsTooLow": "La décélération est trop faible.",
-            "DefaultDecelerationIsTooHigh": "La décélération est trop élevée (inconfortable)."
+            "DefaultDecelerationIsTooHigh": "La décélération est trop élevée (inconfortable).",
+            "WaypointMinZoomOutOfRange": "Le zoom minimal pour les points de repère doit être un nombre entier entre 1 et 15."
         }
     },
     "transitRouting": {

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -398,7 +398,7 @@
         "ShowPaths": "Montrer les lignes et parcours",
         "HidePaths": "Cacher les lignes et parcours",
         "WaypointMinZoom": "Zoom minimal de la carte pour les points de repère de parcours",
-        "WaypointMinZoomHelp": "Les points de repère s'affichent et peuvent être ajoutés ou retirés à partir de ce niveau de zoom (plage permise : 1 à 15). Une valeur plus basse permet d'éditer à une vue plus large.",
+        "WaypointMinZoomHelp": "Les points de repère s'affichent et peuvent être ajoutés ou retirés à partir de ce niveau de zoom (plage permise : 1 à 15, où 1 correspond à la vue mondiale et 15 à la rue). Une valeur plus basse permet d'éditer à une vue plus large.",
         "WaypointMinZoomRefreshHint": "Il faut actualiser la page pour que ce réglage s'applique sur la carte.",
         "true": "Oui",
         "false": "Non",
@@ -523,7 +523,7 @@
             "DefaultDecelerationIsInvalid": "La décélération est invalide.",
             "DefaultDecelerationIsTooLow": "La décélération est trop faible.",
             "DefaultDecelerationIsTooHigh": "La décélération est trop élevée (inconfortable).",
-            "WaypointMinZoomOutOfRange": "Le zoom minimal pour les points de repère doit être un nombre entier entre 1 et 15."
+            "WaypointMinZoomOutOfRange": "Le zoom minimal pour les points de repère doit être un entier entre 1 et 15."
         }
     },
     "transitRouting": {

--- a/packages/chaire-lib-common/src/config/Preferences.ts
+++ b/packages/chaire-lib-common/src/config/Preferences.ts
@@ -191,9 +191,10 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
         }
         const fromMap = _get(this.attributes, 'map.pathWaypointMinZoom');
         const fromLegacy = _get(this.attributes, 'transit.paths.waypointMinZoom');
-        const waypointMinZoom = _isNumber(fromMap) ? fromMap : fromLegacy;
+        const waypointMinZoom = Number.isFinite(fromMap) ? fromMap : fromLegacy;
+        // Must be an integer in [MIN_WAYPOINT_MIN_ZOOM, MAX_WAYPOINT_MIN_ZOOM]; rejects NaN, decimals, strings.
         if (
-            !_isNumber(waypointMinZoom) ||
+            !Number.isInteger(waypointMinZoom) ||
             waypointMinZoom < MIN_WAYPOINT_MIN_ZOOM ||
             waypointMinZoom > MAX_WAYPOINT_MIN_ZOOM
         ) {

--- a/packages/chaire-lib-common/src/config/Preferences.ts
+++ b/packages/chaire-lib-common/src/config/Preferences.ts
@@ -189,9 +189,7 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
                 this._isValid = false;
             }
         }
-        const fromMap = _get(this.attributes, 'map.pathWaypointMinZoom');
-        const fromLegacy = _get(this.attributes, 'transit.paths.waypointMinZoom');
-        const waypointMinZoom = Number.isFinite(fromMap) ? fromMap : fromLegacy;
+        const waypointMinZoom = _get(this.attributes, 'map.pathWaypointMinZoom');
         // Must be an integer in [MIN_WAYPOINT_MIN_ZOOM, MAX_WAYPOINT_MIN_ZOOM]; rejects NaN, decimals, strings.
         if (
             !Number.isInteger(waypointMinZoom) ||

--- a/packages/chaire-lib-common/src/config/Preferences.ts
+++ b/packages/chaire-lib-common/src/config/Preferences.ts
@@ -29,6 +29,10 @@ const MAX_DEFAULT_ACCELERATION = 1.5;
 const MIN_DEFAULT_DECELERATION = 0.3;
 const MAX_DEFAULT_DECELERATION = 1.5;
 
+/** Allowed range for `map.pathWaypointMinZoom` (map zoom level, inclusive) */
+const MIN_WAYPOINT_MIN_ZOOM = 1;
+const MAX_WAYPOINT_MIN_ZOOM = 15;
+
 interface PreferencesModelWithIdAndData extends PreferencesModel {
     id: string;
     data: { [key: string]: any };
@@ -184,6 +188,17 @@ export class PreferencesClass extends ObjectWithHistory<PreferencesModelWithIdAn
                 this.errors.push('transit:transitPath:errors:DefaultRunningSpeedIsTooHigh');
                 this._isValid = false;
             }
+        }
+        const fromMap = _get(this.attributes, 'map.pathWaypointMinZoom');
+        const fromLegacy = _get(this.attributes, 'transit.paths.waypointMinZoom');
+        const waypointMinZoom = _isNumber(fromMap) ? fromMap : fromLegacy;
+        if (
+            !_isNumber(waypointMinZoom) ||
+            waypointMinZoom < MIN_WAYPOINT_MIN_ZOOM ||
+            waypointMinZoom > MAX_WAYPOINT_MIN_ZOOM
+        ) {
+            this._errors.push('transit:transitPath:errors:WaypointMinZoomOutOfRange');
+            this._isValid = false;
         }
         return this._isValid;
     }

--- a/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
+++ b/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
@@ -26,9 +26,12 @@ stubEmitter.on('preferences.read', mockStubReadPreferences);
 
 const originalPreferences = _cloneDeep(Preferences.attributes);
 
-beforeEach(() => {
-    // Reset preferences to the default value
-    Preferences.setAttributes(_cloneDeep(originalPreferences));
+beforeEach(async () => {
+    // Full reset via load (merge defaults + project + {}), same as a fresh session; update() cannot drop keys missing from the patch
+    mockStubReadPreferences.mockImplementationOnce((callback) => {
+        callback(Status.createOk({}));
+    });
+    await Preferences.load(stubEmitter);
     jest.clearAllMocks();
     fetchMock.doMock();
     fetchMock.mockClear();
@@ -191,6 +194,63 @@ describe('map.basemapShortname preference', () => {
         Preferences.set('map.basemapShortname', 'aerial');
         const mapPrefs = Preferences.get('map');
         expect(mapPrefs).toHaveProperty('basemapShortname', 'aerial');
+    });
+});
+
+describe('map.pathWaypointMinZoom preference', () => {
+    const waypointZoomError = 'transit:transitPath:errors:WaypointMinZoomOutOfRange';
+
+    test('has 10 as default value', () => {
+        expect(Preferences.get('map.pathWaypointMinZoom')).toBe(10);
+    });
+
+    test.each(Array.from({ length: 15 }, (_, i) => ({ z: i + 1 })))(
+        'validate passes for pathWaypointMinZoom=$z',
+        ({ z }) => {
+            Preferences.set('map.pathWaypointMinZoom', z);
+            expect(Preferences.validate()).toBe(true);
+            expect(Preferences.errors).not.toContain(waypointZoomError);
+        }
+    );
+
+    test('resetPathToDefault restores default zoom', () => {
+        Preferences.set('map.pathWaypointMinZoom', 3);
+        Preferences.resetPathToDefault('map.pathWaypointMinZoom');
+        expect(Preferences.get('map.pathWaypointMinZoom')).toBe(10);
+        expect(Preferences.validate()).toBe(true);
+    });
+
+    test.each<{ value: unknown; desc: string }>([
+        { value: 0, desc: 'zero' },
+        { value: 16, desc: 'above range' },
+        { value: -1, desc: 'negative' },
+        { value: null, desc: 'null' },
+        { value: '8', desc: 'string' }
+    ])('validate fails for invalid pathWaypointMinZoom ($desc)', ({ value }) => {
+        Preferences.set('map.pathWaypointMinZoom', value);
+        expect(Preferences.validate()).toBe(false);
+        expect(Preferences.errors).toContain(waypointZoomError);
+    });
+
+    test('validate fails when pathWaypointMinZoom is missing from map', async () => {
+        const map = _cloneDeep(Preferences.get('map')) as Record<string, unknown>;
+        delete map['pathWaypointMinZoom'];
+        await Preferences.update({ map: map as PreferencesModel['map'] }, stubEmitter, false);
+        expect(Preferences.validate()).toBe(false);
+        expect(Preferences.errors).toContain(waypointZoomError);
+    });
+
+    test('legacy transit.paths.waypointMinZoom is used for validate when map key absent', async () => {
+        const map = _cloneDeep(Preferences.get('map')) as Record<string, unknown>;
+        delete map['pathWaypointMinZoom'];
+        const transitPaths = _cloneDeep(Preferences.get('transit.paths'));
+        Object.assign(transitPaths, { waypointMinZoom: 12 });
+        await Preferences.update(
+            { map: map as PreferencesModel['map'], 'transit.paths': transitPaths },
+            stubEmitter,
+            false
+        );
+        expect(Preferences.validate()).toBe(true);
     });
 });
 

--- a/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
+++ b/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
@@ -243,18 +243,6 @@ describe('map.pathWaypointMinZoom preference', () => {
         expect(Preferences.errors).toContain(waypointZoomError);
     });
 
-    test('legacy transit.paths.waypointMinZoom is used for validate when map key absent', async () => {
-        const map = _cloneDeep(Preferences.get('map')) as Record<string, unknown>;
-        delete map['pathWaypointMinZoom'];
-        const transitPaths = _cloneDeep(Preferences.get('transit.paths'));
-        Object.assign(transitPaths, { waypointMinZoom: 12 });
-        await Preferences.update(
-            { map: map as PreferencesModel['map'], 'transit.paths': transitPaths },
-            stubEmitter,
-            false
-        );
-        expect(Preferences.validate()).toBe(true);
-    });
 });
 
 test('Test get from default or project default', () => {

--- a/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
+++ b/packages/chaire-lib-common/src/config/__tests__/Preferences.test.ts
@@ -225,7 +225,10 @@ describe('map.pathWaypointMinZoom preference', () => {
         { value: 16, desc: 'above range' },
         { value: -1, desc: 'negative' },
         { value: null, desc: 'null' },
-        { value: '8', desc: 'string' }
+        { value: undefined, desc: 'undefined' },
+        { value: '8', desc: 'string' },
+        { value: Number.NaN, desc: 'NaN' },
+        { value: 10.5, desc: 'decimal' }
     ])('validate fails for invalid pathWaypointMinZoom ($desc)', ({ value }) => {
         Preferences.set('map.pathWaypointMinZoom', value);
         expect(Preferences.validate()).toBe(false);

--- a/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
+++ b/packages/chaire-lib-common/src/config/defaultPreferences.config.ts
@@ -43,6 +43,8 @@ export interface PreferencesModel {
         overlayOpacity: number;
         /** Overlay color: 'black' or 'white' */
         overlayColor: 'black' | 'white';
+        /** Min map zoom (1–15) for path waypoint layers / editing; not under transit.paths so Path defaults do not copy it */
+        pathWaypointMinZoom: number;
     };
     colorPicker: {
         /** Hexadecimal strings of the various colors that should be available */
@@ -62,7 +64,8 @@ const defaultPreferences: PreferencesModel = {
         zoom: 10,
         basemapShortname: 'osm',
         overlayOpacity: 50,
-        overlayColor: 'black'
+        overlayColor: 'black',
+        pathWaypointMinZoom: 10
     },
     socketUploadChunkSize: 10240000,
     defaultWalkingSpeedMetersPerSeconds: 5 / 3.6,

--- a/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
+++ b/packages/chaire-lib-frontend/src/services/map/MapLayerManager.ts
@@ -330,6 +330,36 @@ class MapLibreLayerManager {
     getLayerConfig(layerName: string) {
         return this._layersByName[layerName];
     }
+
+    /**
+     * Updates a layer's minimum zoom on the map and in the stored spec (so re-add uses the new value).
+     *
+     * @param layerName MapLibre layer id
+     * @param minZoom Minimum zoom (inclusive)
+     */
+    updateLayerMinZoom(layerName: string, minZoom: number) {
+        const entry = this._layersByName[layerName];
+        if (!entry) {
+            return;
+        }
+        const spec = entry.layer as LayerSpecification & { minzoom?: number; maxzoom?: number };
+        spec.minzoom = minZoom;
+        if (!this._map?.getLayer(layerName)) {
+            return;
+        }
+        const existingLayer = this._map.getLayer(layerName);
+        const maxZoom = existingLayer?.maxzoom ?? this._map.getMaxZoom();
+        this._map.setLayerZoomRange(layerName, minZoom, maxZoom);
+    }
+
+    /**
+     * Applies the same minimum zoom to several layers (e.g. path waypoint layers after preference change).
+     */
+    updateLayersMinZoom(layerNames: string[], minZoom: number) {
+        for (let i = 0; i < layerNames.length; i++) {
+            this.updateLayerMinZoom(layerNames[i], minZoom);
+        }
+    }
 }
 
 export default MapLibreLayerManager;

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import _toString from 'lodash/toString';
 import Collapsible from 'react-collapsible';
-import { WithTranslation, withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
@@ -19,19 +19,14 @@ import {
     WAYPOINT_MIN_ZOOM_DEFAULT
 } from '../../../../config/layers.config';
 
-const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
-    props: PreferencesSectionProps & WithTranslation
-) => {
+const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSectionProps> = (props) => {
+    const { t } = useTranslation(['main', 'transit']);
     const prefs = props.preferences.attributes;
 
     return (
-        <Collapsible trigger={props.t('transit:transitPath:Paths')} open={true} transitionTime={100}>
+        <Collapsible trigger={t('transit:transitPath:Paths')} open={true} transitionTime={100}>
             <div className="tr__form-section">
-                <InputWrapper
-                    twoColumns={true}
-                    key="waypointMinZoom"
-                    label={props.t('transit:transitPath:WaypointMinZoom')}
-                >
+                <InputWrapper twoColumns={true} key="waypointMinZoom" label={t('transit:transitPath:WaypointMinZoom')}>
                     <InputStringFormatted
                         id="formFieldPreferencesTransitPathWaypointMinZoom"
                         value={prefs.map?.pathWaypointMinZoom ?? WAYPOINT_MIN_ZOOM_DEFAULT}
@@ -60,11 +55,11 @@ const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSection
                         preferences={props.preferences}
                     />
                 </InputWrapper>
-                <p className="apptr__form-help-text">{props.t('transit:transitPath:WaypointMinZoomHelp')}</p>
-                <p className="apptr__form-help-text">{props.t('transit:transitPath:WaypointMinZoomRefreshHint')}</p>
+                <p className="apptr__form-help-text">{t('transit:transitPath:WaypointMinZoomHelp')}</p>
+                <p className="apptr__form-help-text">{t('transit:transitPath:WaypointMinZoomRefreshHint')}</p>
             </div>
         </Collapsible>
     );
 };
 
-export default withTranslation(['main', 'transit'])(PreferencesSectionTransitPaths);
+export default PreferencesSectionTransitPaths;

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionTransitPaths.tsx
@@ -5,14 +5,66 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React from 'react';
-
+import _toString from 'lodash/toString';
+import Collapsible from 'react-collapsible';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
+import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
+import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import PreferencesSectionProps from '../PreferencesSectionProps';
+import { parseIntOrNull } from 'chaire-lib-common/lib/utils/MathUtils';
+import {
+    WAYPOINT_MIN_ZOOM_ALLOWED_MAX,
+    WAYPOINT_MIN_ZOOM_ALLOWED_MIN,
+    WAYPOINT_MIN_ZOOM_DEFAULT
+} from '../../../../config/layers.config';
 
-// TODO: Implement this component or delete it.
-const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSectionProps> = (
-    _props: PreferencesSectionProps
+const PreferencesSectionTransitPaths: React.FunctionComponent<PreferencesSectionProps & WithTranslation> = (
+    props: PreferencesSectionProps & WithTranslation
 ) => {
-    return null;
+    const prefs = props.preferences.attributes;
+
+    return (
+        <Collapsible trigger={props.t('transit:transitPath:Paths')} open={true} transitionTime={100}>
+            <div className="tr__form-section">
+                <InputWrapper
+                    twoColumns={true}
+                    key="waypointMinZoom"
+                    label={props.t('transit:transitPath:WaypointMinZoom')}
+                >
+                    <InputStringFormatted
+                        id="formFieldPreferencesTransitPathWaypointMinZoom"
+                        value={prefs.map?.pathWaypointMinZoom ?? WAYPOINT_MIN_ZOOM_DEFAULT}
+                        onValueUpdated={(payload) => {
+                            // HTML min/max sets valid:false without updating prefs, so validate() never runs.
+                            // Always forward so Preferences.validate() can set errors (see FormErrors at bottom of panel).
+                            if (payload.valid === false) {
+                                props.onValueChange('map.pathWaypointMinZoom', {
+                                    value: payload.value,
+                                    valid: true
+                                });
+                            } else {
+                                props.onValueChange('map.pathWaypointMinZoom', payload);
+                            }
+                        }}
+                        key={`formFieldPreferencesTransitPathWaypointMinZoom_${props.resetChangesCount}`}
+                        stringToValue={parseIntOrNull}
+                        valueToString={(val) => _toString(parseIntOrNull(val))}
+                        type="number"
+                        min={WAYPOINT_MIN_ZOOM_ALLOWED_MIN}
+                        max={WAYPOINT_MIN_ZOOM_ALLOWED_MAX}
+                    />
+                    <PreferencesResetToDefaultButton
+                        resetPrefToDefault={props.resetPrefToDefault}
+                        path="map.pathWaypointMinZoom"
+                        preferences={props.preferences}
+                    />
+                </InputWrapper>
+                <p className="apptr__form-help-text">{props.t('transit:transitPath:WaypointMinZoomHelp')}</p>
+                <p className="apptr__form-help-text">{props.t('transit:transitPath:WaypointMinZoomRefreshHint')}</p>
+            </div>
+        </Collapsible>
+    );
 };
 
-export default PreferencesSectionTransitPaths;
+export default withTranslation(['main', 'transit'])(PreferencesSectionTransitPaths);

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -27,12 +27,11 @@ import { MapEventHandlerDescription } from 'chaire-lib-frontend/lib/services/map
 import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 // Local workspace imports
-import layersConfig, {
-    getWaypointMinZoom,
-    sectionLayers,
-    overlaySource,
-    TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES
-} from '../../config/layers.config';
+import layersConfig, { sectionLayers, overlaySource } from '../../config/layers.config';
+import pathWaypointZoomSync, {
+    MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT,
+    MapUpdateLayersMinZoomPayload
+} from '../../services/map/PathWaypointZoomSync';
 import { polygonSelectionService } from '../../services/map/PolygonSelectionService';
 import transitionMapEvents from '../../services/map/events';
 import mapCustomEvents from '../../services/map/events/MapRelatedCustomEvents';
@@ -212,16 +211,17 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         this.layerManager.setMap(map);
         this.popupManager.setMap(map);
         this.layerManager.updateEnabledLayers(this.state.layers);
-        this.applyWaypointMinZoomFromPreferences();
+        // Trigger an initial generic min-zoom update for any layer whose min zoom
+        // is driven by a preference (e.g. path waypoints).
+        pathWaypointZoomSync.applyNow(serviceLocator.eventManager);
 
         this.setState({ mapLoaded: true });
         serviceLocator.eventManager.emit('map.loaded');
     };
 
-    /** Sync path waypoint layer min zoom with user preference (and after preference save). */
-    applyWaypointMinZoomFromPreferences = () => {
-        const minZ = getWaypointMinZoom();
-        this.layerManager.updateLayersMinZoom([...TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES], minZ);
+    /** Generic handler: update the minzoom of the given map layers. */
+    updateLayersMinZoom = (payload: MapUpdateLayersMinZoomPayload) => {
+        this.layerManager.updateLayersMinZoom(payload.layerNames, payload.minZoom);
     };
 
     showPathsByAttribute = (attribute: string, value: any) => {
@@ -285,7 +285,8 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.on('map.deleteSelectedNodes', this.deleteSelectedNodes);
         serviceLocator.eventManager.on('map.deleteSelectedPolygon', this.onDeleteSelectedPolygon);
         serviceLocator.eventManager.on('collection.update.nodes', this.onNodesUpdatedHandler);
-        serviceLocator.eventManager.on('preferences.updated', this.applyWaypointMinZoomFromPreferences);
+        serviceLocator.eventManager.on(MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT, this.updateLayersMinZoom);
+        pathWaypointZoomSync.start(serviceLocator.eventManager);
     };
 
     onDeleteSelectedPolygon = () => {
@@ -331,7 +332,8 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.off('map.deleteSelectedNodes', this.deleteSelectedNodes);
         serviceLocator.eventManager.off('map.deleteSelectedPolygon', this.onDeleteSelectedPolygon);
         serviceLocator.eventManager.off('collection.update.nodes', this.onNodesUpdatedHandler);
-        serviceLocator.eventManager.off('preferences.updated', this.applyWaypointMinZoomFromPreferences);
+        serviceLocator.eventManager.off(MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT, this.updateLayersMinZoom);
+        pathWaypointZoomSync.stop();
 
         // Remove map event listeners BEFORE react-map-gl cleans up
         // We need to do this early because react-map-gl will call map.remove() automatically

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -27,7 +27,12 @@ import { MapEventHandlerDescription } from 'chaire-lib-frontend/lib/services/map
 import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 // Local workspace imports
-import layersConfig, { sectionLayers, overlaySource } from '../../config/layers.config';
+import layersConfig, {
+    getWaypointMinZoom,
+    sectionLayers,
+    overlaySource,
+    TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES
+} from '../../config/layers.config';
 import { polygonSelectionService } from '../../services/map/PolygonSelectionService';
 import transitionMapEvents from '../../services/map/events';
 import mapCustomEvents from '../../services/map/events/MapRelatedCustomEvents';
@@ -207,9 +212,16 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         this.layerManager.setMap(map);
         this.popupManager.setMap(map);
         this.layerManager.updateEnabledLayers(this.state.layers);
+        this.applyWaypointMinZoomFromPreferences();
 
         this.setState({ mapLoaded: true });
         serviceLocator.eventManager.emit('map.loaded');
+    };
+
+    /** Sync path waypoint layer min zoom with user preference (and after preference save). */
+    applyWaypointMinZoomFromPreferences = () => {
+        const minZ = getWaypointMinZoom();
+        this.layerManager.updateLayersMinZoom([...TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES], minZ);
     };
 
     showPathsByAttribute = (attribute: string, value: any) => {
@@ -273,6 +285,7 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.on('map.deleteSelectedNodes', this.deleteSelectedNodes);
         serviceLocator.eventManager.on('map.deleteSelectedPolygon', this.onDeleteSelectedPolygon);
         serviceLocator.eventManager.on('collection.update.nodes', this.onNodesUpdatedHandler);
+        serviceLocator.eventManager.on('preferences.updated', this.applyWaypointMinZoomFromPreferences);
     };
 
     onDeleteSelectedPolygon = () => {
@@ -318,6 +331,7 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.off('map.deleteSelectedNodes', this.deleteSelectedNodes);
         serviceLocator.eventManager.off('map.deleteSelectedPolygon', this.onDeleteSelectedPolygon);
         serviceLocator.eventManager.off('collection.update.nodes', this.onNodesUpdatedHandler);
+        serviceLocator.eventManager.off('preferences.updated', this.applyWaypointMinZoomFromPreferences);
 
         // Remove map event listeners BEFORE react-map-gl cleans up
         // We need to do this early because react-map-gl will call map.remove() automatically

--- a/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
+++ b/packages/transition-frontend/src/components/map/TransitionMainMap.tsx
@@ -27,12 +27,11 @@ import { MapEventHandlerDescription } from 'chaire-lib-frontend/lib/services/map
 import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 // Local workspace imports
-import layersConfig, {
-    getWaypointMinZoom,
-    sectionLayers,
-    overlaySource,
-    TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES
-} from '../../config/layers.config';
+import layersConfig, { sectionLayers, overlaySource } from '../../config/layers.config';
+import pathWaypointZoomSync, {
+    MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT,
+    MapUpdateLayersMinZoomPayload
+} from '../../services/map/PathWaypointZoomSync';
 import { polygonSelectionService } from '../../services/map/PolygonSelectionService';
 import transitionMapEvents from '../../services/map/events';
 import mapCustomEvents from '../../services/map/events/MapRelatedCustomEvents';
@@ -212,16 +211,18 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         this.layerManager.setMap(map);
         this.popupManager.setMap(map);
         this.layerManager.updateEnabledLayers(this.state.layers);
-        this.applyWaypointMinZoomFromPreferences();
+        // The waypoint layers bake their minzoom at module-load time (layers.config),
+        // before user preferences are loaded asynchronously. Reapply it now that the
+        // map exists so the user's saved preference takes effect on first load.
+        pathWaypointZoomSync.applyNow(serviceLocator.eventManager);
 
         this.setState({ mapLoaded: true });
         serviceLocator.eventManager.emit('map.loaded');
     };
 
-    /** Sync path waypoint layer min zoom with user preference (and after preference save). */
-    applyWaypointMinZoomFromPreferences = () => {
-        const minZ = getWaypointMinZoom();
-        this.layerManager.updateLayersMinZoom([...TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES], minZ);
+    /** Generic handler: update the minzoom of the given map layers. */
+    updateLayersMinZoom = (payload: MapUpdateLayersMinZoomPayload) => {
+        this.layerManager.updateLayersMinZoom(payload.layerNames, payload.minZoom);
     };
 
     showPathsByAttribute = (attribute: string, value: any) => {
@@ -285,7 +286,8 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.on('map.deleteSelectedNodes', this.deleteSelectedNodes);
         serviceLocator.eventManager.on('map.deleteSelectedPolygon', this.onDeleteSelectedPolygon);
         serviceLocator.eventManager.on('collection.update.nodes', this.onNodesUpdatedHandler);
-        serviceLocator.eventManager.on('preferences.updated', this.applyWaypointMinZoomFromPreferences);
+        serviceLocator.eventManager.on(MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT, this.updateLayersMinZoom);
+        pathWaypointZoomSync.start(serviceLocator.eventManager);
     };
 
     onDeleteSelectedPolygon = () => {
@@ -331,7 +333,8 @@ class MainMap extends React.Component<MainMapProps & WithTranslation & PropsWith
         serviceLocator.eventManager.off('map.deleteSelectedNodes', this.deleteSelectedNodes);
         serviceLocator.eventManager.off('map.deleteSelectedPolygon', this.onDeleteSelectedPolygon);
         serviceLocator.eventManager.off('collection.update.nodes', this.onNodesUpdatedHandler);
-        serviceLocator.eventManager.off('preferences.updated', this.applyWaypointMinZoomFromPreferences);
+        serviceLocator.eventManager.off(MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT, this.updateLayersMinZoom);
+        pathWaypointZoomSync.stop();
 
         // Remove map event listeners BEFORE react-map-gl cleans up
         // We need to do this early because react-map-gl will call map.remove() automatically

--- a/packages/transition-frontend/src/config/layers.config.ts
+++ b/packages/transition-frontend/src/config/layers.config.ts
@@ -21,17 +21,11 @@ export const TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES = [
 
 /**
  * Minimum map zoom for waypoint visibility and add/remove/drag operations.
- * Reads `map.pathWaypointMinZoom`, or legacy `transit.paths.waypointMinZoom`, then clamps.
+ * Reads `map.pathWaypointMinZoom` and clamps to the allowed range; falls back to
+ * `WAYPOINT_MIN_ZOOM_DEFAULT` if missing or non-finite.
  */
 export const getWaypointMinZoom = (): number => {
-    const fromMap = Preferences.get('map.pathWaypointMinZoom');
-    const legacy = Preferences.get('transit.paths.waypointMinZoom');
-    let raw = WAYPOINT_MIN_ZOOM_DEFAULT;
-    if (typeof fromMap === 'number' && Number.isFinite(fromMap)) {
-        raw = fromMap;
-    } else if (typeof legacy === 'number' && Number.isFinite(legacy)) {
-        raw = legacy;
-    }
+    const raw = Preferences.get('map.pathWaypointMinZoom');
     const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
     if (!Number.isFinite(n)) {
         return WAYPOINT_MIN_ZOOM_DEFAULT;

--- a/packages/transition-frontend/src/config/layers.config.ts
+++ b/packages/transition-frontend/src/config/layers.config.ts
@@ -5,8 +5,39 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 
-/** Minimum zoom level for waypoint visibility and operations */
-export const WAYPOINT_MIN_ZOOM = 14;
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
+
+/** Default and allowed bounds for `map.pathWaypointMinZoom` (must match preferences validation) */
+export const WAYPOINT_MIN_ZOOM_DEFAULT = 10;
+export const WAYPOINT_MIN_ZOOM_ALLOWED_MIN = 1;
+export const WAYPOINT_MIN_ZOOM_ALLOWED_MAX = 15;
+
+/** MapLibre layers whose `minzoom` follows the waypoint preference */
+export const TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES = [
+    'transitPathWaypoints',
+    'transitPathWaypointsSelected',
+    'transitPathWaypointsErrors'
+] as const;
+
+/**
+ * Minimum map zoom for waypoint visibility and add/remove/drag operations.
+ * Reads `map.pathWaypointMinZoom`, or legacy `transit.paths.waypointMinZoom`, then clamps.
+ */
+export const getWaypointMinZoom = (): number => {
+    const fromMap = Preferences.get('map.pathWaypointMinZoom');
+    const legacy = Preferences.get('transit.paths.waypointMinZoom');
+    let raw = WAYPOINT_MIN_ZOOM_DEFAULT;
+    if (typeof fromMap === 'number' && Number.isFinite(fromMap)) {
+        raw = fromMap;
+    } else if (typeof legacy === 'number' && Number.isFinite(legacy)) {
+        raw = legacy;
+    }
+    const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+    if (!Number.isFinite(n)) {
+        return WAYPOINT_MIN_ZOOM_DEFAULT;
+    }
+    return Math.min(WAYPOINT_MIN_ZOOM_ALLOWED_MAX, Math.max(WAYPOINT_MIN_ZOOM_ALLOWED_MIN, Math.round(n)));
+};
 
 // Define which layers should be visible for each section
 export const sectionLayers = {
@@ -343,7 +374,7 @@ const layersConfig = {
 
     transitPathWaypoints: {
         type: 'circle',
-        minzoom: WAYPOINT_MIN_ZOOM,
+        minzoom: getWaypointMinZoom(),
         paint: {
             'circle-radius': {
                 base: 1,
@@ -369,7 +400,7 @@ const layersConfig = {
 
     transitPathWaypointsSelected: {
         type: 'circle',
-        minzoom: WAYPOINT_MIN_ZOOM,
+        minzoom: getWaypointMinZoom(),
         paint: {
             'circle-radius': {
                 base: 1,
@@ -395,7 +426,7 @@ const layersConfig = {
 
     transitPathWaypointsErrors: {
         type: 'circle',
-        minzoom: WAYPOINT_MIN_ZOOM,
+        minzoom: getWaypointMinZoom(),
         paint: {
             'circle-radius': {
                 base: 1,

--- a/packages/transition-frontend/src/services/map/PathWaypointZoomSync.ts
+++ b/packages/transition-frontend/src/services/map/PathWaypointZoomSync.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { EventEmitter } from 'events';
+
+import { getWaypointMinZoom, TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES } from '../../config/layers.config';
+
+/** Generic event the map subscribes to to update the minzoom of a list of layers. */
+export const MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT = 'map.updateLayersMinZoom';
+
+/** Payload of {@link MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT}. */
+export type MapUpdateLayersMinZoomPayload = {
+    layerNames: string[];
+    minZoom: number;
+};
+
+/**
+ * Bridges the waypoint min-zoom preference to a generic map event so the map
+ * does not need to know about a specific preference.
+ *
+ * On `preferences.updated` (and on demand via {@link applyNow}) it reads
+ * `getWaypointMinZoom()` and emits {@link MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT} with
+ * the path waypoint layer names and the resolved min zoom.
+ */
+class PathWaypointZoomSync {
+    private _eventManager: EventEmitter | undefined;
+
+    /** Subscribe to preference updates. Idempotent. */
+    start(eventManager: EventEmitter): void {
+        if (this._eventManager) {
+            return;
+        }
+        this._eventManager = eventManager;
+        eventManager.on('preferences.updated', this._onPreferencesUpdated);
+    }
+
+    /** Unsubscribe. Safe to call when not started. */
+    stop(): void {
+        if (!this._eventManager) {
+            return;
+        }
+        this._eventManager.off('preferences.updated', this._onPreferencesUpdated);
+        this._eventManager = undefined;
+    }
+
+    /** Emit the generic event now (e.g. after the map first loads). */
+    applyNow(eventManager: EventEmitter): void {
+        const payload: MapUpdateLayersMinZoomPayload = {
+            layerNames: [...TRANSIT_PATH_WAYPOINT_MAP_LAYER_NAMES],
+            minZoom: getWaypointMinZoom()
+        };
+        eventManager.emit(MAP_UPDATE_LAYERS_MIN_ZOOM_EVENT, payload);
+    }
+
+    private _onPreferencesUpdated = (): void => {
+        if (this._eventManager) {
+            this.applyNow(this._eventManager);
+        }
+    };
+}
+
+export default new PathWaypointZoomSync();

--- a/packages/transition-frontend/src/services/map/events/PathSectionMapEvents.ts
+++ b/packages/transition-frontend/src/services/map/events/PathSectionMapEvents.ts
@@ -12,7 +12,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import TransitPath from 'transition-common/lib/services/path/Path';
 import TransitLine from 'transition-common/lib/services/line/Line';
 import { unhoverPath } from './PathLayerMapEvents';
-import { WAYPOINT_MIN_ZOOM } from '../../../config/layers.config';
+import { getWaypointMinZoom } from '../../../config/layers.config';
 import { addDraggingClass, removeDraggingClass, removeHoverClass } from '../MapCursorHelper';
 
 /* This file encapsulates map events specific for the paths */
@@ -83,9 +83,10 @@ const onPathWaypointMouseUp = (e: MapMouseEvent) => {
             map._hoverNodeSource = null;
         }
 
-        const features = e.target.queryRenderedFeatures(e.point);
-        const featureSources = features.map((feature) => feature.source);
-        const hoverNodeIndex = featureSources.indexOf('transitNodes');
+        // Restrict to MapLibre layer to avoid deck.gl interleaved overlay
+        // returning a 'overlay' source instead of 'transitNodes'.
+        const features = e.target.queryRenderedFeatures(e.point, { layers: ['transitNodes'] });
+        const hoverNodeIndex = features.length > 0 ? 0 : -1;
         if (hoverNodeIndex >= 0) {
             // replace waypoint by node
             const nodeGeojson = features[hoverNodeIndex];
@@ -221,11 +222,25 @@ const showPathSelectionContextMenu = (paths: MapGeoJSONFeature[], e: MapMouseEve
 // Click tolerance in pixels for path/node/waypoint detection
 const CLICK_TOLERANCE = 5;
 
+// MapLibre layers consulted by the path-section click handler. Restricting the
+// query excludes deck.gl interleaved layers (source: 'overlay') which would
+// otherwise occlude these and make every click look like it landed on nothing.
+const PATH_SECTION_CLICK_LAYERS = [
+    'transitNodes',
+    'transitNodesSelected',
+    'transitPathWaypoints',
+    'transitPathsSelected',
+    'transitPaths'
+];
+
 const onPathSectionMapClick = async (e: MapMouseEvent) => {
-    const features = e.target.queryRenderedFeatures([
-        [e.point.x - CLICK_TOLERANCE, e.point.y - CLICK_TOLERANCE],
-        [e.point.x + CLICK_TOLERANCE, e.point.y + CLICK_TOLERANCE]
-    ]);
+    const features = e.target.queryRenderedFeatures(
+        [
+            [e.point.x - CLICK_TOLERANCE, e.point.y - CLICK_TOLERANCE],
+            [e.point.x + CLICK_TOLERANCE, e.point.y + CLICK_TOLERANCE]
+        ],
+        { layers: PATH_SECTION_CLICK_LAYERS }
+    );
 
     const map = e.target;
     const featureSources = features.map((feature) => {
@@ -320,7 +335,7 @@ const onPathSectionMapClick = async (e: MapMouseEvent) => {
             clickedNodeIndex < 0
         ) {
             // Skip waypoint operations below minimum zoom level (waypoints are hidden below this zoom)
-            if (map.getZoom() < WAYPOINT_MIN_ZOOM) {
+            if (map.getZoom() < getWaypointMinZoom()) {
                 return;
             }
             // Skip if another path update is in progress to prevent race conditions
@@ -365,7 +380,7 @@ const onPathSectionMapClick = async (e: MapMouseEvent) => {
             } else {
                 // add waypoint
                 // Skip waypoint operations below minimum zoom level (waypoints are hidden below this zoom)
-                if (map.getZoom() < WAYPOINT_MIN_ZOOM) {
+                if (map.getZoom() < getWaypointMinZoom()) {
                     return;
                 }
                 // Skip if another path update is in progress to prevent race conditions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable minimum zoom for transit path waypoints (controls when waypoints are visible/editable).
  * Preference UI to set the waypoint minimum zoom and a reset-to-default option.
  * Map sync so changes take effect across the map.

* **Bug Fixes**
  * Validation added to ensure zoom values are integers within 1–15.
  * Refresh hint: page refresh required for some map updates to apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->