### PR TITLE
Issue #1346: Remove strokes from polygon calculation

### DIFF
--- a/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
+++ b/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
@@ -6,22 +6,11 @@
  */
 import {
     featureCollection as turfFeatureCollection,
-    lineString as turfLineString,
-    multiLineString as turfMultiLineString,
     area as turfArea,
-    polygonToLine as turfPolygonToLine,
     intersect as turfIntersect,
     difference as turfDifference
 } from '@turf/turf';
-import {
-    Feature,
-    FeatureCollection,
-    Point,
-    MultiPolygon,
-    MultiLineString,
-    LineString,
-    GeoJsonProperties
-} from 'geojson';
+import { Feature, FeatureCollection, Point, MultiPolygon } from 'geojson';
 
 import _cloneDeep from 'lodash/cloneDeep';
 import _sum from 'lodash/sum';
@@ -247,8 +236,7 @@ export class TransitAccessibilityMapCalculator {
         const difference = turfDifference(polygons) as Feature<MultiPolygon> | null;
         if (difference === null) {
             return {
-                polygons: turfFeatureCollection([]),
-                strokes: turfFeatureCollection([])
+                polygons: turfFeatureCollection([])
             };
         }
 
@@ -258,11 +246,8 @@ export class TransitAccessibilityMapCalculator {
 
         difference.properties.color = color;
 
-        const multiLineStroke = this.getPolygonStrokes(difference);
-
         return {
-            polygons: turfFeatureCollection([difference]),
-            strokes: turfFeatureCollection([multiLineStroke])
+            polygons: turfFeatureCollection([difference])
         };
     }
 
@@ -277,8 +262,7 @@ export class TransitAccessibilityMapCalculator {
 
         if (intersection === null) {
             return {
-                polygons: turfFeatureCollection([]),
-                strokes: turfFeatureCollection([])
+                polygons: turfFeatureCollection([])
             };
         }
 
@@ -291,11 +275,8 @@ export class TransitAccessibilityMapCalculator {
         intersection.properties.areaSqKm = area / 1000000;
         intersection.properties.areaSqMiles = area / 1000000 / 2.58999;
 
-        const multiLineStroke = this.getPolygonStrokes(intersection);
-
         return {
-            polygons: turfFeatureCollection([intersection]),
-            strokes: turfFeatureCollection([multiLineStroke])
+            polygons: turfFeatureCollection([intersection])
         };
     }
 
@@ -326,8 +307,7 @@ export class TransitAccessibilityMapCalculator {
             console.timeEnd(consoleTimerId);
 
             return {
-                polygons: turfFeatureCollection(polygons.polygons),
-                strokes: turfFeatureCollection(polygons.strokes),
+                polygons: turfFeatureCollection(polygons),
                 resultByNode: routingResult
             };
         } catch (error) {
@@ -377,11 +357,6 @@ export class TransitAccessibilityMapCalculator {
                     intersection: intersection.polygons.features,
                     scenario1Minus2: scenario1Minus2.polygons.features,
                     scenario2Minus1: scenario2Minus1.polygons.features
-                },
-                strokes: {
-                    intersection: intersection.strokes.features,
-                    scenario1Minus2: scenario1Minus2.strokes.features,
-                    scenario2Minus1: scenario2Minus1.strokes.features
                 }
             });
         }
