### PR TITLE
Fix changes to scrollTo return value

### DIFF
--- a/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
+++ b/packages/chaire-lib-frontend/src/components/dashboard/RightPanel.tsx
@@ -39,7 +39,9 @@ const RightPanel: React.FunctionComponent<RightPanelProps> = ({ contributions, .
         [props.activeSection, props.availableRoutingModes]
     );
     // Reset ref scroll position when changing section
-    React.useEffect(() => rightPanelRef.current?.scrollTo({ left: 0, top: 0 }), [props.activeSection]);
+    React.useEffect(() => {
+        rightPanelRef.current?.scrollTo({ left: 0, top: 0 });
+    }, [props.activeSection]);
 
     return (
         <section ref={rightPanelRef} id="tr__right-panel">


### PR DESCRIPTION
With Chrome 150, a change to scrollTo return value occuring. It's now a promise instead of undefined. (see https://chromestatus.com/feature/5082138340491264)

This fix was found and proposed by Claude Fable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted an existing scroll-reset effect in the dashboard’s right panel for readability. Behavior remains unchanged: the panel still returns to the top when the active section changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->