### PR TITLE
auth: make the `verify` route available only to admin

### DIFF
--- a/packages/transition-frontend/src/components/routers/TransitionRouter.tsx
+++ b/packages/transition-frontend/src/components/routers/TransitionRouter.tsx
@@ -32,7 +32,7 @@ const TransitionRouter: React.FunctionComponent<TransitionRouterProps> = (props:
             <Route path="/register" element={<PublicRoute component={RegisterPage} />} />
             <Route path="/forgot" element={<PublicRoute component={ForgotPage} />} />
             <Route path="/unconfirmed" element={<PublicRoute component={UnconfirmedPage} />} />
-            <Route path="/verify/:token" element={<PublicRoute component={VerifyPage} />} />
+            <Route path="/verify/:token" element={<PrivateRoute component={VerifyPage} />} />
             <Route path="/reset/:token" element={<PublicRoute component={ResetPasswordPage} />} />
             <Route path="/unauthorized" element={<PublicRoute component={UnauthorizedPage} />} />
             <Route path="/login" element={<PublicRoute component={LoginPage} />} />


### PR DESCRIPTION
The verify page currently automatically verifies the account, without requiring login. Since some email clients automatically click on links sent to emails, that means that without requiring authentication, this automatically validates the account without an admin explicitly approving it. While by default the permissions are minimal, it still means the user has a valid account on the system, opening possible security risk.

This makes sure the `verify` page requires login. This also makes the `confirmByUser` method non-functional, but we are currently not using it, it will be brought back eventually.