### PR TITLE
routing: fix OD point drag moving the wrong point and black points while calculating

### DIFF
--- a/packages/chaire-lib-frontend/src/services/map/MapWithCustomEventsState.ts
+++ b/packages/chaire-lib-frontend/src/services/map/MapWithCustomEventsState.ts
@@ -29,6 +29,11 @@ export type MapWithCustomEventsState = MapLibreMap & {
     _draggingEventsOrder?: string[];
     /** Identifies the type of feature currently being dragged. */
     _currentDraggingFeature?: DraggingFeatureType;
+    /**
+     * Set right after a feature drag-release so the synthetic map `click`
+     * that fires next is ignored.
+     */
+    _featureDragJustEnded?: boolean;
     /** The MapLibre internal integer ID of the currently hovered path. */
     _hoverPathIntegerId?: string | number | null;
     /** The application ID (UUID) of the currently hovered path. */

--- a/packages/transition-frontend/src/components/forms/transitRouting/widgets/ODCoordinatesComponent.tsx
+++ b/packages/transition-frontend/src/components/forms/transitRouting/widgets/ODCoordinatesComponent.tsx
@@ -13,8 +13,6 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
 import InputStringFormatted from 'chaire-lib-frontend/lib/components/input/InputStringFormatted';
 import Button from 'chaire-lib-frontend/lib/components/input/Button';
-import { EventManager } from 'chaire-lib-common/lib/services/events/EventManager';
-import { MapUpdateLayerEventType } from 'chaire-lib-frontend/lib/services/map/events/MapEventsCallbacks';
 
 export interface ODCoordinatesComponentProps extends WithTranslation {
     originGeojson?: GeoJSON.Feature<GeoJSON.Point>;
@@ -100,28 +98,6 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
         this.updateDestination(coordinates[0], coordinates[1], true);
     };
 
-    originDestinationToGeojson = (): GeoJSON.FeatureCollection<GeoJSON.Point> => {
-        const features: GeoJSON.Feature<GeoJSON.Point>[] = [];
-        if (this.hasOrigin(this.state)) {
-            features.push({
-                type: 'Feature',
-                geometry: { type: 'Point', coordinates: [this.state.originLon, this.state.originLat] },
-                properties: {}
-            });
-        }
-        if (this.hasDestination(this.state)) {
-            features.push({
-                type: 'Feature',
-                geometry: { type: 'Point', coordinates: [this.state.destinationLon, this.state.destinationLat] },
-                properties: {}
-            });
-        }
-        return {
-            type: 'FeatureCollection',
-            features
-        };
-    };
-
     hasOrigin = (
         state: ODCoordinatesComponentState
     ): state is { originLat: number; originLon: number; externalUpdate: number } => {
@@ -155,6 +131,7 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
     };
 
     onClickedOnMap = (coordinates: GeoJSON.Position, isOrigin: boolean) => {
+        // The map layer update is handled automatically by updateOrigin/updateDestination below.
         if ((!this.hasOrigin(this.state) && isOrigin !== false) || isOrigin) {
             this.setState({
                 originLat: coordinates[1],
@@ -162,10 +139,6 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
                 externalUpdate: this.state.externalUpdate + 1
             });
             this.updateOrigin(coordinates[0], coordinates[1]);
-            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
-                layerName: 'routingPoints',
-                data: this.originDestinationToGeojson()
-            });
         } else {
             this.setState({
                 destinationLat: coordinates[1],
@@ -173,10 +146,6 @@ class ODCoordinatesComponent extends React.Component<ODCoordinatesComponentProps
                 externalUpdate: this.state.externalUpdate + 1
             });
             this.updateDestination(coordinates[0], coordinates[1]);
-            (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
-                layerName: 'routingPoints',
-                data: this.originDestinationToGeojson()
-            });
         }
     };
 

--- a/packages/transition-frontend/src/services/map/events/RoutingSectionMapEvents.ts
+++ b/packages/transition-frontend/src/services/map/events/RoutingSectionMapEvents.ts
@@ -19,6 +19,15 @@ const isRoutingActiveSection = (activeSection: string) => {
 };
 
 const onRoutingSectionMapClick = (e: MapMouseEvent) => {
+    const map = e.target as MapWithCustomEventsState;
+    // After releasing a dragged point, MapLibre still fires a synthetic `click`
+    // (no pan happened since dragPan was disabled). Ignoring it prevents that
+    // click from moving the other point to the drop location (see issue #1956).
+    if (map._featureDragJustEnded) {
+        map._featureDragJustEnded = false;
+        e.originalEvent.stopPropagation();
+        return;
+    }
     serviceLocator.eventManager.emit('routing.transit.clickedOnMap', e.lngLat.toArray());
     e.originalEvent.stopPropagation();
 };
@@ -52,6 +61,13 @@ const onRoutingPointMouseUp = (e: MapMouseEvent) => {
             e.lngLat.toArray()
         );
         map._currentDraggingFeature = null;
+        // Ignore the synthetic click MapLibre fires right after this drag-release.
+        // Also clear the flag after a short delay in case that synthetic click
+        // never fires, so it can't end up blocking a later, legitimate click.
+        map._featureDragJustEnded = true;
+        setTimeout(() => {
+            map._featureDragJustEnded = false;
+        }, 300);
         removeDraggingClass();
         removeHoverClass(); // Clean up hover state since mouseleave doesn't fire during drag
         serviceLocator.eventManager.emit('map.enableDragPan');


### PR DESCRIPTION
Two issues when editing routing origin/destination points on the map:

- Dragging the origin could move the destination instead (issue #1956). Releasing a dragged point left MapLibre firing a synthetic `click` (no pan happened since dragPan was disabled), which `onClickedOnMap` interpreted as "set destination", moving it to the drop location. A `_routingPointDragJustEnded` flag set on drag-release now lets the routing click handler ignore that trailing click. Dragging the destination only looked fine because the click re-set it to the same spot.

- Setting a point via map click or the context menu turned both points black until the routing result came back. `onClickedOnMap` emitted a second layer update built from stale, color-less component state, overwriting the colored update already done by onUpdateOD. Removing that redundant emit keeps the model's colored features (and correct position) applied immediately, before the calculation runs.

  Code by Claude Opus 4.8 Low thinking, reviewed by @kaligrafy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental map selections after dragging routing points.
  * Improved origin and destination updates when repositioning routing points on the map.
  * Prevented duplicate routing updates caused by synthetic click events after dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->