### PR TITLE
Add a user-agent for OSM overpass data download

### DIFF
--- a/packages/chaire-lib-backend/src/utils/osm/OsmOverpassDownloader.ts
+++ b/packages/chaire-lib-backend/src/utils/osm/OsmOverpassDownloader.ts
@@ -61,7 +61,9 @@ class OsmOverpassDownloaderImpl implements OsmOverpassDownloader {
             method: 'POST',
             body: overpassXmlQueryString,
             headers: {
-                'Content-Type': 'application/xml'
+                'Content-Type': 'application/xml',
+                // Add a user-agent to comply with official overpass server requirements
+                'User-Agent': 'Transition/1.0 (+https://github.com/chairemobilite/transition)'
             }
         });
 

--- a/packages/chaire-lib-backend/src/utils/osm/__tests__/OsmOverpassDownloader.test.ts
+++ b/packages/chaire-lib-backend/src/utils/osm/__tests__/OsmOverpassDownloader.test.ts
@@ -164,7 +164,8 @@ test('download json data from overpass', async () => {
     expect(mockedFetch).toHaveBeenCalledWith('http://overpass-api.de/api/interpreter', {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/xml'
+            'Content-Type': 'application/xml',
+            "User-Agent": "Transition/1.0 (+https://github.com/chairemobilite/transition)"
         },
         body: overpassQuery.replace('BOUNDARY', polyboundary).replace('OUTPUT', 'json')
     });
@@ -189,7 +190,8 @@ test('download geojson data from overpass', async () => {
     expect(mockedFetch).toHaveBeenCalledWith('http://overpass-api.de/api/interpreter', {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/xml'
+            'Content-Type': 'application/xml',
+            "User-Agent": "Transition/1.0 (+https://github.com/chairemobilite/transition)"
         },
         body: overpassQuery.replace('BOUNDARY', polyboundary).replace('OUTPUT', 'json')
     });
@@ -222,7 +224,8 @@ test('download xml data from overpass', async () => {
     expect(mockedFetch).toHaveBeenCalledWith('http://overpass-api.de/api/interpreter', {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/xml'
+            'Content-Type': 'application/xml',
+            "User-Agent": "Transition/1.0 (+https://github.com/chairemobilite/transition)"
         },
         body: overpassQuery.replace('BOUNDARY', polyboundary).replace('OUTPUT', 'xml')
     });


### PR DESCRIPTION
Recently, the main Overpass server got more strict and now require every request to have an user-agent (See https://community.openstreetmap.org/t/overpass-api-performance-issues/140598/74)

This add a user-agent with Transition name, a dummy version and a link to the github repo to better identify the project.

Tested that it now works. (Before we were immediatly getting an error 406)

Fixes: #1976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a more complete HTTP request header (including a proper `User-Agent`) for map data downloads to improve compatibility with the Overpass service and reduce request failures.
* **Tests**
  * Updated Overpass downloader tests to reflect the additional `User-Agent` header in outgoing requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->