### PR TITLE
Set OSRM annotations flag to false by default

### DIFF
--- a/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
@@ -192,7 +192,7 @@ export default class OSRMRoutingService extends RoutingService.default {
             points: params.points.features,
             steps: params.showSteps || false,
             overview: params.overview === 'simplified' ? 'simplified' : params.overview === 'false' ? 'false' : 'full',
-            annotations: _isBlank(params.annotations) ? true : params.annotations,
+            annotations: _isBlank(params.annotations) ? false : params.annotations,
             // gaps      : 'ignore',
             continue_straight:
                 // TODO: Migrate this value from preferences to config like the osrm modes. See issue #1140

--- a/packages/chaire-lib-common/src/services/routing/__tests__/OSRMRoutingService.test.ts
+++ b/packages/chaire-lib-common/src/services/routing/__tests__/OSRMRoutingService.test.ts
@@ -119,7 +119,7 @@ describe('Route', () => {
         
         const routeResult = await routingService.route({ mode: 'walking', points: { type: 'FeatureCollection', features: stubPlaces}, withAlternatives: true });
         expect(mockRoute).toHaveBeenCalledTimes(1);
-        expect(mockRoute).toHaveBeenCalledWith({mode: 'walking', points: stubPlaces, annotations: true, steps: false, continue_straight: undefined, overview: "full", withAlternatives: true }, expect.any(Function))
+        expect(mockRoute).toHaveBeenCalledWith({mode: 'walking', points: stubPlaces, annotations: false, steps: false, continue_straight: undefined, overview: "full", withAlternatives: true }, expect.any(Function))
         expect(routeResult).toEqual(expectedResponse);
     });
     
@@ -137,7 +137,7 @@ describe('Route', () => {
             haveThrown = true;
         }
         expect(mockRoute).toHaveBeenCalledTimes(1);
-        expect(mockRoute).toHaveBeenCalledWith({ mode: 'walking', points: stubPlaces, annotations: true, steps: false, continue_straight: undefined, overview: "full", withAlternatives: false }, expect.any(Function))
+        expect(mockRoute).toHaveBeenCalledWith({ mode: 'walking', points: stubPlaces, annotations: false, steps: false, continue_straight: undefined, overview: "full", withAlternatives: false }, expect.any(Function))
         expect(routeResult).toBeUndefined();
         expect(haveThrown).toBe(true);
     });


### PR DESCRIPTION
In general, we don't need the OSRM annotation. The default flag should be set to false. This should save some parsing CPU time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing requests by correctly handling blank/empty annotation settings (now disabled instead of enabled).
  * Preserved existing behavior for all other routing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->