### PR TITLE
tasks: move the taskWrapper import at the beginning of imports

### DIFF
--- a/packages/chaire-lib-backend/src/scripts/osm/1_downloadOsmDataToFiles.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osm/1_downloadOsmDataToFiles.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import downloadOsmData from '../../tasks/dataImport/downloadOsmData';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import downloadOsmData from '../../tasks/dataImport/downloadOsmData';
 
 import { fileManager } from '../../utils/filesystem/fileManager';
 import { CliPromptGeojsonPolygonService } from '../../services/prompt/CliPromptGeojsonPolygonService';

--- a/packages/chaire-lib-backend/src/scripts/osm/1b_prepareAndEnhanceOsmPolygonData.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osm/1b_prepareAndEnhanceOsmPolygonData.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import enhanceAndSaveOsmPolygonData from '../../tasks/dataImport/enhanceAndSaveOsmPolygonData';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import enhanceAndSaveOsmPolygonData from '../../tasks/dataImport/enhanceAndSaveOsmPolygonData';
 
 import { fileManager } from '../../utils/filesystem/fileManager';
 

--- a/packages/chaire-lib-backend/src/scripts/osm/2_importAndProcessOsmDataToFiles.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osm/2_importAndProcessOsmDataToFiles.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import prepareOsmData from '../../tasks/dataImport/prepareOsmDataForImport';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import prepareOsmData from '../../tasks/dataImport/prepareOsmDataForImport';
 
 import { fileManager } from '../../utils/filesystem/fileManager';
 

--- a/packages/chaire-lib-backend/src/scripts/osm/2b_assignWeightsToPOIs.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osm/2b_assignWeightsToPOIs.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import assignWeightToPOIs from '../../tasks/dataImport/assignWeightToPOIs';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import assignWeightToPOIs from '../../tasks/dataImport/assignWeightToPOIs';
 
 import { fileManager } from '../../utils/filesystem/fileManager';
 

--- a/packages/chaire-lib-backend/src/scripts/osm/3_importAndValidateLandRoleData.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osm/3_importAndValidateLandRoleData.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import importAndValidatePlaces from '../../tasks/dataImport/importAndValidatePlaces';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import importAndValidatePlaces from '../../tasks/dataImport/importAndValidatePlaces';
 
 import { fileManager } from '../../utils/filesystem/fileManager';
 import { CliPromptGeojsonPolygonService } from '../../services/prompt/CliPromptGeojsonPolygonService';

--- a/packages/chaire-lib-backend/src/scripts/osrm/downloadOsmNetworkData.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osrm/downloadOsmNetworkData.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { DownloadOsmNetworkData } from '../../tasks/osrm/downloadOsmNetworkData';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import { DownloadOsmNetworkData } from '../../tasks/osrm/downloadOsmNetworkData';
 
 import { fileManager } from '../../utils/filesystem/fileManager';
 import { CliPromptGeojsonPolygonService } from '../../services/prompt/CliPromptGeojsonPolygonService';

--- a/packages/chaire-lib-backend/src/scripts/osrm/prepareOsmNetworkData.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/osrm/prepareOsmNetworkData.task.ts
@@ -4,8 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import { PrepareOsmNetworkData } from '../../tasks/osrm/prepareOsmNetworkData';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import { PrepareOsmNetworkData } from '../../tasks/osrm/prepareOsmNetworkData';
 
 taskWrapper(new PrepareOsmNetworkData())
     .then(() => {

--- a/packages/chaire-lib-backend/src/scripts/zones/importZones.task.ts
+++ b/packages/chaire-lib-backend/src/scripts/zones/importZones.task.ts
@@ -4,9 +4,9 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
-import '../../config/dotenv.config'; // Unused, but must be imported
-import { ImportZonesFromGeojson } from '../../tasks/zones/importZonesFromGeojson';
+// Task wrapper should be imported first for the config and dotenv to be loaded before any other import
 import taskWrapper from '../../tasks/taskWrapper';
+import { ImportZonesFromGeojson } from '../../tasks/zones/importZonesFromGeojson';
 
 taskWrapper(new ImportZonesFromGeojson())
     .then(() => {

--- a/packages/chaire-lib-backend/src/tasks/taskWrapper.ts
+++ b/packages/chaire-lib-backend/src/tasks/taskWrapper.ts
@@ -4,6 +4,7 @@
  * This file is licensed under the MIT License.
  * License text available at https://opensource.org/licenses/MIT
  */
+// Import dotenv at the beginning to make sure environment is set in tasks
 import '../config/dotenv.config';
 
 // Just make sure the config is initialized in the task, so tasks that are in common workspaces can have the right config
@@ -75,4 +76,13 @@ async function taskWrapper(task: GenericTask) {
     }
 }
 
+/**
+ * This is a wrapper for tasks that can be used in scripts. It makes sure the
+ * config is loaded before any task is imported, and provides a common way to
+ * run tasks and handle errors.
+ *
+ * This function should be imported at the very beginning of a task script,
+ * before any other import, to make sure the config is loaded before the task
+ * starts to run.
+ */
 export default taskWrapper;


### PR DESCRIPTION
fixes #1938

The taskWrapper import also sets up config and dotenv and should be imported before any other import to allow this, otherwise, some imports may call constructors that use still undefined environment variables and configuration options.

Also document this in the taskWrapper file, so the taskWrapper doc tells consumers to make sure the import is at the right place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of backend data processing tasks by correcting initialization order to ensure environment configuration is properly loaded before task execution. This fix addresses initialization sequencing in OSM data processing, network data preparation, and zone import operations to prevent failures from missing or improperly timed configuration loading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chairemobilite/transition/pull/1939)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->