### PR TITLE
feat(map): add north arrow and zoom +/- on map

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -295,7 +295,8 @@
         "DateTimeFormat12H": "12 hours ({{formatted}})",
         "Map": "Map preferences",
         "MapOverlayOpacity": "Map overlay opacity (%)",
-        "MapOverlayColor": "Map overlay color"
+        "MapOverlayColor": "Map overlay color",
+        "MapNavigationControl": "Display map navigation controls"
     },
     "ShowingNofX": "Showing {{n}} of {{x}} results",
     "PageNofX": "Page {{n}} of {{x}}",

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -295,7 +295,8 @@
         "DateTimeFormat12H": "12 heures ({{formatted}})",
         "Map": "Préférences de la carte",
         "MapOverlayOpacity": "Opacité de la couche de transparence de la carte (%)",
-        "MapOverlayColor": "Couleur de la couche de transparence de la carte"
+        "MapOverlayColor": "Couleur de la couche de transparence de la carte",
+        "MapNavigationControl": "Affichage des contrôles de navigation de la carte"
     },
     "ShowingNofX": "{{n}} de {{x}} résultats",
     "PageNofX": "Page {{n}} de {{x}}",

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
@@ -53,6 +53,23 @@ const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProp
                         preferences={props.preferences}
                     />
                 </InputWrapper>
+
+                <InputWrapper twoColumns={true} label={props.t('main:preferences:MapNavigationControl')}>
+                    <InputCheckboxBoolean
+                        id={'formFieldPreferencesFeatureMapNavigationControl'}
+                        isChecked={props.preferences.get('features.map.navigationControl')}
+                        defaultChecked={true}
+                        label={props.t('main:Yes')}
+                        onValueChange={(e) =>
+                            props.onValueChange('features.map.navigationControl', { value: e.target.value })
+                        }
+                    />
+                    <PreferencesResetToDefaultButton
+                        resetPrefToDefault={props.resetPrefToDefault}
+                        path="features.map.navigationControl"
+                        preferences={props.preferences}
+                    />
+                </InputWrapper>
             </div>
         </Collapsible>
     );

--- a/packages/transition-frontend/src/components/map/MapRenderer.tsx
+++ b/packages/transition-frontend/src/components/map/MapRenderer.tsx
@@ -5,13 +5,20 @@
  * License text available at https://opensource.org/licenses/MIT
  */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import MapLibreMap, { MapRef, ScaleControl, SourceSpecification, LayerSpecification } from 'react-map-gl/maplibre';
+import MapLibreMap, {
+    MapRef,
+    ScaleControl,
+    NavigationControl,
+    SourceSpecification,
+    LayerSpecification
+} from 'react-map-gl/maplibre';
 import type { StyleSpecification } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import type { LayersList } from '@deck.gl/core';
 import { useTranslation } from 'react-i18next';
 
 import serviceLocator from 'chaire-lib-common/lib/utils/ServiceLocator';
+import Preferences from 'chaire-lib-common/lib/config/Preferences';
 import ConfirmModal from 'chaire-lib-frontend/lib/components/modal/ConfirmModal';
 import {
     isProjectBasemapStyleUrl,
@@ -269,6 +276,15 @@ const MapRenderer: React.FC<MapRendererProps> = ({
                 {/* DeckGL overlay for animated selected paths and nodes - only render when there are layers */}
                 {shouldAnimate && <DeckGLControl key={deckOverlayRemountKey} layers={deckLayers} />}
                 <ScaleControl position="bottom-right" />
+                {Preferences.get('features.map.navigationControl', true) && (
+                    <NavigationControl
+                        position="top-left"
+                        showCompass={true}
+                        showZoom={true}
+                        visualizePitch={true}
+                        visualizeRoll={true}
+                    />
+                )}
             </MapLibreMap>
             {mapLoaded && (
                 <MapControlsPanel

--- a/packages/transition-frontend/src/styles/transition.scss
+++ b/packages/transition-frontend/src/styles/transition.scss
@@ -37,8 +37,7 @@
     z-index: 2;
 }
 
-.tr__map-controls-button,
-.maplibregl-control-container button {
+.tr__map-controls-button {
     background: #fff;
     border: 0;
     cursor: pointer;
@@ -47,6 +46,16 @@
     justify-content: center;
     width: 1.875rem;
     height: 1.875rem;
+    font-size: 2rem;
+    padding: 0.2rem;
+    color: rgba(0, 0, 0, 0.7);
+}
+
+.maplibregl-control-container button {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 2rem;
     padding: 0.2rem;
     color: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
- Add map navigation control component (north arrow, +/- zoom).
- Add associated user preference to enable/disable component.
- Correct styling as it was enforcing a very small component size and inconsistent hover style:
  - When hovered, the component's buttons had rounded corners (see screenshot below)
  - When not hovered, the buttons had square corners

*Left: not hovered | Right: hovered*

<img width="51" height="78" alt="image" src="https://github.com/user-attachments/assets/5cb68ed9-b1dd-4039-9a58-ef84b7ce643d" />

<img width="51" height="78" alt="image" src="https://github.com/user-attachments/assets/a410e126-17e2-4418-8fce-a239b9ce9b9a" />

Solves: #956

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/chairemobilite/transition/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preference to show or hide map navigation controls.
  * Map navigation controls now support compass, zoom, pitch, and roll visualization.
  * The preference is enabled by default and can be reset to its default setting.

* **Localization**
  * Added English and French translations for the new map navigation control preference.

* **Style**
  * Improved styling consistency for map and custom control buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->