@@ -409,13 +384,12 @@ export class TransitAccessibilityMapCalculator {
         durations: number[],
         deltaCount = 1,
         options: TransitMapCalculationOptions = {}
-    ) {
+    ): Promise<Feature<MultiPolygon>[]> {
         const isCancelled = options.isCancelled || (() => false);
 
         durations.sort((a, b) => b - a); // durations must be in descending order so it appears correctly in qgis
 
         const polygons: Feature<MultiPolygon>[] = [];
-        const polygonStrokes: Feature<MultiLineString>[] = [];
 
         const walkingSpeedMps = attributes.walkingSpeedMps;
         const maxDistanceMeters = Math.floor(attributes.maxAccessEgressTravelTimeSeconds * walkingSpeedMps);
@@ -544,7 +518,6 @@ export class TransitAccessibilityMapCalculator {
             }
 
             polygons.push(polygon);
-            polygonStrokes.push(this.getPolygonStrokes(polygon));
 
             // Emit progress after processing
             if (serviceLocator.eventManager) {
@@ -556,36 +529,6 @@ export class TransitAccessibilityMapCalculator {
             throw 'Cancelled';
         }
 
-        return { polygons: polygons, strokes: polygonStrokes };
-    }
-
-    // From a polygon, generate the strokes that surround it.
-    private static getPolygonStrokes(
-        polygon: Feature<MultiPolygon, GeoJsonProperties>
-    ): Feature<MultiLineString, GeoJsonProperties> {
-        let polygonStroke = turfPolygonToLine(polygon);
-        if (polygonStroke.type === 'Feature') {
-            polygonStroke = turfFeatureCollection([polygonStroke]);
-        }
-        const polygonStrokesWithHoles: FeatureCollection<LineString> = turfFeatureCollection([]);
-
-        for (let i = 0, countI = polygonStroke.features.length; i < countI; i++) {
-            const feature = polygonStroke.features[i];
-            if (feature.geometry.type === 'MultiLineString') {
-                // this is a polygon with hole, we need to separate into two LineStrings.
-                for (let j = 1, countJ = feature.geometry.coordinates.length; j < countJ; j++) {
-                    polygonStrokesWithHoles.features.push(turfLineString(feature.geometry.coordinates[j]));
-                }
-                polygonStrokesWithHoles.features.push(turfLineString(feature.geometry.coordinates[0])); // keep the first one as is, but convert to LineString
-            } else {
-                polygonStrokesWithHoles.features.push(feature as Feature<LineString>);
-            }
-        }
-
-        return turfMultiLineString(
-            polygonStrokesWithHoles.features.map((lineString) => {
-                return lineString.geometry.coordinates;
-            })
-        );
+        return polygons;
     }
 }

--- a/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
+++ b/packages/transition-backend/src/services/transitRouting/__tests__/TrAccessibilityMapBatch.test.ts
@@ -65,14 +65,13 @@ const mockResultProcessor = {
     processResult: jest.fn(),
     end: jest.fn(),
     getFiles: jest.fn().mockReturnValue({ csv: 'result.csv' })
-}
+};
 const mockedCreateResult = createAccessMapFileResultProcessor as jest.MockedFunction<typeof createAccessMapFileResultProcessor>;
 mockedCreateResult.mockReturnValue(mockResultProcessor);
 
 const mockedCalculateWithPolygon = TransitAccessibilityMapCalculator.calculateWithPolygons = jest.fn() as jest.MockedFunction<typeof TransitAccessibilityMapCalculator.calculateWithPolygons>;
 mockedCalculateWithPolygon.mockResolvedValue({
-    polygons: { type: 'FeatureCollection', features: []},
-    strokes: { type: 'FeatureCollection', features: []},
+    polygons: { type: 'FeatureCollection', features: [] },
     resultByNode: undefined
 });
 
@@ -170,7 +169,7 @@ beforeEach(async () => {
 
 });
 
