### PR TITLE
Enable workflow_call run type for coderabbit retry workflow

### DIFF
--- a/.github/workflows/coderabbit-retry.yml
+++ b/.github/workflows/coderabbit-retry.yml
@@ -60,6 +60,7 @@ on:
     # Hourly overnight (UTC). Adjust to your low-activity window.
     - cron: '0 3-11/3 * * *'
   workflow_dispatch:
+  workflow_call: # To be able to run it from other repo
 
 concurrency:
   group: coderabbit-retry


### PR DESCRIPTION
This allows it to be call from another workflow, which will enable us to reuse the same code from another repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for invoking the CodeRabbit retry workflow from other workflows and repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->