### PR TITLE
Detect malformated End of Line in GTFS import

### DIFF
--- a/locales/en/transit.json
+++ b/locales/en/transit.json
@@ -853,7 +853,8 @@
             "ErrorImportingAgencies": "An error occurred while importing agencies from GTFS. Agencies may not have been imported properly.",
             "ErrorImportingLines": "An error occurred while importing lines from GTFS. Lines may not have been imported properly.",
             "ErrorImportingServices": "An error occurred while importing services from GTFS. Services may not have been imported properly.",
-            "ErrorExportingGtfs": "An error occurred while generating the GTFS file."
+            "ErrorExportingGtfs": "An error occurred while generating the GTFS file.",
+            "MalformedCsvFile": "The file \"{{fileName}}\" has malformed line endings that prevent the GTFS from being read. Try normalizing the line endings, e.g. with `dos2unix {{fileName}}`."
         }
     },
     "simulation": {

--- a/locales/fr/transit.json
+++ b/locales/fr/transit.json
@@ -853,7 +853,8 @@
             "ErrorImportingAgencies": "Une erreur s'est produite lors de l'import des agences à partir du GTFS. Les agences n'ont peut-être pas toutes été importées.",
             "ErrorImportingLines": "Une erreur s'est produite lors de l'import des lignes à partir du GTFS. Les lignes n'ont peut-être pas toutes été importées.",
             "ErrorImportingServices": "Une erreur s'est produite lors de l'import des services à partir du GTFS. Les services n'ont peut-être pas tous été importés.",
-            "ErrorExportingGtfs": "Une erreur s'est produite lors de la génération de l'archive GTFS."
+            "ErrorExportingGtfs": "Une erreur s'est produite lors de la génération de l'archive GTFS.",
+            "MalformedCsvFile": "Le fichier « {{fileName}} » a des fins de ligne mal formées qui empêchent le GTFS d'être lu. Essayez de normaliser les fins de ligne, par exemple avec la commande `dos2unix {{fileName}}`."
         }
     },
     "simulation": {

--- a/packages/chaire-lib-backend/src/services/files/CsvFile.ts
+++ b/packages/chaire-lib-backend/src/services/files/CsvFile.ts
@@ -5,7 +5,53 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import fs from 'fs';
+import path from 'path';
 import { parseCsvFile as parse, CsvFileAttributes } from 'chaire-lib-common/lib/utils/files/CsvFile';
+
+/**
+ * Detect symptoms of CSV-parser line-ending confusion in a parsed row. If a
+ * header key or first-column value contains an embedded `\r` or `\n`, the
+ * parser has almost certainly misread the file's line endings (e.g. on
+ * `\r\r\n` / CRCRLF input). Returns a description of the problem, or `null`
+ * if the row looks healthy. See chairemobilite/transition#1909.
+ */
+const detectMalformedRow = (row: { [key: string]: any } | any[]): string | null => {
+    if (Array.isArray(row)) {
+        // header: false: any newline in any cell signals corruption.
+        for (let i = 0; i < row.length; i++) {
+            const cell = row[i];
+            if (typeof cell === 'string' && /[\r\n]/.test(cell)) {
+                return `field at column ${i} contains an embedded newline character: ${JSON.stringify(cell.slice(0, 40))}`;
+            }
+        }
+        return null;
+    }
+    // header: true: check the keys, and the first column's value. We avoid
+    // checking later columns to leave room for legitimate RFC 4180 multiline
+    // quoted text; GTFS first columns are always IDs that never contain
+    // newlines, so a newline there is unambiguous corruption.
+    const keys = Object.keys(row);
+    for (const key of keys) {
+        if (/[\r\n]/.test(key)) {
+            return `header column name contains an embedded newline character: ${JSON.stringify(key.slice(0, 40))}`;
+        }
+    }
+    if (keys.length > 0) {
+        const firstValue = row[keys[0]];
+        if (typeof firstValue === 'string' && /[\r\n]/.test(firstValue)) {
+            return `value of "${keys[0]}" contains an embedded newline character: ${JSON.stringify(firstValue.slice(0, 40))}`;
+        }
+    }
+    return null;
+};
+
+const buildMalformedCsvError = (filePath: string, detail: string): Error => {
+    const fileName = path.basename(filePath);
+    return new Error(
+        `CSV file "${fileName}" has malformed line endings (${detail}). ` +
+            `Try normalizing them with \`dos2unix ${fileName}\`.`
+    );
+};
 
 /**
  * Wrapper around the papaparse file parser for CSV files. It transforms the
@@ -32,7 +78,24 @@ export const parseCsvFile = async (
     return new Promise((resolve, reject) => {
         if (fs.existsSync(filePath)) {
             const readStream = fs.createReadStream(filePath);
-            parse(readStream, rowCallback, options)
+            // Sanity-check the first few rows for parser line-ending
+            // confusion. After the check window, the wrapper falls away.
+            // Three rows is enough to catch CRCRLF in `header: false` mode,
+            // where row 1 ends up as an empty cell `[""]` between the two
+            // CRs and the corruption only shows up on row 2.
+            const ROWS_TO_CHECK_FOR_CORRUPTION = 3;
+            let rowsCheckedForCorruption = 0;
+            const wrappedCallback = (row: any, rowNumber: number) => {
+                if (rowsCheckedForCorruption < ROWS_TO_CHECK_FOR_CORRUPTION) {
+                    rowsCheckedForCorruption++;
+                    const problem = detectMalformedRow(row);
+                    if (problem !== null) {
+                        throw buildMalformedCsvError(filePath, problem);
+                    }
+                }
+                rowCallback(row, rowNumber);
+            };
+            parse(readStream, wrappedCallback, options)
                 .then((result) => {
                     console.log(`CSV file ${filePath} parsed`);
                     resolve(result);

--- a/packages/chaire-lib-backend/src/services/files/CsvFile.ts
+++ b/packages/chaire-lib-backend/src/services/files/CsvFile.ts
@@ -7,6 +7,8 @@
 import fs from 'fs';
 import path from 'path';
 import { parseCsvFile as parse, CsvFileAttributes } from 'chaire-lib-common/lib/utils/files/CsvFile';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 
 /**
  * Detect symptoms of CSV-parser line-ending confusion in a parsed row. If a
@@ -45,13 +47,53 @@ const detectMalformedRow = (row: { [key: string]: any } | any[]): string | null 
     return null;
 };
 
-const buildMalformedCsvError = (filePath: string, detail: string): Error => {
-    const fileName = path.basename(filePath);
-    return new Error(
-        `CSV file "${fileName}" has malformed line endings (${detail}). ` +
-            `Try normalizing them with \`dos2unix ${fileName}\`.`
-    );
+/**
+ * Thrown by `parseCsvFile` when the CSV parser appears to be confused by
+ * malformed line endings in the input. As a `TrError`, it carries both a
+ * technical message (visible in server logs) and an optional localized
+ * message keyed for the UI, so callers can rethrow it without needing to
+ * know its specific type.
+ *
+ * The localized message is supplied by the caller (typically via a
+ * `parseCsvFile` option) rather than hard-coded here, because `parseCsvFile`
+ * is consumed in multiple domains (GTFS imports, OD trip CSVs, demographic
+ * data, etc.) that each have their own i18n namespace. See
+ * chairemobilite/transition#1909.
+ */
+export class MalformedCsvError extends TrError {
+    constructor(fileName: string, detail: string, localizedMessage: TranslatableMessage = '') {
+        super(
+            `CSV file "${fileName}" has malformed line endings (${detail}). ` +
+                `Try normalizing them with \`dos2unix ${fileName}\`.`,
+            'MALFORMED_CSV_LINE_ENDINGS',
+            localizedMessage
+        );
+    }
+}
+
+const buildMalformedCsvError = (
+    filePath: string,
+    detail: string,
+    localizedMessage: TranslatableMessage = ''
+): MalformedCsvError => {
+    return new MalformedCsvError(path.basename(filePath), detail, localizedMessage);
 };
+
+/**
+ * Options for `parseCsvFile` that are specific to the backend wrapper (i.e.
+ * not part of the underlying papaparse options).
+ */
+export interface BackendCsvFileOptions {
+    /**
+     * Translatable message to attach to a `MalformedCsvError` if the parser
+     * detects line-ending corruption in the file. Each calling domain (GTFS,
+     * OD trips, demographic data, etc.) supplies its own i18n key so the user
+     * sees a domain-appropriate message. If omitted, the error is still
+     * thrown but without a localized message; callers receiving it will fall
+     * back to whatever generic message they would normally show.
+     */
+    malformedCsvLocalizedMessage?: (fileName: string) => TranslatableMessage;
+}
 
 /**
  * Wrapper around the papaparse file parser for CSV files. It transforms the
@@ -65,14 +107,16 @@ const buildMalformedCsvError = (filePath: string, detail: string): Error => {
  * row as keys, otherwise, it is an array, with the index of each
  * comma-separated element as key. The rowNumber is the current row number, with
  * first row being 1.
- * @param {Partial<CsvFileAttributes>} options Options for file read
+ * @param {Partial<CsvFileAttributes> & BackendCsvFileOptions} options Options
+ * for file read. Combines the underlying papaparse options with backend-only
+ * options like `malformedCsvLocalizedMessage`.
  * @return {*}  {(Promise<'completed' | 'notfound'>)} 'completed' when the file
  * was read without error, 'notfound' if the file was not found.
  */
 export const parseCsvFile = async (
     filePath: string,
     rowCallback: (object: { [key: string]: any }, rowNumber: number) => void,
-    options: Partial<CsvFileAttributes>
+    options: Partial<CsvFileAttributes> & BackendCsvFileOptions
 ): Promise<'completed' | 'notfound'> => {
     console.log(`parsing csv file ${filePath}...`);
     return new Promise((resolve, reject) => {
@@ -90,7 +134,11 @@ export const parseCsvFile = async (
                     rowsCheckedForCorruption++;
                     const problem = detectMalformedRow(row);
                     if (problem !== null) {
-                        throw buildMalformedCsvError(filePath, problem);
+                        const fileName = path.basename(filePath);
+                        const localized = options.malformedCsvLocalizedMessage
+                            ? options.malformedCsvLocalizedMessage(fileName)
+                            : '';
+                        throw buildMalformedCsvError(filePath, problem, localized);
                     }
                 }
                 rowCallback(row, rowNumber);

--- a/packages/chaire-lib-backend/src/services/files/__tests__/CsvFile.test.ts
+++ b/packages/chaire-lib-backend/src/services/files/__tests__/CsvFile.test.ts
@@ -7,7 +7,8 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { parseCsvFile } from '../CsvFile';
+import { parseCsvFile, MalformedCsvError } from '../CsvFile';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
 
 const filePath = `${__dirname}/testFiles/test.csv`;
 
@@ -109,36 +110,62 @@ describe('Detection of CSV-parser line-ending corruption (issue #1909)', () => {
         } catch (err) {
             thrownError = err;
         }
-        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError).toBeInstanceOf(MalformedCsvError);
+        expect(thrownError).toBeInstanceOf(TrError);
+        expect(TrError.isTrError(thrownError)).toBe(true);
+        // Technical message goes to logs
         expect(thrownError.message).toMatch(/malformed line endings/i);
-        // Error should name the file and offer a concrete repair hint
         expect(thrownError.message).toMatch(new RegExp(path.basename(fixture)));
         expect(thrownError.message).toMatch(/dos2unix/);
+        // No localized message by default: the parser is domain-agnostic;
+        // callers opt in by supplying `malformedCsvLocalizedMessage`.
+        expect((thrownError as TrError).export().localizedMessage).toEqual('');
     });
 
-    test('Rejects when an embedded LF in the header confuses the parser', async () => {
-        // LF inside the header makes papaparse pick `\n` as the terminator,
-        // leaving stray `\r` bytes on values. Detection catches it via
-        // either the keys or the first-column values.
-        const fixture = writeFixture(
-            'broken-header.csv',
-            'stop_id,stop\nname\r\n1,Station A\r\n'
-        );
+    test('Threads a caller-supplied localized message through to the thrown error', async () => {
+        const fixture = writeFixture('bad-with-locale.csv', [HEADER, ROW1, ROW2].join('\r\r\n') + '\r\r\n');
         let thrownError: any = undefined;
         try {
-            await parseCsvFile(fixture, () => undefined, { header: true });
+            await parseCsvFile(fixture, () => undefined, {
+                header: true,
+                malformedCsvLocalizedMessage: (fileName) => ({
+                    text: 'some:domain:errors:MalformedCsvFile',
+                    params: { fileName }
+                })
+            });
         } catch (err) {
             thrownError = err;
         }
-        expect(thrownError).toBeInstanceOf(Error);
-        expect(thrownError.message).toMatch(/embedded newline/i);
+        expect(thrownError).toBeInstanceOf(MalformedCsvError);
+        expect((thrownError as TrError).export().localizedMessage).toEqual({
+            text: 'some:domain:errors:MalformedCsvFile',
+            params: { fileName: path.basename(fixture) }
+        });
     });
 
-    test('Rejects in header:false mode when the header row has a stray newline', async () => {
-        const fixture = writeFixture('crcrlf-no-header.csv', [HEADER, ROW1, ROW2].join('\r\r\n') + '\r\r\n');
+    // Both cases share the same assertion shape; only the fixture content,
+    // filename, and `header` option differ. LF inside the header (in
+    // header:true mode) and CRCRLF in header:false mode are different
+    // mechanisms that produce the same symptom: a parsed row whose value
+    // contains an embedded newline character.
+    test.each([
+        [
+            'embedded LF in header (header:true)',
+            'broken-header.csv',
+            'stop_id,stop\nname\r\n1,Station A\r\n',
+            { header: true } as const
+        ],
+        [
+            'CRCRLF with header:false',
+            'crcrlf-no-header.csv',
+            [HEADER, ROW1, ROW2].join('\r\r\n') + '\r\r\n',
+            { header: false } as const
+        ]
+    ])('Rejects with /embedded newline/ error: %s', async (_label, fileName, content, opts) => {
+        const fixture = writeFixture(fileName, content);
         let thrownError: any = undefined;
         try {
-            await parseCsvFile(fixture, () => undefined, { header: false });
+            await parseCsvFile(fixture, () => undefined, opts);
         } catch (err) {
             thrownError = err;
         }

--- a/packages/chaire-lib-backend/src/services/files/__tests__/CsvFile.test.ts
+++ b/packages/chaire-lib-backend/src/services/files/__tests__/CsvFile.test.ts
@@ -4,6 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { parseCsvFile } from '../CsvFile';
 
 const filePath = `${__dirname}/testFiles/test.csv`;
@@ -69,4 +72,119 @@ test('Callback return error', async() => {
         thrownError = err;
     }
     expect(thrownError).toEqual(errorToThrow);
+});
+
+describe('Detection of CSV-parser line-ending corruption (issue #1909)', () => {
+    // Fixtures are generated at runtime: \r\r\n bytes are easy to mangle
+    // by editors or Git autocrlf, which is the very condition under test.
+    const tmpDir = path.join(os.tmpdir(), `transition-csvfile-test-${process.pid}`);
+    const writeFixture = (name: string, content: string): string => {
+        const p = path.join(tmpDir, name);
+        fs.writeFileSync(p, content);
+        return p;
+    };
+
+    beforeAll(() => {
+        fs.mkdirSync(tmpDir, { recursive: true });
+    });
+
+    afterAll(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const HEADER = 'stop_id,stop_name,stop_lat,stop_lon';
+    const ROW1 = '1,Station A,45.5,-73.5';
+    const ROW2 = '2,Station B,45.6,-73.6';
+
+    /* --------------- cases the detection MUST flag --------------- */
+
+    test.each([
+        ['CRCRLF (\\r\\r\\n) -- the issue case', '\r\r\n'],
+        ['triple-CR + LF (\\r\\r\\r\\n)', '\r\r\r\n']
+    ])('Rejects with a clear error: %s', async (_label, sep) => {
+        const fixture = writeFixture(`bad-${sep.length}.csv`, [HEADER, ROW1, ROW2].join(sep) + sep);
+        let thrownError: any = undefined;
+        try {
+            await parseCsvFile(fixture, () => undefined, { header: true });
+        } catch (err) {
+            thrownError = err;
+        }
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toMatch(/malformed line endings/i);
+        // Error should name the file and offer a concrete repair hint
+        expect(thrownError.message).toMatch(new RegExp(path.basename(fixture)));
+        expect(thrownError.message).toMatch(/dos2unix/);
+    });
+
+    test('Rejects when an embedded LF in the header confuses the parser', async () => {
+        // LF inside the header makes papaparse pick `\n` as the terminator,
+        // leaving stray `\r` bytes on values. Detection catches it via
+        // either the keys or the first-column values.
+        const fixture = writeFixture(
+            'broken-header.csv',
+            'stop_id,stop\nname\r\n1,Station A\r\n'
+        );
+        let thrownError: any = undefined;
+        try {
+            await parseCsvFile(fixture, () => undefined, { header: true });
+        } catch (err) {
+            thrownError = err;
+        }
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toMatch(/embedded newline/i);
+    });
+
+    test('Rejects in header:false mode when the header row has a stray newline', async () => {
+        const fixture = writeFixture('crcrlf-no-header.csv', [HEADER, ROW1, ROW2].join('\r\r\n') + '\r\r\n');
+        let thrownError: any = undefined;
+        try {
+            await parseCsvFile(fixture, () => undefined, { header: false });
+        } catch (err) {
+            thrownError = err;
+        }
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toMatch(/embedded newline/i);
+    });
+
+    /* --------------- cases the detection MUST NOT flag --------------- */
+
+    test.each([
+        ['plain LF', '\n'],
+        ['CRLF', '\r\n'],
+        ['CR-only (old Mac)', '\r']
+    ])('Accepts a well-formed file with %s line endings', async (_label, sep) => {
+        const fixture = writeFixture(`good-${_label}.csv`, [HEADER, ROW1, ROW2].join(sep) + sep);
+        const rows: any[] = [];
+        const result = await parseCsvFile(fixture, (row) => rows.push(row), { header: true });
+        expect(result).toEqual('completed');
+        expect(rows.length).toEqual(2);
+        expect(rows[0]).toEqual({
+            stop_id: '1',
+            stop_name: 'Station A',
+            stop_lat: '45.5',
+            stop_lon: '-73.5'
+        });
+    });
+
+    test('Accepts a file with a legitimate multiline quoted field (does not false-positive)', async () => {
+        // Per RFC 4180 a quoted field may contain newlines; we only check
+        // the first column, where here the value is "1".
+        const fixture = writeFixture(
+            'multiline-quoted.csv',
+            `${HEADER}\r\n1,"Line one\nLine two",45.5,-73.5\r\n2,Station B,45.6,-73.6\r\n`
+        );
+        const rows: any[] = [];
+        const result = await parseCsvFile(fixture, (row) => rows.push(row), { header: true });
+        expect(result).toEqual('completed');
+        expect(rows.length).toEqual(2);
+        expect(rows[0].stop_name).toEqual('Line one\nLine two');
+    });
+
+    test('Accepts an empty file (no rows -> no first-row check, no error)', async () => {
+        const fixture = writeFixture('empty.csv', '');
+        const rows: any[] = [];
+        const result = await parseCsvFile(fixture, (row) => rows.push(row), { header: true });
+        expect(result).toEqual('completed');
+        expect(rows.length).toEqual(0);
+    });
 });

--- a/packages/chaire-lib-common/src/utils/TrError.ts
+++ b/packages/chaire-lib-common/src/utils/TrError.ts
@@ -14,6 +14,27 @@ export default class TrError extends Error {
         return error.code && typeof error.getCode === 'function' && typeof error.export === 'function';
     }
 
+    /**
+     * If `error` is a `TrError` carrying a non-empty `localizedMessage`,
+     * return that message. Otherwise return `undefined`. Useful when surfacing
+     * a caught error to the user: callers can use `??` to fall back to a
+     * domain-specific generic message when the thrown error doesn't carry its
+     * own localized text.
+     */
+    static getLocalizedMessage(error: unknown): TranslatableMessage | undefined {
+        if (error === null || typeof error !== 'object') {
+            return undefined;
+        }
+        if (!TrError.isTrError(error)) {
+            return undefined;
+        }
+        const localized = error.export().localizedMessage;
+        if (localized === '' || localized === undefined || localized === null) {
+            return undefined;
+        }
+        return localized;
+    }
+
     constructor(message: string, code: string, localizedError: TranslatableMessage = '') {
         super(message);
 

--- a/packages/chaire-lib-common/src/utils/__tests__/TrError.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/TrError.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import TrError from '../TrError';
+
+describe('TrError.getLocalizedMessage', () => {
+    test.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['a string', 'plain error'],
+        ['a number', 42],
+        ['a plain Error', new Error('boom')],
+        ['a TrError without a localizedMessage', new TrError('technical', 'CODE')],
+        ['a TrError with empty-string localizedMessage', new TrError('technical', 'CODE', '')]
+    ])('Returns undefined for %s', (_label, value) => {
+        expect(TrError.getLocalizedMessage(value)).toBeUndefined();
+    });
+
+    test('Returns the localized string of a TrError carrying a string localizedMessage', () => {
+        const err = new TrError('technical', 'CODE', 'some:translation:key');
+        expect(TrError.getLocalizedMessage(err)).toEqual('some:translation:key');
+    });
+
+    test('Returns the localized object of a TrError carrying a parameterized localizedMessage', () => {
+        const err = new TrError('technical', 'CODE', {
+            text: 'some:translation:key',
+            params: { foo: 'bar' }
+        });
+        expect(TrError.getLocalizedMessage(err)).toEqual({
+            text: 'some:translation:key',
+            params: { foo: 'bar' }
+        });
+    });
+});

--- a/packages/transition-backend/src/api/__tests__/uploads.socketRoutes.test.ts
+++ b/packages/transition-backend/src/api/__tests__/uploads.socketRoutes.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { buildGtfsUploadErrorPayload } from '../uploads.socketRoutes';
+
+describe('buildGtfsUploadErrorPayload (issue #1909)', () => {
+    test('Returns the localizedMessage of any TrError', () => {
+        const err = new TrError(
+            'technical: malformed CSV agency.txt',
+            'MALFORMED_CSV_LINE_ENDINGS',
+            { text: 'transit:gtfs:errors:MalformedCsvFile', params: { fileName: 'agency.txt' } }
+        );
+        expect(buildGtfsUploadErrorPayload(err)).toEqual({
+            text: 'transit:gtfs:errors:MalformedCsvFile',
+            params: { fileName: 'agency.txt' }
+        });
+    });
+
+    test('Falls back to a generic string for a TrError without a localizedMessage', () => {
+        const err = new TrError('technical only', 'CODE');
+        const payload = buildGtfsUploadErrorPayload(err);
+        expect(typeof payload).toEqual('string');
+        expect(payload).toMatch(/error importing gtfs file/);
+    });
+
+    test('Falls back to a generic string for a plain Error', () => {
+        const err = new Error('something else broke');
+        const payload = buildGtfsUploadErrorPayload(err);
+        expect(typeof payload).toEqual('string');
+        expect(payload).toMatch(/error importing gtfs file/);
+        expect(payload).toMatch(/something else broke/);
+    });
+
+    test('Falls back to a generic string for non-Error values', () => {
+        const payload = buildGtfsUploadErrorPayload('plain string error');
+        expect(typeof payload).toEqual('string');
+        expect(payload).toMatch(/plain string error/);
+    });
+});

--- a/packages/transition-backend/src/api/uploads.socketRoutes.ts
+++ b/packages/transition-backend/src/api/uploads.socketRoutes.ts
@@ -10,6 +10,8 @@ import SocketIO from 'socket.io';
 import { directoryManager } from 'chaire-lib-backend/lib/utils/filesystem/directoryManager';
 import uploadSocketRoutes from 'chaire-lib-backend/lib/api/uploads.socketRoutes';
 import serverConfig from 'chaire-lib-backend/lib/config/server.config';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
+import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import GtfsImportPreparation from '../services/gtfsImport/GtfsImportPreparation';
 import agenciesImporter from '../services/importers/AgenciesImporter';
 import nodesImporter from '../services/importers/NodesImporter';
@@ -18,6 +20,16 @@ import servicesImporter from '../services/importers/ServicesImporter';
 import linesImporter from '../services/importers/LinesImporter';
 import pathsImporter from '../services/importers/PathsImporter';
 import Users from 'chaire-lib-backend/lib/services/users/users';
+
+/**
+ * Build the payload for a `gtfsImporter.gtfsUploadError` socket event from an
+ * error caught while preparing a GTFS upload. If the error is a `TrError`
+ * with a `localizedMessage`, return that so the user gets a specific,
+ * actionable description; otherwise keep the historical generic string
+ * payload. Exported for unit testing.
+ */
+export const buildGtfsUploadErrorPayload = (err: unknown): TranslatableMessage =>
+    TrError.getLocalizedMessage(err) ?? 'error importing gtfs file ' + String(err);
 
 const gtfsImportFunction = async (socket: SocketIO.Socket, absoluteUserDir: string, filePath: string) => {
     const gtfsFilesDirectoryPath = `${absoluteUserDir}/gtfs/gtfs/`;
@@ -45,7 +57,7 @@ const gtfsImportFunction = async (socket: SocketIO.Socket, absoluteUserDir: stri
         console.log('GTFS zip file prepared');
     } catch (err) {
         console.error('Error importing gtfs file', err);
-        socket.emit('gtfsImporter.gtfsUploadError', 'error importing gtfs file ' + String(err));
+        socket.emit('gtfsImporter.gtfsUploadError', buildGtfsUploadErrorPayload(err));
     }
 };
 

--- a/packages/transition-backend/src/services/gtfsImport/AgencyImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/AgencyImporter.ts
@@ -5,6 +5,7 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import Agency, { AgencyAttributes } from 'transition-common/lib/services/agency/Agency';
 import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollection';
@@ -79,7 +80,7 @@ export class AgencyImporter implements GtfsObjectImporter<AgencyImportData, Agen
                             }
                 });
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return agencies;
     }

--- a/packages/transition-backend/src/services/gtfsImport/FrequencyImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/FrequencyImporter.ts
@@ -8,6 +8,7 @@
 import type * as GtfsTypes from 'gtfs-types';
 
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { timeStrToSecondsSinceMidnight } from 'chaire-lib-common/lib/utils/DateTimeUtils';
@@ -66,7 +67,7 @@ export class FrequencyImporter implements GtfsObjectPreparator<Frequencies> {
 
                 frequencies.push(frequency);
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return frequencies;
     }

--- a/packages/transition-backend/src/services/gtfsImport/GtfsImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/GtfsImporter.ts
@@ -14,6 +14,7 @@ import AgencyCollection from 'transition-common/lib/services/agency/AgencyCollec
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
 import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
 import AgencyImporter from './AgencyImporter';
 import ServiceImporter from './ServiceImporter';
 import LineImporter from './LineImporter';
@@ -32,6 +33,19 @@ import PathCollection from 'transition-common/lib/services/path/PathCollection';
 
 // Number of steps for the import, to track progress at every step
 const nbImportSteps = 6;
+
+/**
+ * Map an error caught during a GTFS import step to a user-facing
+ * `TranslatableMessage`. If the error is a `TrError`, surface its
+ * `localizedMessage` so the user gets a specific, actionable description
+ * (e.g. naming the file that failed). Otherwise fall back to the step's
+ * generic message. This keeps the importer agnostic of any specific
+ * exception type: any code in the import chain that wants to surface a
+ * tailored UI message just needs to throw a `TrError` with a
+ * `localizedMessage` set.
+ */
+const errorToImportMessage = (error: unknown, fallback: TranslatableMessage): TranslatableMessage =>
+    TrError.getLocalizedMessage(error) ?? fallback;
 
 /**
  * Import GTFS data from an unzipped gtfs directory
@@ -108,7 +122,11 @@ const importGtfsData = async (
         await nodeCollection.loadFromServer(serviceLocator.socketEventManager);
     } catch (error) {
         console.error(`error importing stops: ${error}`);
-        return { status: 'failed', errors: [GtfsMessages.NodesImportError], nodesDirty };
+        return {
+            status: 'failed',
+            errors: [errorToImportMessage(error, GtfsMessages.NodesImportError)],
+            nodesDirty
+        };
     } finally {
         progressEmitter?.emit('progress', { name: 'ImportingStops', progress: 1.0 });
         currentStepCompleted++;
@@ -130,7 +148,11 @@ const importGtfsData = async (
         await agencies.loadFromServer(serviceLocator.socketEventManager, collectionManager);
     } catch (error) {
         console.error(`error importing agencies: ${error}`);
-        return { status: 'failed', errors: [GtfsMessages.AgenciesImportError], nodesDirty };
+        return {
+            status: 'failed',
+            errors: [errorToImportMessage(error, GtfsMessages.AgenciesImportError)],
+            nodesDirty
+        };
     } finally {
         progressEmitter?.emit('progress', { name: 'ImportingAgencies', progress: 1.0 });
         currentStepCompleted++;
@@ -152,7 +174,11 @@ const importGtfsData = async (
         await lineCollection.loadFromServer(serviceLocator.socketEventManager, collectionManager);
     } catch (error) {
         console.error(`error importing lines: ${error}`);
-        return { status: 'failed', errors: [GtfsMessages.LinesImportError], nodesDirty };
+        return {
+            status: 'failed',
+            errors: [errorToImportMessage(error, GtfsMessages.LinesImportError)],
+            nodesDirty
+        };
     } finally {
         progressEmitter?.emit('progress', { name: 'ImportingLines', progress: 1.0 });
         currentStepCompleted++;
@@ -178,7 +204,11 @@ const importGtfsData = async (
         await services.loadFromServer(serviceLocator.socketEventManager, collectionManager);
     } catch (error) {
         console.error(`error importing lines: ${error}`);
-        return { status: 'failed', errors: [GtfsMessages.ServicesImportError], nodesDirty };
+        return {
+            status: 'failed',
+            errors: [errorToImportMessage(error, GtfsMessages.ServicesImportError)],
+            nodesDirty
+        };
     } finally {
         progressEmitter?.emit('progress', { name: 'ImportingServices', progress: 1.0 });
         currentStepCompleted++;

--- a/packages/transition-backend/src/services/gtfsImport/LineImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/LineImporter.ts
@@ -7,6 +7,7 @@
 // eslint-disable-next-line n/no-unpublished-import
 import type { Route as GtfsRouteSpec } from 'gtfs-types';
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import Line, { LineAttributes } from 'transition-common/lib/services/line/Line';
 import LineCollection from 'transition-common/lib/services/line/LineCollection';
@@ -66,7 +67,7 @@ export class LineImporter implements GtfsObjectImporter<LineImportData, Line> {
                     }
                 });
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return lines;
     }

--- a/packages/transition-backend/src/services/gtfsImport/ServiceImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ServiceImporter.ts
@@ -11,6 +11,7 @@ import _uniq from 'lodash/uniq';
 import _isEqual from 'lodash/isEqual';
 
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import Service, { ServiceAttributes, serviceDays } from 'transition-common/lib/services/service/Service';
 import ServiceCollection from 'transition-common/lib/services/service/ServiceCollection';
@@ -106,7 +107,7 @@ export class ServiceImporter implements GtfsObjectImporter<ServiceImportData, Se
                 }
                 calendarServices[data.service_id] = { service: gtfsToObjectAttributes(service) };
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return calendarServices;
     }
@@ -164,7 +165,7 @@ export class ServiceImporter implements GtfsObjectImporter<ServiceImportData, Se
                 }
                 calendarDateServices[data.service_id] = calendarDateService;
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         Object.keys(calendarDateServices).forEach((key) => this.processService(calendarDateServices[key]));
         return calendarDateServices;

--- a/packages/transition-backend/src/services/gtfsImport/ShapeImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ShapeImporter.ts
@@ -8,6 +8,7 @@
 import type * as GtfsTypes from 'gtfs-types';
 
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GtfsInternalData, ShapeImportData } from './GtfsImportTypes';
@@ -75,7 +76,7 @@ export class ShapeImporter implements GtfsObjectPreparator<GtfsTypes.Shapes> {
 
                 shapes.push(shape);
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return shapes;
     }

--- a/packages/transition-backend/src/services/gtfsImport/StopImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/StopImporter.ts
@@ -10,6 +10,7 @@ import type * as GtfsTypes from 'gtfs-types';
 
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import { Node, NodeAttributes, StopAttributes } from 'transition-common/lib/services/nodes/Node';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
@@ -73,7 +74,7 @@ export class StopImporter implements GtfsObjectPreparator<StopImportData> {
 
                 stops.push({ stop });
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return stops;
     }

--- a/packages/transition-backend/src/services/gtfsImport/StopTimeImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/StopTimeImporter.ts
@@ -8,6 +8,7 @@
 import type * as GtfsTypes from 'gtfs-types';
 
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { timeStrToSecondsSinceMidnight } from 'chaire-lib-common/lib/utils/DateTimeUtils';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
@@ -123,7 +124,7 @@ implements GtfsObjectPreparator<StopTime | Omit<StopTime, 'arrivalTimeSeconds' |
 
                 stopTimes.push(trip);
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return stopTimes;
     }

--- a/packages/transition-backend/src/services/gtfsImport/TripImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/TripImporter.ts
@@ -8,6 +8,7 @@
 import type * as GtfsTypes from 'gtfs-types';
 
 import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { gtfsCsvOptions } from './gtfsCsvOptions';
 import { gtfsFiles } from 'transition-common/lib/services/gtfs/GtfsFiles';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GtfsInternalData } from './GtfsImportTypes';
@@ -66,7 +67,7 @@ export class TripImporter implements GtfsObjectPreparator<GtfsTypes.Trip> {
 
                 trips.push(trip);
             },
-            { header: true }
+            gtfsCsvOptions({ header: true })
         );
         return trips;
     }

--- a/packages/transition-backend/src/services/gtfsImport/__tests__/GtfsImporter.test.ts
+++ b/packages/transition-backend/src/services/gtfsImport/__tests__/GtfsImporter.test.ts
@@ -24,6 +24,7 @@ import ServiceImporter from '../ServiceImporter';
 import PathImporter from '../PathImporter';
 import ScheduleImporter from '../ScheduleImporter';
 import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
+import TrError from 'chaire-lib-common/lib/utils/TrError';
 
 jest.mock('../../../models/db/transitLines.db.queries');
 jest.mock('../../../models/db/transitPaths.db.queries');
@@ -307,4 +308,47 @@ test('Test nodes failure', async() => {
     expect(mockServiceImport).not.toHaveBeenCalled();
     expect(mockedPathImport).not.toHaveBeenCalled();
     expect(mockedScheduleImport).not.toHaveBeenCalled();
+});
+
+describe('Surfacing TrError.localizedMessage to the user (issue #1909)', () => {
+    // Constructs a TrError carrying a translatable message; this could be a
+    // MalformedCsvError or any other TrError thrown anywhere in the import
+    // chain -- the importer is type-agnostic.
+    const makeTrError = (fileName: string) =>
+        new TrError(
+            `technical: malformed CSV ${fileName}`,
+            'MALFORMED_CSV_LINE_ENDINGS',
+            { text: 'transit:gtfs:errors:MalformedCsvFile', params: { fileName } }
+        );
+
+    test.each([
+        ['nodes',    'stops.txt',    () => mockStopImport.mockRejectedValueOnce(makeTrError('stops.txt'))],
+        ['agencies', 'agency.txt',   () => mockAgencyImport.mockRejectedValueOnce(makeTrError('agency.txt'))],
+        ['lines',    'routes.txt',   () => mockLineImport.mockRejectedValueOnce(makeTrError('routes.txt'))],
+        ['services', 'calendar.txt', () => mockServiceImport.mockRejectedValueOnce(makeTrError('calendar.txt'))]
+    ])('Replaces the generic %s-import error with the TrError localizedMessage', async (_step, fileName, makeRejection) => {
+        makeRejection();
+        const result = await GtfsImporter.importGtfsData('', importData as any);
+        expect(result.status).toEqual('failed');
+        const failedResult = result as { status: 'failed'; errors: any[] };
+        expect(failedResult.errors).toEqual([
+            { text: 'transit:gtfs:errors:MalformedCsvFile', params: { fileName } }
+        ]);
+    });
+
+    test('Falls back to the generic step-specific error for non-TrError failures', async () => {
+        mockStopImport.mockRejectedValueOnce(new Error('something else broke'));
+        const result = await GtfsImporter.importGtfsData('', importData as any);
+        expect(result.status).toEqual('failed');
+        const failedResult = result as { status: 'failed'; errors: any[] };
+        expect(failedResult.errors).toEqual([GtfsMessages.NodesImportError]);
+    });
+
+    test('Falls back to the generic step-specific error for a TrError without a localizedMessage', async () => {
+        mockStopImport.mockRejectedValueOnce(new TrError('some technical issue', 'CODE'));
+        const result = await GtfsImporter.importGtfsData('', importData as any);
+        expect(result.status).toEqual('failed');
+        const failedResult = result as { status: 'failed'; errors: any[] };
+        expect(failedResult.errors).toEqual([GtfsMessages.NodesImportError]);
+    });
 });

--- a/packages/transition-backend/src/services/gtfsImport/gtfsCsvOptions.ts
+++ b/packages/transition-backend/src/services/gtfsImport/gtfsCsvOptions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { BackendCsvFileOptions } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { CsvFileAttributes } from 'chaire-lib-common/lib/utils/files/CsvFile';
+import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
+
+/**
+ * Build the options object passed to `parseCsvFile` from a GTFS importer.
+ * Wires up the GTFS-specific `MalformedCsvFile` translation key so users see
+ * a domain-appropriate error if the file's line endings are malformed.
+ *
+ * Use it like:
+ *
+ *     await parseCsvFile(filePath, rowCb, gtfsCsvOptions({ header: true }));
+ */
+export const gtfsCsvOptions = (
+    options: Partial<CsvFileAttributes>
+): Partial<CsvFileAttributes> & BackendCsvFileOptions => ({
+    ...options,
+    malformedCsvLocalizedMessage: (fileName) => ({
+        text: GtfsMessages.MalformedCsvFile,
+        params: { fileName }
+    })
+});

--- a/packages/transition-common/src/services/gtfs/GtfsMessages.ts
+++ b/packages/transition-common/src/services/gtfs/GtfsMessages.ts
@@ -18,5 +18,6 @@ export const GtfsMessages = {
     AgenciesImportError: 'transit:gtfs:errors:ErrorImportingAgencies',
     LinesImportError: 'transit:gtfs:errors:ErrorImportingLines',
     ServicesImportError: 'transit:gtfs:errors:ErrorImportingServices',
-    GtfsExportError: 'transit:gtfs:errors:ErrorExportingGtfs'
+    GtfsExportError: 'transit:gtfs:errors:ErrorExportingGtfs',
+    MalformedCsvFile: 'transit:gtfs:errors:MalformedCsvFile'
 };

--- a/packages/transition-frontend/src/components/forms/gtfs/GtfsImportForm.tsx
+++ b/packages/transition-frontend/src/components/forms/gtfs/GtfsImportForm.tsx
@@ -88,7 +88,15 @@ const GtfsImportForm: React.FC = () => {
     useEffect(() => {
         const onZipFileUploadError = (error) => {
             console.log('GTFS file upload error!', error);
-            setErrors((prevErrors) => [...prevErrors, 'transit:gtfs:errors:ErrorUploadingFile']);
+            // The backend may emit either a legacy string payload or a
+            // TranslatableMessage object. Pass either through to setErrors;
+            // FormErrors knows how to render both shapes. Fall back to the
+            // generic upload error if the payload is missing or unusable.
+            const message =
+                typeof error === 'object' && error !== null && typeof error.text === 'string'
+                    ? error
+                    : 'transit:gtfs:errors:ErrorUploadingFile';
+            setErrors((prevErrors) => [...prevErrors, message]);
         };
 
         const onGtfsFilePrepared = (validatorAttributes: GtfsImportData) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GTFS uploads now pre-validate CSVs and reject files with malformed line endings to prevent downstream failures.
  * Error payloads now surface localized, specific messages (including filename) so the UI shows actionable guidance (e.g., suggesting normalization).

* **Bug Fixes**
  * Upload error handling updated to display the actual error message when available, falling back to the generic upload error otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->