-test('3 locations, all successful', async() => {
+test('3 locations, all successful', async () => {
     mockedParseLocations.mockResolvedValue({ locations, errors: [] });
     const result = await batchAccessibilityMap(mockedJob, progressEmitter, isCancelledMock);
     expect(result).toEqual({
@@ -198,10 +197,10 @@ test('3 locations, all successful', async() => {
         })
     );
     expect(mockedStopBatch).toHaveBeenCalledTimes(2);
-    
+
 });
 
-test('3 locations, error on first', async() => {
+test('3 locations, error on first', async () => {
     mockedParseLocations.mockResolvedValue({ locations, errors: [] });
     mockedCalculateWithPolygon.mockRejectedValueOnce('Some error occurred');
     const result = await batchAccessibilityMap(mockedJob, progressEmitter, isCancelledMock);
@@ -210,7 +209,7 @@ test('3 locations, error on first', async() => {
         completed: true,
         errors: []
     }));
-    expect(result.warnings.length).toEqual(1); 
+    expect(result.warnings.length).toEqual(1);
 
     // Make sure all functions have been called
     expect(mockedParseLocations).toHaveBeenCalledTimes(1);

--- a/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
+++ b/packages/transition-common/src/services/accessibilityMap/TransitAccessibilityMapResult.ts
@@ -26,13 +26,11 @@ export interface TransitAccessibilityMapResult {
 
 export interface TransitAccessibilityMapWithPolygonResult {
     polygons: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon>;
-    strokes: GeoJSON.FeatureCollection<GeoJSON.MultiLineString>;
     resultByNode?: TrRoutingResultAccessibilityMap;
 }
 
 export interface TransitAccessibilityMapComparisonResult {
     polygons: GeoJSONComparison<GeoJSON.MultiPolygon>;
-    strokes: GeoJSONComparison<GeoJSON.MultiLineString>;
 }
 
 interface GeoJSONComparison<T extends GeoJSON.MultiPolygon | GeoJSON.MultiLineString> {

--- a/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityComparison/AccessibilityComparisonForm.tsx
@@ -269,17 +269,12 @@ class AccessibilityComparisonForm extends ChangeEventsForm<
                     ...singleMap.polygons.scenario1Minus2,
                     ...singleMap.polygons.scenario2Minus1
                 ]);
-                const strokes = turfFeatureCollection([
-                    ...singleMap.strokes.intersection,
-                    ...singleMap.strokes.scenario1Minus2,
-                    ...singleMap.strokes.scenario2Minus1
-                ]);
                 const travelTime =
                     numberOfPolygons === 1
                         ? routing.attributes.maxTotalTravelTimeSeconds
                         : Number(this.state.possibleMaxTimes[i].value);
 
-                finalMap.push({ polygons, strokes, travelTime });
+                finalMap.push({ polygons, travelTime });
             }
 
             this.setState({ finalMap });
@@ -343,9 +338,7 @@ class AccessibilityComparisonForm extends ChangeEventsForm<
 
     displayMap(index: number) {
         const currentResult = this.state.finalMap[index];
-        const { polygons, strokes } = currentResult;
-
-        console.log('polygons calculated');
+        const { polygons } = currentResult;
 
         (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
             layerName: 'accessibilityMapPolygons',
@@ -353,7 +346,7 @@ class AccessibilityComparisonForm extends ChangeEventsForm<
         });
         (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
             layerName: 'accessibilityMapPolygonStrokes',
-            data: strokes
+            data: polygons
         });
 
         this.setState({

--- a/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
+++ b/packages/transition-frontend/src/components/forms/accessibilityMap/AccessibilityMapForm.tsx
@@ -185,17 +185,16 @@ class AccessibilityMapForm extends ChangeEventsForm<AccessibilityMapFormProps, A
     }
 
     polygonCalculated(currentResult: TransitAccessibilityMapWithPolygonResult) {
-        const { polygons, strokes, resultByNode } = currentResult;
-
-        console.log('polygons calculated');
+        const { polygons, resultByNode } = currentResult;
 
         (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
             layerName: 'accessibilityMapPolygons',
             data: polygons
         });
+
         (serviceLocator.eventManager as EventManager).emitEvent<MapUpdateLayerEventType>('map.updateLayer', {
             layerName: 'accessibilityMapPolygonStrokes',
-            data: strokes
+            data: polygons
         });
 
         this.setState({


### PR DESCRIPTION
Remove strokes from polygon calculations. Apply two different styles (line and fill) to the same polygon and display it in two map layers.
MapLibre does not support an outline width property for `fill` layers, so two polygons are still required.

Closes #1346

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chairemobilite/transition/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Accessibility map results now provide polygon geometries only, with outline (“stroke”) data removed.
  - Map comparison outputs are simplified to polygon areas only (no separate stroke comparisons).
  - Accessibility map and comparison screens now render using the available polygon-only geometry.
  - Map downloads and per-area travel-time information continue to work as before.
- **Tests**
  - Updated mocked outputs to match the new polygon-only result shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->