### PR TITLE
Revert "Spawn multiple trRouting processes when asking for more than …

### DIFF
--- a/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/TrRoutingProcessManager.ts
@@ -25,14 +25,8 @@ type TrRoutingBatchStartParameters = TrRoutingStartParameters & {
     memcachedServer?: string;
 };
 
-const getServiceName = function (port: number, processIndex: number = 0) {
-    // When spawning multiple instances, the first one will have the classic service name
-    // and the other ones (index 1 and above) will have the index added at the end
-    if (processIndex <= 0) {
-        return `trRouting${port}`;
-    } else {
-        return `trRouting${port}_${processIndex}`;
-    }
+const getServiceName = function (port: number) {
+    return `trRouting${port}`;
 };
 
 const startTrRoutingProcess = async (
@@ -51,11 +45,10 @@ const startTrRoutingProcess = async (
         cacheAllScenarios?: boolean; // Flag to enable the trRouting connection cache for all scenario
         logFiles: TrRoutingConfig['logs'];
         memcachedServer?: string; // If defined, enable use of memcached and use the value as the server URL
-    },
-    processIndex: number = -1
+    }
 ) => {
     const osrmWalkingServerInfo = osrmService.getMode('walking').getHostPort();
-    const serviceName = getServiceName(port, processIndex);
+    const serviceName = getServiceName(port);
     const tagName = 'trRouting';
 
     const [command, cwd] =
@@ -88,10 +81,6 @@ const startTrRoutingProcess = async (
     // Enable memcached usage in TrRouting
     if (memcachedServer) {
         commandArgs.push(`--useMemcached=${memcachedServer}`);
-    }
-
-    if (processIndex >= 0) {
-        commandArgs.push('--enableReusePort=true');
     }
 
     const waitString = 'ready.';
@@ -199,8 +188,6 @@ const status = async (parameters: { port?: number }) => {
     }
 };
 
-const MAX_THREADS_PER_PROCESS = 16; // TrRouting saturate at 24 threads, so let's not get there
-
 const startBatch = async function (
     numberOfCpus?: number,
     {
@@ -232,19 +219,7 @@ const startBatch = async function (
         memcachedServer: memcachedServer
     };
 
-    // Since a single process cannot handle too many threads, we will spawn multiple process
-    // TODO This can go away if we change trRouting to handle more threads
-    // https://github.com/chairemobilite/trRouting/issues/340
-    const processCount = Math.ceil(numberOfCpus / MAX_THREADS_PER_PROCESS);
-    const threadsPerProcess = Math.ceil(numberOfCpus / processCount);
-
-    const startPromises: Promise<any>[] = [];
-    for (let i = 0; i < processCount; i++) {
-        // Last process may get fewer threads if total doesn't divide evenly
-        const threads = Math.min(threadsPerProcess, numberOfCpus - i * threadsPerProcess);
-        startPromises.push(startTrRoutingProcess(port, false, threads, params, i));
-    }
-    await Promise.all(startPromises);
+    await startTrRoutingProcess(port, false, numberOfCpus, params);
 
     return {
         status: 'started',
@@ -254,18 +229,8 @@ const startBatch = async function (
 };
 
 const stopBatch = async function (port: number = serverConfig.getTrRoutingConfig('batch').port) {
-    await stop({ port: port }); // Stop the first one the normal way
-    // Since we don't have a good way to Iterate through the running extra instances
-    // We check for each index and stop if we cannot find one. Only check the first X instances, assuming
-    // the absolute max is 256 threads machines.
-    for (let i = 1; i <= 256 / MAX_THREADS_PER_PROCESS; i++) {
-        const serviceName = getServiceName(port, i);
-        if (await ProcessManager.isServiceRunning(serviceName)) {
-            await ProcessManager.stopProcess(serviceName, 'trRouting');
-        } else {
-            break; // No more processes
-        }
-    }
+    await stop({ port: port });
+
     return {
         status: 'stopped',
         service: 'trRoutingBatch',

--- a/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
+++ b/packages/chaire-lib-backend/src/utils/processManagers/__tests__/TrRoutingProcessManager.test.ts
@@ -510,7 +510,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--enableReusePort=true'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -533,7 +533,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--enableReusePort=true'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -560,7 +560,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=2', '--enableReusePort=true'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=2'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -583,7 +583,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--enableReusePort=true'],
+            commandArgs: ['--port=12345', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -609,7 +609,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: `trRouting${port}`,
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--cacheAllConnectionSets=true', '--enableReusePort=true'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--cacheAllConnectionSets=true'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -637,7 +637,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting12345',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', '--useMemcached=localhost:11212', '--enableReusePort=true'],
+            commandArgs: [`--port=${port}`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${cacheDirectoryPath}`, '--threads=4', '--useMemcached=localhost:11212'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -662,7 +662,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: [`--port=14000`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--useMemcached=localhost:11212', '--enableReusePort=true'],
+            commandArgs: [`--port=14000`, `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--useMemcached=localhost:11212'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -688,7 +688,7 @@ describe('TrRouting Process Manager: startBatch', () => {
             serviceName: 'trRouting14000',
             tagName: 'trRouting',
             command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4', '--enableReusePort=true'],
+            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=1', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=4'],
             waitString: 'ready.',
             useShell: false,
             cwd: undefined,
@@ -697,41 +697,6 @@ describe('TrRouting Process Manager: startBatch', () => {
                 nbLogFiles: logFiles.nbFiles,
                 maxFileSizeKB: logFiles.maxFileSizeKB
             }
-        });
-    });
-    test('start batch process with 32 cpus, should be split in 2 processes', async () => {
-        // Override the configuration
-        // TODO might have a better way to do this
-        config.maxParallelCalculators = 32;
-
-        const status = await TrRoutingProcessManager.startBatch(32);
-        expect(status).toEqual({
-            status: 'started',
-            service: 'trRoutingBatch',
-            port: 14000
-        });
-        expect(startProcessMock).toHaveBeenCalledTimes(2);
-
-        const expectedCommonArgs = {
-            tagName: 'trRouting',
-            command: 'trRouting',
-            commandArgs: ['--port=14000', `--osrmPort=${walkingOsrmMode.getHostPort().port}`, `--osrmHost=${walkingOsrmMode.getHostPort().host}`, '--debug=0', `--cachePath=${directoryManager.transitCacheDirectory}`, '--threads=16', '--enableReusePort=true'],
-            waitString: 'ready.',
-            useShell: false,
-            cwd: undefined,
-            attemptRestart: false,
-            logFiles: {
-                nbLogFiles: 3,
-                maxFileSizeKB: 5120
-            }
-        };
-        expect(startProcessMock).toHaveBeenNthCalledWith(1, {
-            ...expectedCommonArgs,
-            serviceName: 'trRouting14000'
-        });
-        expect(startProcessMock).toHaveBeenNthCalledWith(2, {
-            ...expectedCommonArgs,
-            serviceName: 'trRouting14000_1'
         });
     });
 });


### PR DESCRIPTION
…16 threads"

This reverts commit caeaad1879b92c0b697273e49f9eb415e4486823.

We fixed the performance issues with TrRouting, so we don't need this hack anymore. Simplify the code a bit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified routing service startup and shutdown behavior.
  * Routing batches now run as a single process using the configured CPU allocation.
  * Removed unnecessary multi-process splitting and related reuse-port configuration.
  * Updated supported startup scenarios to reflect the streamlined routing process behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->