### PR TITLE
fix(schedules): generate return trips when path times are fractional

### DIFF
--- a/packages/chaire-lib-common/src/services/routing/ManualRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/ManualRoutingService.ts
@@ -7,6 +7,7 @@
 import * as RoutingService from './RoutingService';
 import * as turf from '@turf/turf';
 import _cloneDeep from 'lodash/cloneDeep';
+import { ceilToPositiveInteger } from '../../utils/MathUtils';
 
 //TODO: Add tests
 
@@ -29,7 +30,7 @@ export default class ManualRoutingService extends RoutingService.default {
             defaultRunningSpeedMps = 30 / 3.6; // this should not happen!
         }
         const runningSpeed = defaultRunningSpeedMps;
-        const birdDistanceDuration = Math.ceil(lineLength / runningSpeed);
+        const birdDistanceDuration = ceilToPositiveInteger(lineLength / runningSpeed);
         const legs: RoutingService.MapLeg[] = [];
         let legCoordinates: GeoJSON.Position[] = [];
 
@@ -46,7 +47,7 @@ export default class ManualRoutingService extends RoutingService.default {
                 const legLength = turf.length(legGeojson, { units: 'meters' });
                 legs.push({
                     distance: legLength,
-                    duration: Math.ceil(legLength / runningSpeed),
+                    duration: ceilToPositiveInteger(legLength / runningSpeed),
                     steps: [
                         {
                             distance: legLength,

--- a/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
+++ b/packages/chaire-lib-common/src/services/routing/OSRMRoutingService.ts
@@ -15,6 +15,7 @@ import { _isBlank } from '../../utils/LodashExtensions';
 import Preferences from '../../config/Preferences';
 import * as Status from '../../utils/Status';
 import * as OSRMRoutingAPI from '../../api/OSRMRouting';
+import { ceilToPositiveInteger } from '../../utils/MathUtils';
 
 const defaultRoutingRadiusMeters = 20;
 
@@ -171,7 +172,7 @@ export default class OSRMRoutingService extends RoutingService.default {
     public async mapMatch(params: RoutingService.MapMatchParameters): Promise<RoutingService.MapMatchingResults> {
         // we need to divide radiuses by 3 since osrm match service will use RADIUS_MULTIPLIER of 3.
         const radiuses = params.points.features.map((feature) =>
-            Math.ceil((feature.properties?.radius || defaultRoutingRadiusMeters) / 3)
+            ceilToPositiveInteger((feature.properties?.radius || defaultRoutingRadiusMeters) / 3)
         );
         const timestamps = params.points.features.map((feature) => feature.properties?.timestamp || 0);
         const routingResult = await this.callOsrmMap({

--- a/packages/chaire-lib-common/src/utils/DateTimeUtils.ts
+++ b/packages/chaire-lib-common/src/utils/DateTimeUtils.ts
@@ -9,6 +9,7 @@ import _isString from 'lodash/isString';
 import _padStart from 'lodash/padStart';
 import { _isBlank } from './LodashExtensions';
 import type { TFunction } from 'i18next';
+import { ceilToPositiveInteger } from './MathUtils';
 
 /**
  * Formats the number of seconds since midnight to a time string (HH:MM[:ss]).
@@ -72,7 +73,7 @@ const timeStrToDecimalHour = function (timeStr) {
     return null;
 };
 
-const secondsToMinutes = function (seconds, rounding = Math.ceil) {
+const secondsToMinutes = function (seconds, rounding = ceilToPositiveInteger) {
     seconds = parseInt(seconds);
     return _isFinite(seconds) ? rounding(seconds / 60) : null;
 };
@@ -82,7 +83,7 @@ const secondsToMinutesDecimal = function (seconds) {
     return _isFinite(seconds) ? seconds / 60 : null;
 };
 
-const secondsToHours = function (seconds, rounding = Math.ceil) {
+const secondsToHours = function (seconds, rounding = ceilToPositiveInteger) {
     seconds = parseInt(seconds);
     return _isFinite(seconds) ? rounding(seconds / 3600) : null;
 };
@@ -92,7 +93,7 @@ const secondsToHoursDecimal = function (seconds) {
     return _isFinite(seconds) ? seconds / 3600 : null;
 };
 
-const minutesToHours = function (minutes: string | number, rounding = Math.ceil) {
+const minutesToHours = function (minutes: string | number, rounding = ceilToPositiveInteger) {
     minutes = typeof minutes === 'string' ? parseInt(minutes) : minutes;
     return _isFinite(minutes) ? rounding(minutes / 60) : null;
 };
@@ -222,7 +223,7 @@ const intTimeToSecondsSinceMidnight = function (intTime) {
 };
 
 // returns value as seconds, rounded, ceiled or floored to the nearest 60 seconds:
-const roundSecondsToNearestMinute = function (seconds: number, rounding = Math.ceil): number {
+const roundSecondsToNearestMinute = function (seconds: number, rounding = ceilToPositiveInteger): number {
     return rounding(seconds / 60) * 60;
 };
 

--- a/packages/chaire-lib-common/src/utils/MathUtils.ts
+++ b/packages/chaire-lib-common/src/utils/MathUtils.ts
@@ -140,11 +140,25 @@ export const sequentialArray = function (n: number, startAt = 0, increment = 1):
     return array;
 };
 
+/**
+ * Ceil a numeric value to a positive integer.
+ * @param value The value to ceil to a positive integer.
+ * @returns The value rounded up to the nearest positive integer.
+ * Throws an error if the value is not a finite number or < 0.
+ */
+export const ceilToPositiveInteger = function (value: number): number {
+    if (!Number.isFinite(value) || value < 0) {
+        throw new Error('ceilToPositiveInteger: Value must be a finite number and >= 0');
+    }
+    return Math.ceil(value);
+};
+
 export default {
     parseIntOrNull,
     parseFloatOrNull,
     roundToDecimals,
     median,
     permutationsWithRepetition,
-    sequentialArray
+    sequentialArray,
+    ceilToPositiveInteger
 };

--- a/packages/chaire-lib-common/src/utils/__tests__/DateTimeUtils.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/DateTimeUtils.test.ts
@@ -7,22 +7,22 @@
 import * as DateTimeUtils from '../DateTimeUtils';
 import type { TFunction } from 'i18next';
 
-test('should convert decimal hour to time string', function() {
-  expect(DateTimeUtils.decimalHourToTimeStr(6.23)).toBe('6:13');
-  expect(DateTimeUtils.decimalHourToTimeStr(6.999)).toBe('6:59');
-  expect(DateTimeUtils.decimalHourToTimeStr(23.99)).toBe('23:59');
-  expect(DateTimeUtils.decimalHourToTimeStr(23.999)).toBe('23:59');
-  expect(DateTimeUtils.decimalHourToTimeStr(6.999, true, true)).toBe('6:59:56');
-  expect(DateTimeUtils.decimalHourToTimeStr(6.9999, true, true)).toBe('7:00:00');
+test('should convert decimal hour to time string', () => {
+    expect(DateTimeUtils.decimalHourToTimeStr(6.23)).toBe('6:13');
+    expect(DateTimeUtils.decimalHourToTimeStr(6.999)).toBe('6:59');
+    expect(DateTimeUtils.decimalHourToTimeStr(23.99)).toBe('23:59');
+    expect(DateTimeUtils.decimalHourToTimeStr(23.999)).toBe('23:59');
+    expect(DateTimeUtils.decimalHourToTimeStr(6.999, true, true)).toBe('6:59:56');
+    expect(DateTimeUtils.decimalHourToTimeStr(6.9999, true, true)).toBe('7:00:00');
 });
 
-test('should return null if decimal hour is not valid', function() {
-  expect(DateTimeUtils.decimalHourToTimeStr('blabla')).toBe(null);
-  expect(DateTimeUtils.decimalHourToTimeStr(-23)).toBe(null);
-  expect(DateTimeUtils.decimalHourToTimeStr('-12:60')).toBe(null);
+test('should return null if decimal hour is not valid', () => {
+    expect(DateTimeUtils.decimalHourToTimeStr('blabla')).toBe(null);
+    expect(DateTimeUtils.decimalHourToTimeStr(-23)).toBe(null);
+    expect(DateTimeUtils.decimalHourToTimeStr('-12:60')).toBe(null);
 });
 
-test('timeStrToSecondsSinceMidnight', function() {
+test('timeStrToSecondsSinceMidnight', () => {
     expect(DateTimeUtils.timeStrToSecondsSinceMidnight('1:00')).toBe(3600);
     expect(DateTimeUtils.timeStrToSecondsSinceMidnight('1:01')).toBe(3660);
     expect(DateTimeUtils.timeStrToSecondsSinceMidnight('1:')).toBe(3600);
@@ -39,7 +39,7 @@ test('timeStrToSecondsSinceMidnight', function() {
     expect(DateTimeUtils.timeStrToSecondsSinceMidnight('01:10:do')).toBeNull();
 });
 
-test('secondsSinceMidnightToTimeStr', function() {
+test('secondsSinceMidnightToTimeStr', () => {
     expect(DateTimeUtils.secondsSinceMidnightToTimeStr(3600)).toBe('1:00');
     expect(DateTimeUtils.secondsSinceMidnightToTimeStr(3667)).toBe('1:01');
     expect(DateTimeUtils.secondsSinceMidnightToTimeStr(5)).toBe('0:00');
@@ -55,16 +55,16 @@ test('secondsSinceMidnightToTimeStr', function() {
     expect(DateTimeUtils.secondsSinceMidnightToTimeStr(-87000)).toBe('23:50');
 });
 
-test('roundSecondsToNearestMinute', function() {
+test('roundSecondsToNearestMinute', () => {
     expect(DateTimeUtils.roundSecondsToNearestMinute(0)).toBe(0);
     expect(DateTimeUtils.roundSecondsToNearestMinute(10)).toBe(60);
-    expect(DateTimeUtils.roundSecondsToNearestMinute(-1)).toBe(-0); // it seems Javascript differentiate -0 from 0
-    expect(DateTimeUtils.roundSecondsToNearestMinute(-59)).toBe(-0);
-    expect(DateTimeUtils.roundSecondsToNearestMinute(-72)).toBe(-60);
+    expect(() => DateTimeUtils.roundSecondsToNearestMinute(-1)).toThrow();
+    expect(() => DateTimeUtils.roundSecondsToNearestMinute(-59)).toThrow();
+    expect(() => DateTimeUtils.roundSecondsToNearestMinute(-72)).toThrow();
     expect(DateTimeUtils.roundSecondsToNearestMinute(60)).toBe(60);
     expect(DateTimeUtils.roundSecondsToNearestMinute(0, Math.ceil)).toBe(0);
     expect(DateTimeUtils.roundSecondsToNearestMinute(10, Math.ceil)).toBe(60);
-    expect(DateTimeUtils.roundSecondsToNearestMinute(-1, Math.ceil)).toBe(-0);
+    expect(DateTimeUtils.roundSecondsToNearestMinute(-1, Math.ceil)).toBe(-0); // it seems Javascript differentiate -0 from 0
     expect(DateTimeUtils.roundSecondsToNearestMinute(-59, Math.ceil)).toBe(-0);
     expect(DateTimeUtils.roundSecondsToNearestMinute(-72, Math.ceil)).toBe(-60);
     expect(DateTimeUtils.roundSecondsToNearestMinute(60, Math.ceil)).toBe(60);
@@ -79,7 +79,7 @@ test('roundSecondsToNearestMinute', function() {
     expect(DateTimeUtils.roundSecondsToNearestMinute(60, Math.round)).toBe(60);
     expect(DateTimeUtils.roundSecondsToNearestMinute(256, Math.round)).toBe(240);
     expect(DateTimeUtils.roundSecondsToNearestMinute(280, Math.round)).toBe(300);
-    expect(DateTimeUtils.roundSecondsToNearestMinute(Infinity)).toBe(Infinity);
+    expect(() => DateTimeUtils.roundSecondsToNearestMinute(Infinity)).toThrow();
     expect(DateTimeUtils.roundSecondsToNearestMinute(Infinity, Math.ceil)).toBe(Infinity);
     expect(DateTimeUtils.roundSecondsToNearestMinute(Infinity, Math.floor)).toBe(Infinity);
     expect(DateTimeUtils.roundSecondsToNearestMinute(Infinity, Math.round)).toBe(Infinity);
@@ -92,7 +92,7 @@ describe('toXXhrYYminZZsec', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-    })
+    });
 
     test.each([
         [34, '34 s'],
@@ -184,5 +184,5 @@ describe('toXXhrYYminZZsec', () => {
         expect(mockT.mock.calls).toEqual(expectedCalls);
     });
 
-    
+
 });

--- a/packages/chaire-lib-common/src/utils/__tests__/MathUtils.test.ts
+++ b/packages/chaire-lib-common/src/utils/__tests__/MathUtils.test.ts
@@ -124,3 +124,25 @@ test('should get sequential array', function() {
     expect(MathUtils.sequentialArray(4, 2, 2)).toEqual([2,4,6,8]);
     expect(MathUtils.sequentialArray(5, 1.5, 0.5)).toEqual([1.5,2,2.5,3,3.5]);
 });
+
+test.each([
+    [540, 540],
+    [540.1, 541],
+    [540.7, 541],
+    [0, 0],
+    [0.0, 0],
+    [0.1, 1],
+    [1.9, 2]
+])('should ceil to positive integer %p => %p', (input, expected) => {
+    expect(MathUtils.ceilToPositiveInteger(input)).toBe(expected);
+});
+
+test.each([
+    [-5],
+    [-0.1],
+    [NaN],
+    [Infinity],
+    [-Infinity]
+])('should throw for invalid input %p', (input) => {
+    expect(() => MathUtils.ceilToPositiveInteger(input as any)).toThrow('ceilToPositiveInteger: Value must be a finite number and >= 0');
+});

--- a/packages/chaire-lib-common/src/utils/objects/GenericPlaceCollection.ts
+++ b/packages/chaire-lib-common/src/utils/objects/GenericPlaceCollection.ts
@@ -12,6 +12,7 @@ import GenericMapObjectCollection from './GenericMapObjectCollection';
 import { _isBlank } from '../LodashExtensions';
 import Preferences from '../../config/Preferences';
 import routingServiceManager from '../../services/routing/RoutingServiceManager';
+import { ceilToPositiveInteger } from '../MathUtils';
 
 /**
  * A collection of point locations on a map
@@ -103,8 +104,8 @@ export default abstract class GenericPlaceCollection<
                 const distanceMeters = distances[i];
                 pointsInRoutedRadius.push({
                     id: pointInBirdRadius.properties.id,
-                    walkingTravelTimesSeconds: Math.ceil(travelTimeSeconds),
-                    walkingDistancesMeters: Math.ceil(distanceMeters)
+                    walkingTravelTimesSeconds: ceilToPositiveInteger(travelTimeSeconds),
+                    walkingDistancesMeters: ceilToPositiveInteger(distanceMeters)
                 });
             }
         }

--- a/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
+++ b/packages/transition-backend/src/services/accessibilityMap/TransitAccessibilityMapCalculator.ts
@@ -39,11 +39,12 @@ import nodeDbQueries from '../../models/db/transitNodes.db.queries';
 import placesDbQueries from '../../models/db/places.db.queries';
 import { clipPolygon as clipPolygonWithPostGIS } from '../../models/db/geometryUtils.db.queries';
 import censusDbQueries from '../../models/db/census.db.queries';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 const getDurations = (maxDuration: number, numberOfPolygons: number): number[] => {
-    const durations = [maxDuration];
+    const durations = [ceilToPositiveInteger(maxDuration)];
     for (let i = numberOfPolygons - 1; i > 0; i--) {
-        durations.push(Math.ceil((i * maxDuration) / numberOfPolygons));
+        durations.push(ceilToPositiveInteger((i * maxDuration) / numberOfPolygons));
     }
     return durations;
 };

--- a/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/ScheduleImporter.ts
@@ -21,6 +21,7 @@ import scheduleDbQueries from '../../models/db/transitSchedules.db.queries';
 import { objectToCache as lineObjectToCache } from '../../models/capnpCache/transitLines.cache.queries';
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 type TripAndStopTimes = { trip: GtfsTypes.Trip; stopTimes: StopTime[] };
 
@@ -432,8 +433,8 @@ const generateFrequencyBasedTrips = (
         // For interval, take the average of inbound/outbound frequencies
         currentPeriod.interval_seconds =
             inboundData !== undefined
-                ? Math.ceil((outboundData.frequencySeconds + inboundData.frequencySeconds) / 2)
-                : Math.ceil(outboundData.frequencySeconds);
+                ? ceilToPositiveInteger((outboundData.frequencySeconds + inboundData.frequencySeconds) / 2)
+                : ceilToPositiveInteger(outboundData.frequencySeconds);
 
         schedule.generateForPeriod(currentPeriod.period_shortname as string);
     }

--- a/packages/transition-backend/src/services/gtfsImport/StopTimeImporter.ts
+++ b/packages/transition-backend/src/services/gtfsImport/StopTimeImporter.ts
@@ -14,6 +14,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { GtfsInternalData, StopTimeImportData, StopTime } from './GtfsImportTypes';
 
 import { GtfsObjectPreparator } from './GtfsObjectPreparator';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 /**
  * Estimate stop_times row count from the number of trips.
@@ -156,7 +157,7 @@ implements GtfsObjectPreparator<StopTime | Omit<StopTime, 'arrivalTimeSeconds' |
             const timeBetweenReferences =
                 (stopTimes[stopIndex] as StopTime).arrivalTimeSeconds -
                 (stopTimes[startIndex] as StopTime).departureTimeSeconds;
-            const interpolationDelta = Math.ceil(timeBetweenReferences / (stopIndex - startIndex));
+            const interpolationDelta = ceilToPositiveInteger(timeBetweenReferences / (stopIndex - startIndex));
             // Interpolate times
             for (let segmentIndex = startIndex + 1; segmentIndex < stopIndex; segmentIndex++) {
                 (stopTimes[segmentIndex] as StopTime).arrivalTimeSeconds =

--- a/packages/transition-backend/src/services/nodes/TransferableNodeUtils.ts
+++ b/packages/transition-backend/src/services/nodes/TransferableNodeUtils.ts
@@ -10,6 +10,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import TransitNode, { TransferableNodes } from 'transition-common/lib/services/nodes/Node';
 import NodeCollection from 'transition-common/lib/services/nodes/NodeCollection';
 import { getNodesInBirdDistance } from './NodeCollectionUtils';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 const getTransferableNodesFromBirdRadius = (
     nodesInBirdRadius: { id: string; distance: number }[],
@@ -25,9 +26,9 @@ const getTransferableNodesFromBirdRadius = (
 
         transferableNodes.nodesIds.push(nodeInBirdRadius.id);
         transferableNodes.walkingTravelTimesSeconds.push(
-            Math.ceil(nodeInBirdRadius.distance / walkingSpeedMetersPerSeconds)
+            ceilToPositiveInteger(nodeInBirdRadius.distance / walkingSpeedMetersPerSeconds)
         );
-        transferableNodes.walkingDistancesMeters.push(Math.ceil(nodeInBirdRadius.distance));
+        transferableNodes.walkingDistancesMeters.push(ceilToPositiveInteger(nodeInBirdRadius.distance));
     }
     return transferableNodes;
 };
@@ -69,8 +70,8 @@ const getTransferableNodeOsrm = async (
             if (nodeInBirdRadius.distance <= distanceMeters + 100) {
                 // osrm will calculate and give very short durations and distances when the nearest network osm node is very far (out of routing network), so we make sure not to keep these.
                 transferableNodes.nodesIds.push(nodeInBirdRadius.id);
-                transferableNodes.walkingTravelTimesSeconds.push(Math.ceil(travelTimeSeconds));
-                transferableNodes.walkingDistancesMeters.push(Math.ceil(distanceMeters));
+                transferableNodes.walkingTravelTimesSeconds.push(ceilToPositiveInteger(travelTimeSeconds));
+                transferableNodes.walkingDistancesMeters.push(ceilToPositiveInteger(distanceMeters));
             }
         }
     }

--- a/packages/transition-backend/src/services/nodes/__tests__/TransferableNodeUtils.test.ts
+++ b/packages/transition-backend/src/services/nodes/__tests__/TransferableNodeUtils.test.ts
@@ -15,14 +15,14 @@ import Preferences from 'chaire-lib-common/lib/config/Preferences';
 jest.mock('../../../models/db/transitNodes.db.queries', () => {
     return {
         getNodesInBirdDistance: jest.fn()
-    }
+    };
 });
 const mockedGetNodesInBirdDistance = nodesDbQueries.getNodesInBirdDistance as jest.MockedFunction<typeof nodesDbQueries.getNodesInBirdDistance>;
 
 const mockTableFrom = RoutingServiceManagerMock.routingServiceManagerMock.getRoutingServiceForEngine('engine').tableFrom;
 const mockTableTo = RoutingServiceManagerMock.routingServiceManagerMock.getRoutingServiceForEngine('engine').tableTo;
-// Actual response does not matter for this test, just return 0s for every destination 
-mockTableFrom.mockImplementation(async (params) => ({ query: '', durations: params.destinations.map(d => 0), distances: params.destinations.map(d => 0) }));
+// Actual response does not matter for this test, just return 0s for every destination
+mockTableFrom.mockImplementation(async (params) => ({ query: '', durations: params.destinations.map((d) => 0), distances: params.destinations.map((d) => 0) }));
 
 const commonProperties = {
     is_enabled: true,
@@ -30,7 +30,7 @@ const commonProperties = {
     default_dwell_time_seconds: 20,
     is_frozen: false,
     data: { }
-}
+};
 
 // 4 nodes: 1 reference node, 2 within 1km distance, one beyond
 
@@ -87,8 +87,8 @@ beforeEach(() => {
 describe('getTransferableNodes', () => {
 
     let refNode: Node;
-    const travelTimeSeconds = Preferences.get('transit.nodes.maxTransferWalkingTravelTimeSeconds')
-    const defaultSpeedMps = Preferences.get('defaultWalkingSpeedMetersPerSeconds')
+    const travelTimeSeconds = Preferences.get('transit.nodes.maxTransferWalkingTravelTimeSeconds');
+    const defaultSpeedMps = Preferences.get('defaultWalkingSpeedMetersPerSeconds');
     const distanceMeters = Math.ceil(defaultSpeedMps * travelTimeSeconds);
 
     beforeEach(() => {
@@ -119,7 +119,7 @@ describe('getTransferableNodes', () => {
             walkingTravelTimesSeconds: [0, 150, 550],
             walkingDistancesMeters: [0, 120, 512]
         });
-        
+
     });
 
     test('With some accessible nodes, but too far from network, or too long', async() => {
@@ -139,7 +139,7 @@ describe('getTransferableNodes', () => {
             walkingTravelTimesSeconds: [0, 150],
             walkingDistancesMeters: [0, 120]
         });
-        
+
     });
 
     test('No other node within distance', async() => {
@@ -185,8 +185,8 @@ describe('getTransferableNodesWithAffected', () => {
 
     test('With transferable nodes', async() => {
         const node = nodeCollection.newObject(referenceNodeGeojson);
-        const nodesInBirdRadius = [ 
-            { id: nodeAttributesClose1.id, distance: 300 }, 
+        const nodesInBirdRadius = [
+            { id: nodeAttributesClose1.id, distance: 300 },
             { id: nodeAttributesClose2.id, distance: 700 }
         ];
         mockedGetNodesInBirdDistance.mockResolvedValueOnce(nodesInBirdRadius);
@@ -201,7 +201,7 @@ describe('getTransferableNodesWithAffected', () => {
             durations: [130, 300],
             distances: [410, 910]
         });
-    
+
         const transferableNodes = await TransferableNodeUtils.getTransferableNodesWithAffected(node, nodeCollection, nodesInBirdRadius);
         expect(transferableNodes).toBeDefined();
         expect((transferableNodes as any).from).toEqual({
@@ -209,7 +209,7 @@ describe('getTransferableNodesWithAffected', () => {
             walkingDistancesMeters: [ 0, 400, 900 ],
             walkingTravelTimesSeconds: [0, 120, 240 ]
         });
-    
+
         // Make sure the table from was called with the expected parameters
         expect(mockTableFrom).toHaveBeenCalledTimes(1);
         expect(mockTableFrom).toHaveBeenCalledWith({ mode: 'walking', origin: node.toGeojson(), destinations: [ nodeClose1Geojson, nodeClose2Geojson ] });
@@ -223,12 +223,12 @@ describe('getTransferableNodesWithAffected', () => {
             walkingTravelTimesSeconds: [130, 300 ]
         });
     });
-    
+
     test('updateTransferableNodes without transferable nodes', async() => {
         const nodeFar = nodeCollection.newObject(nodeFarGeojson);
         const nodesInBirdRadius = [];
         mockedGetNodesInBirdDistance.mockResolvedValueOnce(nodesInBirdRadius);
-    
+
         const transferableNodes = await TransferableNodeUtils.getTransferableNodesWithAffected(nodeFar, nodeCollection, nodesInBirdRadius);
         expect(transferableNodes).toBeDefined();
         expect((transferableNodes as any).from).toEqual({
@@ -241,6 +241,6 @@ describe('getTransferableNodesWithAffected', () => {
             walkingDistancesMeters: [ ],
             walkingTravelTimesSeconds: [ ]
         });
-    
+
     });
 });

--- a/packages/transition-backend/src/services/path/PathGtfsGeographyGenerator.ts
+++ b/packages/transition-backend/src/services/path/PathGtfsGeographyGenerator.ts
@@ -11,6 +11,7 @@ import type { TimeAndDistance } from 'transition-common/lib/services/path/PathTy
 import { StopTime } from '../gtfsImport/GtfsImportTypes';
 import { GtfsMessages } from 'transition-common/lib/services/gtfs/GtfsMessages';
 import { TranslatableMessage } from 'chaire-lib-common/lib/utils/TranslatableMessage';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 import {
     length as turfLength,
     cleanCoords as turfCleanCoords,
@@ -47,9 +48,9 @@ const calculateLayoverTimeSeconds = (
     defaultMin: number
 ): number => {
     if (customLayoverMinutes !== undefined) {
-        return customLayoverMinutes * 60;
+        return ceilToPositiveInteger(customLayoverMinutes * 60);
     }
-    return Math.ceil(Math.max(defaultRatio * totalTravelTimeWithDwellTimesSeconds, defaultMin));
+    return ceilToPositiveInteger(Math.max(defaultRatio * totalTravelTimeWithDwellTimesSeconds, defaultMin));
 };
 
 /**
@@ -84,7 +85,7 @@ export const computeSegmentTimesFromStopTimes = (
 
     // calculate trip averages
     const segmentsData: TimeAndDistance[] = segmentTravelTimeTotals.map((total, i) => ({
-        travelTimeSeconds: Math.ceil(total / numTrips),
+        travelTimeSeconds: ceilToPositiveInteger(total / numTrips),
         distanceMeters: segmentDistancesMeters[i]
     }));
 
@@ -183,7 +184,7 @@ const sliceShapeIntoSegments = (
             segments.push(pathCoordinates.length - 1);
         }
         pathCoordinates = pathCoordinates.concat(segmentCoordinates);
-        segmentDistancesMeters.push(Math.ceil(segmentLengthMeters));
+        segmentDistancesMeters.push(ceilToPositiveInteger(segmentLengthMeters));
     }
 
     return { pathCoordinates, segments, segmentDistancesMeters };
@@ -215,8 +216,9 @@ const buildPathData = (params: {
         dwellTimeSeconds: dwellTimeSecondsData,
         layoverTimeSeconds: layoverTimeSeconds,
         travelTimeWithoutDwellTimesSeconds: totalTravelTimeWithoutDwellTimesSeconds,
-        totalDistanceMeters: Math.ceil(totalDistanceMeters),
+        totalDistanceMeters: ceilToPositiveInteger(totalDistanceMeters),
         totalDwellTimeSeconds: totalDwellTimeSeconds,
+        // Totals are sums of already-integer segment times, dwells and layover.
         operatingTimeWithoutLayoverTimeSeconds: totalTravelTimeWithDwellTimesSeconds,
         operatingTimeWithLayoverTimeSeconds: totalTravelTimeWithDwellTimesSeconds + layoverTimeSeconds,
         totalTravelTimeWithReturnBackSeconds: null,

--- a/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
+++ b/packages/transition-backend/src/services/simulation/methods/OdTripSimulation.ts
@@ -15,6 +15,7 @@ import {
     OdTripSimulationDescriptor,
     OdTripSimulationOptions
 } from 'transition-common/lib/services/networkDesign/transit/simulationMethod/OdTripSimulationMethod';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 export const OdTripSimulationTitle = 'OdTripSimulation';
 
@@ -154,13 +155,13 @@ export default class OdTripSimulation implements SimulationMethod {
             (this.simulationDataAttributes.transitNetworkDesignParameters.nbOfVehicles || 1) * 120;
 
         return {
-            transfersCount: Math.ceil(transfersCount),
+            transfersCount: ceilToPositiveInteger(transfersCount),
             totalCount: Math.round(totalCount),
             routedCount: Math.round(routedCount),
             nonRoutedCount: Math.round(nonRoutedCount),
-            totalWalkingTimeMinutes: Math.ceil(totalWalkingTimeMinutes),
-            totalWaitingTimeMinutes: Math.ceil(totalWaitingTimeMinutes),
-            totalTravelTimeMinutes: Math.ceil(totalTravelTimeMinutes),
+            totalWalkingTimeMinutes: ceilToPositiveInteger(totalWalkingTimeMinutes),
+            totalWaitingTimeMinutes: ceilToPositiveInteger(totalWaitingTimeMinutes),
+            totalTravelTimeMinutes: ceilToPositiveInteger(totalTravelTimeMinutes),
             avgWalkingTimeMinutes: Math.round((totalWalkingTimeMinutes / routedCount) * 100) / 100,
             avgWaitingTimeMinutes: Math.round((totalWaitingTimeMinutes / routedCount) * 100) / 100,
             avgTravelTimeMinutes: Math.round((totalTravelTimeMinutes / routedCount) * 100) / 100,

--- a/packages/transition-common/src/services/line/Line.ts
+++ b/packages/transition-common/src/services/line/Line.ts
@@ -25,6 +25,7 @@ import { featureCollection as turfFeatureCollection } from '@turf/turf';
 // eslint-disable-next-line n/no-unpublished-import
 import type { Route as GtfsRoute } from 'gtfs-types';
 import * as Status from 'chaire-lib-common/lib/utils/Status';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 const lineModesConfigByMode = {};
 for (let i = 0, countI = lineModes.length; i < countI; i++) {
@@ -47,7 +48,7 @@ export interface LineAttributes extends GenericAttributes {
     is_enabled?: boolean;
     data: {
         gtfs?: GtfsRoute;
-        deadHeadTravelTimesBetweenPathsByPathId?: { [key: string]: { [key: string]: number } };
+        deadHeadTravelTimesBetweenPathsByPathId?: { [key: string]: { [key: string]: number | null } };
         numberOfVehicles?: number;
         [key: string]: any;
     };
@@ -219,16 +220,16 @@ export class Line extends ObjectWithHistory<LineAttributes> implements Saveable 
                             overview: 'full'
                         });
 
-                        const travelTimeSeconds = _get(routingResult, 'routes[0].duration', null);
-
-                        if (travelTimeSeconds === null) {
+                        let travelTimeSeconds = _get(routingResult, 'routes[0].duration', null);
+                        if (travelTimeSeconds === -1 || travelTimeSeconds === null) {
                             console.error(
                                 `line ${this.toString()} has a deadHeadTravelTime that could not be found (path1: ${path1Id} > path2: ${path2Id}), we will use travel time of first `
                             );
+                            travelTimeSeconds = null;
                         }
 
                         deadHeadTravelTimesBetweenPathsByPathId[path1Id][path2Id] =
-                            travelTimeSeconds !== null ? Math.ceil(travelTimeSeconds) : null;
+                            travelTimeSeconds !== null ? ceilToPositiveInteger(travelTimeSeconds) : null;
                         routingsByPairsOfNodes[path1TerminalNodeId][path2TerminalNodeId] =
                             deadHeadTravelTimesBetweenPathsByPathId[path1Id][path2Id];
                     }

--- a/packages/transition-common/src/services/line/__tests__/Line.test.ts
+++ b/packages/transition-common/src/services/line/__tests__/Line.test.ts
@@ -17,6 +17,10 @@ import Line from '../Line';
 import { lineAttributesBaseData, lineAttributesMinimalData, lineAttributesWithPathAndSchedule } from './LineData';
 import { EventEmitter } from 'events';
 import Schedule from '../../schedules/Schedule';
+import PathCollection from '../../path/PathCollection';
+import { getPathObject } from '../../path/__tests__/PathData';
+import routingServiceManager from 'chaire-lib-common/lib/services/routing/RoutingServiceManager';
+import { TestUtils, RoutingServiceManagerMock } from 'chaire-lib-common/lib/test';
 
 const eventManager = EventManagerMock.eventManagerMock;
 
@@ -228,4 +232,62 @@ describe('Test schedules management', () => {
         expect(line.getSchedules()).toEqual({});
     });
 
+});
+
+describe('calculateDeadHeadTravelTimesBetweenPaths', () => {
+    const mockRoute = RoutingServiceManagerMock.routingServiceManagerMock.getRoutingServiceForEngine('engine').route;
+    const engineService = routingServiceManager.getRoutingServiceForEngine('engine');
+    const originalRoute = engineService.route;
+
+    beforeEach(() => {
+        engineService.route = mockRoute;
+        mockRoute.mockReset();
+    });
+
+    afterEach(() => {
+        engineService.route = originalRoute;
+    });
+
+    const setupLineWithTwoPaths = () => {
+        const pathCollection = new PathCollection([], {});
+        const lineId = lineAttributesBaseData.id;
+        const path1 = getPathObject({ lineId, pathCollection }, 'smallReal');
+        const path2 = getPathObject({ lineId, pathCollection }, 'smallReal');
+        const nodesById: Record<string, GeoJSON.Feature<GeoJSON.Point>> = {};
+        for (const nodeId of [...path1.attributes.nodes, ...path2.attributes.nodes]) {
+            nodesById[nodeId] = TestUtils.makePoint([-73, 45], { id: nodeId });
+        }
+        const collectionManager = {
+            get: (name: string) => (name === 'paths' ? pathCollection : { getById: (id: string) => nodesById[id] })
+        };
+        const line = new Line(
+            { ..._cloneDeep(lineAttributesBaseData), path_ids: [path1.getId(), path2.getId()] },
+            true,
+            collectionManager
+        );
+        return { line, path1, path2 };
+    };
+
+    test.each([
+        [540.7, 541],
+        [-1, null],
+        [null, null]
+    ])('stores routed duration %p as %p', async (duration, expected) => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            mockRoute.mockResolvedValue({ waypoints: [], routes: [{ duration }] } as any);
+            const { line, path1, path2 } = setupLineWithTwoPaths();
+
+            const result = await line.calculateDeadHeadTravelTimesBetweenPaths(eventManager);
+
+            expect(result[path1.getId()][path2.getId()]).toEqual(expected);
+            if (expected === null) {
+                expect(consoleError).toHaveBeenCalled();
+            } else {
+                expect(consoleError).not.toHaveBeenCalled();
+            }
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
 });

--- a/packages/transition-common/src/services/nodes/Node.ts
+++ b/packages/transition-common/src/services/nodes/Node.ts
@@ -24,6 +24,7 @@ import {
     PlaceCategory,
     PlaceDetailedCategory
 } from 'chaire-lib-common/lib/config/osm/osmMappingDetailedCategoryToCategory';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 export interface TransferableNodes {
     nodesIds: string[];
@@ -364,7 +365,7 @@ export class Node extends GenericPlace<NodeAttributes> implements Saveable {
             0
         );
         this.attributes.routing_radius_meters = Math.max(
-            Math.ceil(maxStopDistance),
+            ceilToPositiveInteger(maxStopDistance),
             this.attributes.routing_radius_meters
         );
         this._updateHistory();

--- a/packages/transition-common/src/services/nodes/NodeCollection.ts
+++ b/packages/transition-common/src/services/nodes/NodeCollection.ts
@@ -17,6 +17,7 @@ import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import routingServiceManager from 'chaire-lib-common/lib/services/routing/RoutingServiceManager';
 import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 /**
  * A collection of transit nodes
@@ -87,7 +88,7 @@ export class NodeCollection extends GenericPlaceCollection<NodeAttributes, Node>
 
     setNetworkTravelTimesForBirdDistanceAccessibleNodes(object, geojson, prefix, mode: RoutingMode = 'walking') {
         // geojson: origin or destination geojson
-        return new Promise((resolve, _reject) => {
+        return new Promise((resolve, reject) => {
             if (_isBlank(geojson) && typeof object.toGeojson === 'function') {
                 geojson = object.toGeojson();
             }
@@ -134,39 +135,49 @@ export class NodeCollection extends GenericPlaceCollection<NodeAttributes, Node>
                         object.attributes[`walking_5min_${attributePrefix}accessible_nodes_count`] = 0;
 
                         for (let i = 0, count = birdDistanceAccessibleNodes.length; i < count; i++) {
-                            if (isNaN(Number(travelTimesSeconds[i])) || isNaN(Number(distancesMeters[i]))) {
+                            const travelTimeSeconds = Number(travelTimesSeconds[i]);
+                            const distanceMeters = Number(distancesMeters[i]);
+                            if (
+                                !Number.isFinite(travelTimeSeconds) ||
+                                travelTimeSeconds < 0 ||
+                                !Number.isFinite(distanceMeters) ||
+                                distanceMeters < 0
+                            ) {
                                 console.log(
-                                    `ERROR: OSRM mode ${mode}: duration or distance is NaN for object ${object.get(
+                                    `ERROR: OSRM mode ${mode}: duration or distance is invalid for object ${object.get(
                                         'id'
                                     )}`
                                 );
                             } else if (
-                                travelTimesSeconds[i] <=
+                                travelTimeSeconds <=
                                 Preferences.current.transit.nodes.maxAccessEgressWalkingTravelTimeSeconds
                             ) {
                                 const node = birdDistanceAccessibleNodes[i];
                                 object.attributes.data[`${nodesPrefix}`].push(node.properties.id);
                                 object.attributes.data[`${nodesPrefix}TravelTimes`].push(
-                                    Math.ceil(travelTimesSeconds[i])
+                                    ceilToPositiveInteger(travelTimeSeconds)
                                 );
-                                object.attributes.data[`${nodesPrefix}Distances`].push(Math.ceil(distancesMeters[i]));
-                                if (travelTimesSeconds[i] <= 1200) {
+                                object.attributes.data[`${nodesPrefix}Distances`].push(
+                                    ceilToPositiveInteger(distanceMeters)
+                                );
+                                if (travelTimeSeconds <= 1200) {
                                     object.attributes[`walking_20min_${attributePrefix}accessible_nodes_count`]++;
                                 }
-                                if (travelTimesSeconds[i] <= 900) {
+                                if (travelTimeSeconds <= 900) {
                                     object.attributes[`walking_15min_${attributePrefix}accessible_nodes_count`]++;
                                 }
-                                if (travelTimesSeconds[i] <= 600) {
+                                if (travelTimeSeconds <= 600) {
                                     object.attributes[`walking_10min_${attributePrefix}accessible_nodes_count`]++;
                                 }
-                                if (travelTimesSeconds[i] <= 300) {
+                                if (travelTimeSeconds <= 300) {
                                     object.attributes[`walking_5min_${attributePrefix}accessible_nodes_count`]++;
                                 }
                             }
                             accessibleNodesCount++;
                         }
                         resolve(accessibleNodesCount);
-                    });
+                    })
+                    .catch(reject);
             } else {
                 resolve(0);
             }

--- a/packages/transition-common/src/services/nodes/NodeGeographyUtils.ts
+++ b/packages/transition-common/src/services/nodes/NodeGeographyUtils.ts
@@ -22,6 +22,7 @@ import {
     PlaceDetailedCategory
 } from 'chaire-lib-common/lib/config/osm/osmMappingDetailedCategoryToCategory';
 import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 // TODO: test
 const placesInBirdRadiusMeters = (node: Node, placeCollection: PlaceCollection, birdRadiusMeters = 1000) => {
@@ -90,7 +91,7 @@ export const placesInWalkingTravelTimeRadiusSeconds = async (
     placeCollection: PlaceCollection,
     maxWalkingTravelTimeRadiusSeconds = Preferences.get('transit.nodes.maxTransferWalkingTravelTimeSeconds')
 ): Promise<AccessiblePlacesPerTravelTime> => {
-    const maxWalkingTravelTimeMinutes = Math.ceil(maxWalkingTravelTimeRadiusSeconds / 60.0);
+    const maxWalkingTravelTimeMinutes = ceilToPositiveInteger(maxWalkingTravelTimeRadiusSeconds / 60.0);
     const walkingSpeedMetersPerSeconds = Preferences.get('defaultWalkingSpeedMetersPerSeconds');
     const radiusBirdDistanceMeters = maxWalkingTravelTimeRadiusSeconds * walkingSpeedMetersPerSeconds;
     const placesByTravelTimeByCategoryTemplate: { [key in PlaceCategory]: number[] }[] = [];
@@ -133,12 +134,12 @@ export const placesInWalkingTravelTimeRadiusSeconds = async (
                 placeInBirdRadius.geometry.coordinates[1]
             ) * 1000;
         const travelTimeSeconds = useBirdDistances
-            ? Math.ceil(birdDistanceMeters / walkingSpeedMetersPerSeconds)
+            ? ceilToPositiveInteger(birdDistanceMeters / walkingSpeedMetersPerSeconds)
             : durations[i];
 
         if (!_isBlank(travelTimeSeconds) && travelTimeSeconds <= maxWalkingTravelTimeRadiusSeconds) {
             if (useBirdDistances || birdDistanceMeters <= distances[i] + 100) {
-                const travelTimeMinutes = Math.ceil(travelTimeSeconds / 60.0);
+                const travelTimeMinutes = ceilToPositiveInteger(travelTimeSeconds / 60.0);
                 // osrm will calculate and give very short durations and distances when the nearest network osm node is very far (out of routing network), so we make sure not to keep these.
                 if (travelTimeMinutes <= maxWalkingTravelTimeMinutes) {
                     const category: PlaceCategory = placeInBirdRadius.properties.data.category;

--- a/packages/transition-common/src/services/path/Path.ts
+++ b/packages/transition-common/src/services/path/Path.ts
@@ -23,7 +23,7 @@ import type { SegmentChangeInfo } from './PathTypes';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import { roundToDecimals, median } from 'chaire-lib-common/lib/utils/MathUtils';
+import { roundToDecimals, median, ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 // TODO Should not be needed
 // import ODProximityLineGenerator from './generators/ODProximityLineGenerator';
 import lineModesConfig from '../../config/lineModes';
@@ -926,8 +926,8 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
             .filter((distance) => distance !== null) as number[];
 
         if (segmentDistances.length > 0) {
-            variables.d_l_min = Math.ceil(Math.min(...segmentDistances));
-            variables.d_l_max = Math.ceil(Math.max(...segmentDistances));
+            variables.d_l_min = ceilToPositiveInteger(Math.min(...segmentDistances));
+            variables.d_l_max = ceilToPositiveInteger(Math.max(...segmentDistances));
             variables.d_l_avg = roundToDecimals(_mean(segmentDistances), 0);
             variables.d_l_med = roundToDecimals(median(segmentDistances), 0);
         }
@@ -958,11 +958,11 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
         if (
             nodesCount < 2 ||
             _isBlank(this.get('direction')) ||
-            !_isNumber(this.getData('totalDistanceMeters')) ||
-            !_isNumber(this.getData('operatingTimeWithLayoverTimeSeconds')) ||
-            !_isNumber(this.getData('travelTimeWithoutDwellTimesSeconds')) ||
-            !_isNumber(this.getData('totalDwellTimeSeconds')) ||
-            !_isNumber(this.getData('layoverTimeSeconds')) ||
+            !_isFinite(this.getData('totalDistanceMeters')) ||
+            !_isFinite(this.getData('operatingTimeWithLayoverTimeSeconds')) ||
+            !_isFinite(this.getData('travelTimeWithoutDwellTimesSeconds')) ||
+            !_isFinite(this.getData('totalDwellTimeSeconds')) ||
+            !_isFinite(this.getData('layoverTimeSeconds')) ||
             this.getData('routingFailed') === true ||
             this.attributes.segments.length !== nodesCount - 1 ||
             dwellTimesSeconds.length !== nodesCount ||
@@ -972,12 +972,12 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
         }
         for (let i = 0, count = nodesCount - 1; i < count; i++) {
             if (
-                !_isNumber(dwellTimesSeconds[i]) ||
+                !_isFinite(dwellTimesSeconds[i]) ||
                 dwellTimesSeconds[i] < 0 ||
                 !segments[i] ||
-                !_isNumber(segments[i].distanceMeters) ||
+                !_isFinite(segments[i].distanceMeters) ||
                 segments[i].distanceMeters === null ||
-                !_isNumber(segments[i].travelTimeSeconds) ||
+                !_isFinite(segments[i].travelTimeSeconds) ||
                 segments[i].travelTimeSeconds < 0
             ) {
                 /*console.log(dwellTimesSeconds[i], segments[i])*/
@@ -1153,7 +1153,7 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
             nodeDwellTimeSeconds !== undefined && nodeDwellTimeSeconds >= 0
                 ? nodeDwellTimeSeconds
                 : defaultGeneralDwellTimeSeconds;
-        return Math.ceil(Math.max(defaultNodeDwellTime, pathDwellTimeSeconds));
+        return ceilToPositiveInteger(Math.max(defaultNodeDwellTime, pathDwellTimeSeconds));
     }
 
     getTemporalTortuosity() {
@@ -1266,7 +1266,7 @@ export class Path extends MapObject<GeoJSON.LineString, PathAttributes> implemen
 
     averageInterNodesDistanceMeters() {
         if (this.isComplete()) {
-            return Math.ceil((this.attributes.data.totalDistanceMeters || 0) / (this.countNodes() - 1));
+            return ceilToPositiveInteger((this.attributes.data.totalDistanceMeters || 0) / (this.countNodes() - 1));
         }
         return null;
     }

--- a/packages/transition-common/src/services/path/PathGeographyGenerator.ts
+++ b/packages/transition-common/src/services/path/PathGeographyGenerator.ts
@@ -9,7 +9,7 @@ import { MapMatchingResults, MapLeg } from 'chaire-lib-common/lib/services/routi
 import TrError from 'chaire-lib-common/lib/utils/TrError';
 import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
-import { roundToDecimals } from 'chaire-lib-common/lib/utils/MathUtils';
+import { roundToDecimals, ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 import {
     durationFromAccelerationDecelerationDistanceAndRunningSpeed,
     kphToMps
@@ -336,12 +336,14 @@ const getDwellTimeSecondsForNode = (path: Path, nodeId: unknown): number => {
 const calculateLayoverSeconds = (path: Path, totalTravelTimeWithDwellTimesSeconds: number): number => {
     const customLayoverMinutes: any = path.getData('customLayoverMinutes', null);
     if (!_isBlank(customLayoverMinutes)) {
-        return customLayoverMinutes * 60;
+        return ceilToPositiveInteger(customLayoverMinutes * 60);
     }
-    return Math.max(
-        Preferences.current.transit.paths.data.defaultLayoverRatioOverTotalTravelTime *
-            totalTravelTimeWithDwellTimesSeconds,
-        Preferences.current.transit.paths.data.defaultMinLayoverTimeSeconds
+    return ceilToPositiveInteger(
+        Math.max(
+            Preferences.current.transit.paths.data.defaultLayoverRatioOverTotalTravelTime *
+                totalTravelTimeWithDwellTimesSeconds || 0,
+            Preferences.current.transit.paths.data.defaultMinLayoverTimeSeconds || 0
+        )
     );
 };
 
@@ -373,6 +375,7 @@ const buildPathData = (
         travelTimeWithoutDwellTimesSeconds: totals.totalTravelTimeWithoutDwellTimesSeconds,
         totalDistanceMeters: totals.totalDistance,
         totalDwellTimeSeconds: totals.totalDwellTimeSeconds,
+        // Totals are sums of already-integer segment times, dwells and layover.
         operatingTimeWithoutLayoverTimeSeconds: totals.totalTravelTimeWithDwellTimesSeconds,
         operatingTimeWithLayoverTimeSeconds: totals.totalTravelTimeWithDwellTimesSeconds + layoverTimeSeconds,
         totalTravelTimeWithReturnBackSeconds: totals.totalTravelTimeWithReturnBackSeconds + layoverTimeSeconds,
@@ -522,11 +525,13 @@ const buildSegmentsAndGeometry = (
 
         appendLegCoordinates(leg, globalCoordinates);
 
+        // Routed duration stays fractional: it is the speed input for accel/decel physics.
         segmentTimeAndDistance.travelTimeSeconds += leg.duration;
-        segmentTimeAndDistance.distanceMeters = (segmentTimeAndDistance.distanceMeters || 0) + Math.ceil(leg.distance);
-
+        segmentTimeAndDistance.distanceMeters = (segmentTimeAndDistance.distanceMeters || 0) + leg.distance;
         // Path cannot finish at a waypoint, so this last segment is not part of the total calculations.
         if (i === routing.legs.length - 1 && !nodeIds[nextNodeIndex]) {
+            segmentTimeAndDistance.distanceMeters = ceilToPositiveInteger(segmentTimeAndDistance.distanceMeters || 0);
+            segmentTimeAndDistance.travelTimeSeconds = ceilToPositiveInteger(segmentTimeAndDistance.travelTimeSeconds);
             segments.push(segmentCoordinatesStartIndex);
             segmentsData.push(segmentTimeAndDistance);
             break;
@@ -536,6 +541,7 @@ const buildSegmentsAndGeometry = (
             continue;
         }
 
+        segmentTimeAndDistance.distanceMeters = ceilToPositiveInteger(segmentTimeAndDistance.distanceMeters || 0);
         const segmentIndex = segments.length;
         const segmentParams: ComputeSegmentDataParams = {
             path,
@@ -619,6 +625,10 @@ const adjustSegmentTime = (
         current.segmentsData[segmentIndex].travelTimeSeconds =
             current.segmentsData[segmentIndex].travelTimeSeconds * current.ratioDifferenceTime;
     }
+    // Store integer seconds so path totals equal the sum of their parts.
+    current.segmentsData[segmentIndex].travelTimeSeconds = ceilToPositiveInteger(
+        current.segmentsData[segmentIndex].travelTimeSeconds
+    );
 };
 
 /**

--- a/packages/transition-common/src/services/path/PathGeographyUtils.ts
+++ b/packages/transition-common/src/services/path/PathGeographyUtils.ts
@@ -16,6 +16,7 @@ import { RoutingMode } from 'chaire-lib-common/lib/config/routingModes';
 import { generatePathGeographyFromRouting } from './PathGeographyGenerator';
 import type { SegmentChangeInfo } from './PathTypes';
 import { kphToMps } from 'chaire-lib-common/lib/utils/PhysicsUtils';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 
 /*
 DEFAULT_MIN_MATCHING_TIMESTAMP is the minimum interval between timestamps for the matching routing (using OSRM).
@@ -41,7 +42,7 @@ class PathGeographyUtils {
         const lineWithPrevious = turf.lineString([from.geometry.coordinates, to.geometry.coordinates]);
         const lineWithPreviousLength = turf.length(lineWithPrevious, { units: 'meters' });
         // Using a default speed of 15 km/h seems just fine with map matching (faster speeds makes osrm fails to find some routes):
-        return Math.ceil(lineWithPreviousLength / Math.max(defaultRunningSpeedMps, kphToMps(15)));
+        return ceilToPositiveInteger(lineWithPreviousLength / Math.max(defaultRunningSpeedMps, kphToMps(15)));
     };
 
     initializePointGeojsonCollection = (): FeatureCollection<Point> => {
@@ -335,10 +336,10 @@ const updateGeography = async (path: any, changesInfo?: SegmentChangeInfo): Prom
         path.attributes.data.geographyErrors = pathGeographyUtils.getErrorsForDirectPath(points);
         return { path };
     } else {
-        path.attributes.data.directRouteBetweenTerminalsTravelTimeSeconds = Math.ceil(
+        path.attributes.data.directRouteBetweenTerminalsTravelTimeSeconds = ceilToPositiveInteger(
             direct.matchings[0].legs[0].duration
         );
-        path.attributes.data.directRouteBetweenTerminalsDistanceMeters = Math.ceil(
+        path.attributes.data.directRouteBetweenTerminalsDistanceMeters = ceilToPositiveInteger(
             direct.matchings[0].legs[0].distance
         );
     }

--- a/packages/transition-common/src/services/path/__tests__/PathGeographyGenerator.test.ts
+++ b/packages/transition-common/src/services/path/__tests__/PathGeographyGenerator.test.ts
@@ -71,6 +71,8 @@ const sum = (total: number, num: number) => { return total + num; };
 const twoDecimals = (num: number, denum: number) => { return Math.round(num / denum * 100) / 100; };
 const segmentDuration = (distanceMeters: number, routedDurationSeconds: number) =>
     durationFromAccelerationDecelerationDistanceAndRunningSpeed(DEFAULT_ACC_DEC, DEFAULT_ACC_DEC, distanceMeters, distanceMeters / routedDurationSeconds);
+const storedSegmentDuration = (distanceMeters: number, routedDurationSeconds: number) =>
+    Math.ceil(segmentDuration(distanceMeters, routedDurationSeconds));
 
 test('Generate From Routing Total Calculations', async() => {
     /* Test path between 2 nodes with engine */
@@ -122,7 +124,7 @@ test('Generate From Routing Total Calculations', async() => {
         coordinates: [node1.geometry.coordinates, node4.geometry.coordinates]
     });
     let expectedNoDwellTimes = [66.67];
-    let expectedTravelTimes = [segmentDuration(1000, 66.67)];
+    let expectedTravelTimes = [storedSegmentDuration(1000, 66.67)];
     let expectedDistances = [1000];
     const expectedDwellTime = NODE4_DWELL_TIME;
     let expectedTotalTime = expectedTravelTimes.reduce(sum, 0);
@@ -140,9 +142,9 @@ test('Generate From Routing Total Calculations', async() => {
         travelTimeWithoutDwellTimesSeconds: expectedNoDwellTime,
         totalDistanceMeters: expectedTotalDistance,
         totalDwellTimeSeconds: expectedDwellTime,
-        operatingTimeWithoutLayoverTimeSeconds: expectedOperatingTime,
-        operatingTimeWithLayoverTimeSeconds: expectedOperatingTime + LAYOVER_TIME,
-        totalTravelTimeWithReturnBackSeconds: expectedOperatingTime + LAYOVER_TIME,
+        operatingTimeWithoutLayoverTimeSeconds: Math.ceil(expectedOperatingTime),
+        operatingTimeWithLayoverTimeSeconds: Math.ceil(expectedOperatingTime + LAYOVER_TIME),
+        totalTravelTimeWithReturnBackSeconds: Math.ceil(expectedOperatingTime + LAYOVER_TIME),
         averageSpeedWithoutDwellTimesMetersPerSecond: twoDecimals(expectedTotalDistance, expectedNoDwellTime),
         operatingSpeedMetersPerSecond: twoDecimals(expectedTotalDistance, expectedOperatingTime),
         operatingSpeedWithLayoverMetersPerSecond: twoDecimals(expectedTotalDistance, expectedOperatingTime + LAYOVER_TIME)
@@ -193,9 +195,9 @@ test('Generate From Routing Total Calculations', async() => {
         travelTimeWithoutDwellTimesSeconds: expectedNoDwellTime,
         totalDistanceMeters: expectedTotalDistance,
         totalDwellTimeSeconds: expectedDwellTime,
-        operatingTimeWithoutLayoverTimeSeconds: expectedOperatingTime,
-        operatingTimeWithLayoverTimeSeconds: expectedOperatingTime + LAYOVER_TIME,
-        totalTravelTimeWithReturnBackSeconds: expectedOperatingTime + LAYOVER_TIME,
+        operatingTimeWithoutLayoverTimeSeconds: Math.ceil(expectedOperatingTime),
+        operatingTimeWithLayoverTimeSeconds: Math.ceil(expectedOperatingTime + LAYOVER_TIME),
+        totalTravelTimeWithReturnBackSeconds: Math.ceil(expectedOperatingTime + LAYOVER_TIME),
         averageSpeedWithoutDwellTimesMetersPerSecond: twoDecimals(expectedTotalDistance, expectedNoDwellTime),
         operatingSpeedMetersPerSecond: twoDecimals(expectedTotalDistance, expectedOperatingTime),
         operatingSpeedWithLayoverMetersPerSecond: twoDecimals(expectedTotalDistance, expectedOperatingTime + LAYOVER_TIME)
@@ -270,7 +272,7 @@ test('Generate From Routing Simple Use Cases', async() => {
         coordinates: [node1.geometry.coordinates, waypoint1, node4.geometry.coordinates, node6.geometry.coordinates]
     });
     const expectedNoDwellTimes = [100, 66.67];
-    const expectedTravelTime = [segmentDuration(1500, 100), segmentDuration(1000, 66.67)];
+    const expectedTravelTime = [storedSegmentDuration(1500, 100), storedSegmentDuration(1000, 66.67)];
     const expectedDistances = [1500, 1000];
     const expectedDwellTime = NODE4_DWELL_TIME + 25;
     const expectedTotalTime = expectedTravelTime.reduce(sum, 0);
@@ -290,9 +292,9 @@ test('Generate From Routing Simple Use Cases', async() => {
         travelTimeWithoutDwellTimesSeconds: expectedNoDwellTime,
         totalDistanceMeters: expectedTotalDistance,
         totalDwellTimeSeconds: expectedDwellTime,
-        operatingTimeWithoutLayoverTimeSeconds: expectedDwellTime + expectedTotalTime,
-        operatingTimeWithLayoverTimeSeconds: expectedDwellTime + expectedTotalTime + LAYOVER_TIME,
-        totalTravelTimeWithReturnBackSeconds: expectedDwellTime + expectedTotalTime + LAYOVER_TIME,
+        operatingTimeWithoutLayoverTimeSeconds: Math.ceil(expectedDwellTime + expectedTotalTime),
+        operatingTimeWithLayoverTimeSeconds: Math.ceil(expectedDwellTime + expectedTotalTime + LAYOVER_TIME),
+        totalTravelTimeWithReturnBackSeconds: Math.ceil(expectedDwellTime + expectedTotalTime + LAYOVER_TIME),
         averageSpeedWithoutDwellTimesMetersPerSecond: twoDecimals(expectedTotalDistance, expectedNoDwellTime),
         operatingSpeedMetersPerSecond: twoDecimals(expectedTotalDistance, expectedTotalTime + expectedDwellTime),
         operatingSpeedWithLayoverMetersPerSecond: twoDecimals(expectedTotalDistance, expectedTotalTime + expectedDwellTime + LAYOVER_TIME)
@@ -419,7 +421,7 @@ test('Generate From Routing', async() => {
     expect(complexPath.attributes.segments).toEqual([0, 2, 4]);
     // Use leg-level additions to match the floating point accumulation in the production code
     const expectedNoDwellTimes = [200, 100 + 66.67, 100];
-    const expectedTravelTime = [segmentDuration(1500 + 1500, 100 + 150), segmentDuration(1500 + 1000, 150 + 66.67)];
+    const expectedTravelTime = [storedSegmentDuration(1500 + 1500, 100 + 150), storedSegmentDuration(1500 + 1000, 150 + 66.67)];
     const expectedDistances = [1500 + 1500, 1500 + 1000];
     const expectedDwellTime = NODE4_DWELL_TIME + 25;
     const expectedTotalTime = expectedTravelTime.reduce(sum, 0);
@@ -442,9 +444,9 @@ test('Generate From Routing', async() => {
         travelTimeWithoutDwellTimesSeconds: expectedNoDwellTime,
         totalDistanceMeters: expectedTotalDistance,
         totalDwellTimeSeconds: expectedDwellTime,
-        operatingTimeWithoutLayoverTimeSeconds: expectedDwellTime + expectedTotalTime,
-        operatingTimeWithLayoverTimeSeconds: expectedDwellTime + expectedTotalTime + LAYOVER_TIME,
-        totalTravelTimeWithReturnBackSeconds: expectedDwellTime + expectedTotalTime + LAYOVER_TIME,
+        operatingTimeWithoutLayoverTimeSeconds: Math.ceil(expectedDwellTime + expectedTotalTime),
+        operatingTimeWithLayoverTimeSeconds: Math.ceil(expectedDwellTime + expectedTotalTime + LAYOVER_TIME),
+        totalTravelTimeWithReturnBackSeconds: Math.ceil(expectedDwellTime + expectedTotalTime + LAYOVER_TIME),
         averageSpeedWithoutDwellTimesMetersPerSecond: twoDecimals(expectedTotalDistance, expectedNoDwellTime),
         operatingSpeedMetersPerSecond: twoDecimals(expectedTotalDistance, expectedTotalTime + expectedDwellTime),
         operatingSpeedWithLayoverMetersPerSecond: twoDecimals(expectedTotalDistance, expectedTotalTime + expectedDwellTime + LAYOVER_TIME)
@@ -753,7 +755,7 @@ describe('Node insert and remove operations', () => {
             { previousTime: initialSegments[2].travelTimeSeconds, distance: legsAfterInsert[3].distance, routedDuration: legsAfterInsert[3].duration },
         ]);
         expect(path.attributes.data.segments[0].travelTimeSeconds).toEqual(
-            segmentDuration(legsAfterInsert[0].distance, legsAfterInsert[0].duration) * ratio
+            Math.ceil(segmentDuration(legsAfterInsert[0].distance, legsAfterInsert[0].duration) * ratio)
         );
     });
 
@@ -795,10 +797,10 @@ describe('Node insert and remove operations', () => {
             { previousTime: initialSegments[2].travelTimeSeconds, distance: legsAfterInsert[3].distance, routedDuration: legsAfterInsert[3].duration },
         ]);
         expect(path.attributes.data.segments[1].travelTimeSeconds).toEqual(
-            segmentDuration(legsAfterInsert[1].distance, legsAfterInsert[1].duration) * ratio
+            Math.ceil(segmentDuration(legsAfterInsert[1].distance, legsAfterInsert[1].duration) * ratio)
         );
         expect(path.attributes.data.segments[2].travelTimeSeconds).toEqual(
-            segmentDuration(legsAfterInsert[2].distance, legsAfterInsert[2].duration) * ratio
+            Math.ceil(segmentDuration(legsAfterInsert[2].distance, legsAfterInsert[2].duration) * ratio)
         );
     });
 
@@ -842,7 +844,7 @@ describe('Node insert and remove operations', () => {
             { previousTime: initialSegments[2].travelTimeSeconds, distance: legsAfterInsert[2].distance, routedDuration: legsAfterInsert[2].duration },
         ]);
         expect(path.attributes.data.segments[3].travelTimeSeconds).toEqual(
-            segmentDuration(legsAfterInsert[3].distance, legsAfterInsert[3].duration) * ratio
+            Math.ceil(segmentDuration(legsAfterInsert[3].distance, legsAfterInsert[3].duration) * ratio)
         );
     });
 
@@ -910,7 +912,7 @@ describe('Node insert and remove operations', () => {
             { previousTime: initialSegments[2].travelTimeSeconds, distance: legsAfterRemove[1].distance, routedDuration: legsAfterRemove[1].duration },
         ]);
         expect(path.attributes.data.segments[0].travelTimeSeconds).toEqual(
-            segmentDuration(legsAfterRemove[0].distance, legsAfterRemove[0].duration) * ratio
+            Math.ceil(segmentDuration(legsAfterRemove[0].distance, legsAfterRemove[0].duration) * ratio)
         );
     });
 
@@ -965,9 +967,9 @@ describe('Node insert and remove operations', () => {
         expect(path.attributes.data.routingFailed).toBeFalsy();
         expect(path.attributes.data.segments.length).toEqual(3);
         // All segments recalculated from OSRM — none preserve previous times
-        expect(path.attributes.data.segments[0].travelTimeSeconds).toEqual(segmentDuration(1500, 100));
-        expect(path.attributes.data.segments[1].travelTimeSeconds).toEqual(segmentDuration(1000, 66.67));
-        expect(path.attributes.data.segments[2].travelTimeSeconds).toEqual(segmentDuration(1200, 80));
+        expect(path.attributes.data.segments[0].travelTimeSeconds).toEqual(storedSegmentDuration(1500, 100));
+        expect(path.attributes.data.segments[1].travelTimeSeconds).toEqual(storedSegmentDuration(1000, 66.67));
+        expect(path.attributes.data.segments[2].travelTimeSeconds).toEqual(storedSegmentDuration(1200, 80));
     });
 
     test('forceRecalculate uses node dwell times even when previous dwell was zero with short travel time', async () => {
@@ -1214,9 +1216,9 @@ describe('Waypoint change operations', () => {
         // Ratio from unchanged segment 1 (single leg 2)
         const ratio = initialSegments[1].travelTimeSeconds / segmentDuration(legs[2].distance, legs[2].duration);
         // Changed segment 0: legs 0+1 combined
-        const changedSegDistance = Math.ceil(legs[0].distance) + Math.ceil(legs[1].distance);
+        const changedSegDistance = Math.ceil(legs[0].distance + legs[1].distance);
         const changedSegDuration = legs[0].duration + legs[1].duration;
-        expect(path.attributes.data.segments[0].travelTimeSeconds).toEqual(segmentDuration(changedSegDistance, changedSegDuration) * ratio);
+        expect(path.attributes.data.segments[0].travelTimeSeconds).toEqual(Math.ceil(segmentDuration(changedSegDistance, changedSegDuration) * ratio));
     });
 
     test('waypoint after last node has no effect on segment times', async() => {

--- a/packages/transition-common/src/services/schedules/Schedule.ts
+++ b/packages/transition-common/src/services/schedules/Schedule.ts
@@ -14,6 +14,7 @@ import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
 import TransitPath from '../path/Path';
 import { _isBlank } from 'chaire-lib-common/lib/utils/LodashExtensions';
 import { timeStrToSecondsSinceMidnight } from 'chaire-lib-common/lib/utils/DateTimeUtils';
+import { ceilToPositiveInteger } from 'chaire-lib-common/lib/utils/MathUtils';
 import Saveable from 'chaire-lib-common/lib/utils/objects/Saveable';
 import SaveUtils from 'chaire-lib-common/lib/services/objects/SaveUtils';
 import CollectionManager from 'chaire-lib-common/lib/utils/objects/CollectionManager';
@@ -390,9 +391,9 @@ export class AsymmetricScheduleStrategy extends BaseScheduleStrategy {
         if (_isNumber(period.number_of_units)) {
             period.inboundIntervalSeconds = 0;
             tripsNumberOfUnits = period.number_of_units;
-            tripsIntervalSeconds = Math.ceil(cycleTimeSeconds / period.number_of_units);
+            tripsIntervalSeconds = ceilToPositiveInteger(cycleTimeSeconds / period.number_of_units);
             if (secondAllowed !== true) {
-                tripsIntervalSeconds = Math.ceil(tripsIntervalSeconds / 60) * 60;
+                tripsIntervalSeconds = ceilToPositiveInteger(tripsIntervalSeconds / 60) * 60;
             }
 
             period.calculated_interval_seconds = tripsIntervalSeconds;
@@ -404,18 +405,18 @@ export class AsymmetricScheduleStrategy extends BaseScheduleStrategy {
             // Precise calculation of unit requirements for each direction
 
             // For outbound trips: how many units are needed to maintain the interval
-            const outboundUnitsNeeded = Math.ceil(outboundTotalTimeSeconds / period.interval_seconds);
+            const outboundUnitsNeeded = ceilToPositiveInteger(outboundTotalTimeSeconds / period.interval_seconds);
 
             // For inbound trips: how many units are needed to maintain the interval
-            const inboundUnitsNeeded = Math.ceil(inboundTotalTimeSeconds / period.inbound_interval_seconds);
+            const inboundUnitsNeeded = ceilToPositiveInteger(inboundTotalTimeSeconds / period.inbound_interval_seconds);
 
             // We need enough units for both directions
             tripsNumberOfUnits = outboundUnitsNeeded + inboundUnitsNeeded;
 
             // Check if additional units are needed for simultaneous starts
             const simultaneousStartsNeeded = Math.min(
-                Math.ceil(totalPeriod / period.interval_seconds),
-                Math.ceil(totalPeriod / period.inbound_interval_seconds)
+                ceilToPositiveInteger(totalPeriod / period.interval_seconds),
+                ceilToPositiveInteger(totalPeriod / period.inbound_interval_seconds)
             );
 
             // Ensure a minimum number of units for initial simultaneous departures
@@ -627,8 +628,8 @@ export class AsymmetricScheduleStrategy extends BaseScheduleStrategy {
             const periodDuration = options.endAtSecondsSinceMidnight - options.startAtSecondsSinceMidnight;
 
             // Estimated number of departures in each direction during the period
-            const outboundDepartures = Math.ceil(periodDuration / options.outboundIntervalSeconds);
-            const inboundDepartures = Math.ceil(periodDuration / options.inboundIntervalSeconds);
+            const outboundDepartures = ceilToPositiveInteger(periodDuration / options.outboundIntervalSeconds);
+            const inboundDepartures = ceilToPositiveInteger(periodDuration / options.inboundIntervalSeconds);
 
             // Calculate the distribution ratio based on the number of departures
             const totalDepartures = outboundDepartures + inboundDepartures;
@@ -742,7 +743,7 @@ export class AsymmetricScheduleStrategy extends BaseScheduleStrategy {
         // Initialize units with staggered start times
         for (let i = 0; i < unitsCount; i++) {
             const unit = options.units[i];
-            unit.timeInCycle = Math.ceil((i * cycleTimeSeconds) / unitsCount);
+            unit.timeInCycle = i === 0 ? 0 : ceilToPositiveInteger((i * cycleTimeSeconds) / unitsCount);
         }
 
         // Trip generation loop
@@ -858,13 +859,13 @@ export class SymmetricScheduleStrategy extends BaseScheduleStrategy {
             // ignore number of units if interval is set
             tripsIntervalSeconds = period.interval_seconds;
             tripsNumberOfUnitsFloat = cycleTimeSeconds / period.interval_seconds;
-            tripsNumberOfUnits = Math.ceil(cycleTimeSeconds / period.interval_seconds);
+            tripsNumberOfUnits = ceilToPositiveInteger(cycleTimeSeconds / period.interval_seconds);
             period.calculated_interval_seconds = tripsIntervalSeconds;
             period.calculated_number_of_units = tripsNumberOfUnitsFloat;
         } else if (_isNumber(period.number_of_units)) {
-            tripsIntervalSeconds = Math.ceil(cycleTimeSeconds / period.number_of_units);
+            tripsIntervalSeconds = ceilToPositiveInteger(cycleTimeSeconds / period.number_of_units);
             tripsIntervalSeconds =
-                secondAllowed === true ? tripsIntervalSeconds : Math.ceil(tripsIntervalSeconds / 60) * 60;
+                secondAllowed === true ? tripsIntervalSeconds : ceilToPositiveInteger(tripsIntervalSeconds / 60) * 60;
             tripsNumberOfUnits = period.number_of_units;
             period.calculated_interval_seconds = tripsIntervalSeconds;
             period.calculated_number_of_units = period.number_of_units;
@@ -915,7 +916,7 @@ export class SymmetricScheduleStrategy extends BaseScheduleStrategy {
 
         for (let i = 0; i < unitsCount; i++) {
             const unit = units[i];
-            unit.timeInCycle = Math.ceil((i * cycleTimeSeconds) / unitsCount);
+            unit.timeInCycle = i === 0 ? 0 : ceilToPositiveInteger((i * cycleTimeSeconds) / unitsCount);
         }
 
         for (let timeSoFar = startAtSecondsSinceMidnight; timeSoFar < endAtSecondsSinceMidnight; timeSoFar++) {
@@ -1214,10 +1215,12 @@ class Schedule extends ObjectWithHistory<ScheduleAttributes> implements Saveable
 
         // get outbound/inbound paths info to calculate number of units required or minimum interval and travel times:
 
-        // calculate durations
-        const outboundTotalTimeSeconds = outboundPath.attributes.data.operatingTimeWithLayoverTimeSeconds || 0;
+        // calculate durations (ceil to whole seconds: timeInCycle advances by 1 each simulated second)
+        const outboundTotalTimeSeconds = ceilToPositiveInteger(
+            outboundPath.attributes.data.operatingTimeWithLayoverTimeSeconds || 0
+        );
         const inboundTotalTimeSeconds = inboundPath
-            ? inboundPath.attributes.data.operatingTimeWithLayoverTimeSeconds || 0
+            ? ceilToPositiveInteger(inboundPath.attributes.data.operatingTimeWithLayoverTimeSeconds || 0)
             : 0;
 
         // Create the generation strategy

--- a/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
+++ b/packages/transition-common/src/services/schedules/__tests__/Schedule.test.ts
@@ -473,6 +473,65 @@ describe('generateForPeriod', () => {
         }
     });
 
+    describe('generates trips when operatingTimeWithLayoverTimeSeconds is fractional', () => {
+        // 540.7 ceils to 541 (trunc/round-down would be 540); 540.3 ceils to 541 (trunc/round would be 540)
+        const outboundDurationSeconds = 540.7;
+        const inboundDurationSeconds = 540.3;
+        const intervalSeconds = minutesToSeconds(15) as number;
+        let tripsByDirection: {
+            outbound: ScheduleTypes.SchedulePeriodTrip[];
+            inbound: ScheduleTypes.SchedulePeriodTrip[];
+        };
+        let calculatedNumberOfUnits: number | undefined;
+
+        beforeEach(() => {
+            const localPathCollection = new PathCollection([], {});
+            const localCollectionManager = new CollectionManager(null);
+            const outbound = getPathObject({ lineId, pathCollection: localPathCollection }, 'smallReal');
+            const inbound = getPathObject({ lineId, pathCollection: localPathCollection }, 'smallReal');
+            inbound.attributes.direction = 'inbound';
+            outbound.attributes.data.operatingTimeWithLayoverTimeSeconds = outboundDurationSeconds;
+            inbound.attributes.data.operatingTimeWithLayoverTimeSeconds = inboundDurationSeconds;
+
+            localCollectionManager.add(
+                'lines',
+                new LineCollection([new Line({ id: lineId, path_ids: [outbound.getId(), inbound.getId()] }, false)], {})
+            );
+            localCollectionManager.add('paths', localPathCollection);
+
+            const testAttributes = _cloneDeep(scheduleAttributesForUpdate);
+            const testPeriods = _cloneDeep(smallPeriodsForUpdate);
+            testPeriods[0].interval_seconds = intervalSeconds;
+            testPeriods[0].outbound_path_id = outbound.getId();
+            testPeriods[0].inbound_path_id = inbound.getId();
+            testAttributes.periods = testPeriods;
+
+            const schedule = new Schedule(testAttributes, true, localCollectionManager);
+            const { trips } = schedule.generateForPeriod(testPeriods[0].period_shortname as string);
+            tripsByDirection = {
+                outbound: trips.filter((trip) => trip.path_id === outbound.getId()),
+                inbound: trips.filter((trip) => trip.path_id === inbound.getId())
+            };
+            calculatedNumberOfUnits = schedule.attributes.periods[0].calculated_number_of_units;
+        });
+
+        test.each([['outbound'], ['inbound']] as const)('%s trip count is greater than zero', (direction) => {
+            expect(tripsByDirection[direction].length).toBeGreaterThan(0);
+        });
+
+        test('ceils both path durations to whole seconds before scheduling', () => {
+            const periodStart = timeStrToSecondsSinceMidnight('10:00') as number;
+            // Unit 0's return starts after ceil(540.7)=541s; trunc would be 540s.
+            expect(tripsByDirection.inbound.map((trip) => trip.departure_time_seconds)).toContain(
+                periodStart + Math.ceil(outboundDurationSeconds)
+            );
+            // Cycle is ceil(540.7)+ceil(540.3)=1082; trunc 1080, round 1081.
+            expect(calculatedNumberOfUnits).toEqual(
+                (Math.ceil(outboundDurationSeconds) + Math.ceil(inboundDurationSeconds)) / intervalSeconds
+            );
+        });
+    });
+
     test('Update unexisting period', () => {
         // Use a 15-minute frequency
         const testFrequencyMinutes = 15;


### PR DESCRIPTION
Symmetric schedule generation compares unit.timeInCycle (integer) to operatingTimeWithLayoverTimeSeconds, which can be fractional after path geography recalculation. Ceil both outbound and inbound cycle times to whole seconds before scheduling so return trips are generated.

Closes #2005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when rounding travel times, distances, schedules, transfers, and accessibility calculations.
  * Fractional schedule durations now produce reliable trip timings and vehicle requirements.
  * Invalid or unavailable routing results are handled safely instead of generating incorrect values.
  * Deadhead travel times with missing or negative durations are recorded as unavailable.
  * Path and routing calculations now better handle fractional and non-finite values.

* **Tests**
  * Added coverage for fractional schedules, routing edge cases, deadhead travel times, and invalid numeric inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->